### PR TITLE
Node station registry sync and observed stations

### DIFF
--- a/wis2watch/src/wis2watch/core/catalogue.py
+++ b/wis2watch/src/wis2watch/core/catalogue.py
@@ -25,11 +25,10 @@ that the rules above are testable without the network.
 
 import logging
 
-import requests
 from django.db import transaction
 from django.utils import timezone as dj_timezone
 
-from .interpretation import extract_discovery_records, next_page_url
+from .interpretation import extract_discovery_records
 from .models import (
     Dataset,
     GlobalDiscoveryCatalogue,
@@ -37,7 +36,7 @@ from .models import (
     SyncLog,
     WIS2Node,
 )
-from .sync import CREATED, ERRORED, UPDATED, SyncCounts
+from .sync import CREATED, ERRORED, UPDATED, SyncCounts, fetch_pages
 
 logger = logging.getLogger(__name__)
 
@@ -46,9 +45,6 @@ DISCOVERY_METADATA_COLLECTION = "wis2-discovery-metadata"
 
 #: Records requested per page. Catalogues hold a few hundred records in total.
 PAGE_SIZE = 500
-
-#: A ceiling on paging, so a catalogue whose ``next`` links cycle cannot spin.
-MAX_PAGES = 50
 
 FETCH_TIMEOUT = 60
 
@@ -62,38 +58,13 @@ def discovery_metadata_url(catalogue):
 
 
 def fetch_discovery_pages(catalogue):
-    """Every page of a catalogue's discovery metadata, exactly as returned.
-
-    Paging follows the catalogue's own ``next`` link rather than an offset we
-    compute, since that link already carries whatever query the catalogue needs
-    to resume. Only the first request supplies parameters.
-    """
-    url = discovery_metadata_url(catalogue)
-    params = {"f": "json", "limit": PAGE_SIZE}
-
-    for _ in range(MAX_PAGES):
-        response = requests.get(
-            url,
-            params=params,
-            timeout=FETCH_TIMEOUT,
-            headers={"Accept": "application/json"},
-            verify=catalogue.verify_ssl,
-        )
-        response.raise_for_status()
-        payload = response.json()
-
-        yield payload
-
-        url = next_page_url(payload)
-        if not url:
-            return
-
-        params = None
-
-    logger.warning(
-        "Stopped paging %s after %s pages; its next links do not terminate",
-        catalogue.centre_id,
-        MAX_PAGES,
+    """Every page of a catalogue's discovery metadata, exactly as returned."""
+    return fetch_pages(
+        discovery_metadata_url(catalogue),
+        params={"f": "json", "limit": PAGE_SIZE},
+        verify=catalogue.verify_ssl,
+        timeout=FETCH_TIMEOUT,
+        read_from=catalogue.centre_id,
     )
 
 

--- a/wis2watch/src/wis2watch/core/catalogue.py
+++ b/wis2watch/src/wis2watch/core/catalogue.py
@@ -24,13 +24,12 @@ that the rules above are testable without the network.
 """
 
 import logging
-from dataclasses import dataclass
 
 import requests
 from django.db import transaction
 from django.utils import timezone as dj_timezone
 
-from .interpretation import extract_discovery_records
+from .interpretation import extract_discovery_records, next_page_url
 from .models import (
     Dataset,
     GlobalDiscoveryCatalogue,
@@ -38,6 +37,7 @@ from .models import (
     SyncLog,
     WIS2Node,
 )
+from .sync import CREATED, ERRORED, UPDATED, SyncCounts
 
 logger = logging.getLogger(__name__)
 
@@ -52,48 +52,6 @@ MAX_PAGES = 50
 
 FETCH_TIMEOUT = 60
 
-CREATED = "created"
-UPDATED = "updated"
-ERRORED = "errored"
-
-
-@dataclass
-class SyncCounts:
-    """What became of the records a run read.
-
-    Counts are of discovery records naming a monitored centre -- one record
-    describes one dataset -- so ``found`` is what the catalogue offered for the
-    region, and the rest is what became of it.
-    """
-
-    found: int = 0
-    created: int = 0
-    updated: int = 0
-    errored: int = 0
-
-    def record(self, outcome):
-        """Count one record's outcome: ``CREATED``, ``UPDATED`` or ``ERRORED``,
-        each of which names the field it counts into."""
-        setattr(self, outcome, getattr(self, outcome) + 1)
-
-    @property
-    def status(self):
-        """A run that stepped over records succeeded only partly."""
-        return SyncLog.PARTIAL if self.errored else SyncLog.SUCCESS
-
-    def close(self, sync_log, status, error_message=""):
-        """Close a sync log off with these counts."""
-        sync_log.status = status
-        sync_log.error_message = error_message
-        sync_log.items_found = self.found
-        sync_log.items_created = self.created
-        sync_log.items_updated = self.updated
-        sync_log.items_errored = self.errored
-        sync_log.completed_at = dj_timezone.now()
-        sync_log.save()
-
-        return sync_log
-
 
 def discovery_metadata_url(catalogue):
     """Where a catalogue serves its discovery metadata records."""
@@ -101,14 +59,6 @@ def discovery_metadata_url(catalogue):
         f"{catalogue.base_url.rstrip('/')}"
         f"/collections/{DISCOVERY_METADATA_COLLECTION}/items"
     )
-
-
-def _next_page_url(payload):
-    for link in payload.get("links", []) or []:
-        if link.get("rel") == "next" and link.get("href"):
-            return link["href"]
-
-    return None
 
 
 def fetch_discovery_pages(catalogue):
@@ -134,7 +84,7 @@ def fetch_discovery_pages(catalogue):
 
         yield payload
 
-        url = _next_page_url(payload)
+        url = next_page_url(payload)
         if not url:
             return
 

--- a/wis2watch/src/wis2watch/core/interpretation/__init__.py
+++ b/wis2watch/src/wis2watch/core/interpretation/__init__.py
@@ -27,12 +27,14 @@ from .discovery import (
     extract_discovery_record,
     extract_discovery_records,
 )
+from .node_stations import NodeStation, extract_node_station, extract_node_stations
 from .notifications import (
     ParsedNotification,
     canonical_link,
     parse_notification,
     station_attribution,
 )
+from .ogcapi import next_page_url
 from .oscar import OscarStation, extract_oscar_station, extract_oscar_stations
 from .timestamps import parse_timestamp
 from .topics import CACHE, ORIGIN, ParsedTopic, parse_topic, subscription_topic
@@ -44,6 +46,7 @@ __all__ = [
     "DiscoveredDataset",
     "DiscoveredNode",
     "DiscoveryRecord",
+    "NodeStation",
     "ORIGIN",
     "OscarStation",
     "ParsedNotification",
@@ -53,10 +56,13 @@ __all__ = [
     "centre_id_prefix",
     "extract_discovery_record",
     "extract_discovery_records",
+    "extract_node_station",
+    "extract_node_stations",
     "extract_oscar_station",
     "extract_oscar_stations",
     "is_monitored_centre_id",
     "monitored_country_code_for_centre_id",
+    "next_page_url",
     "parse_broker_url",
     "parse_notification",
     "parse_timestamp",

--- a/wis2watch/src/wis2watch/core/interpretation/node_stations.py
+++ b/wis2watch/src/wis2watch/core/interpretation/node_stations.py
@@ -1,0 +1,97 @@
+"""A node's own station registry, as station structures.
+
+What a node's registry declares is the second of the three station pictures:
+what the centre itself claims to operate, as opposed to what its country
+declares in OSCAR/Surface and what is actually observed transmitting.
+
+The WIGOS station identifier is the station's identity here as everywhere, and
+the name and traditional identifier beside it are the operator's own. They are
+read out separately rather than folded into the station, because a finding
+against a centre has to be readable in that centre's own naming -- which
+routinely differs from OSCAR's.
+
+The facility type is kept verbatim: registries publish WIGOS facility types
+already, and translating them would be a decision for whatever stores the
+station rather than for reading.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class NodeStation:
+    """A station as a node's own registry declares it."""
+
+    wigos_id: str
+    name: str
+    local_id: str
+    latitude: float | None
+    longitude: float | None
+    elevation: float | None
+    facility_type: str
+    territory: str
+    wmo_region: str
+    raw: dict
+
+
+def _position(geometry):
+    """The feature's position as ``(longitude, latitude, elevation)``.
+
+    GeoJSON orders coordinates longitude first, and the elevation is optional.
+    Anything shorter than a pair places the station nowhere, which is recorded
+    as absence rather than guessed at -- a station whose position the registry
+    omits is still a station.
+    """
+    coordinates = (geometry or {}).get("coordinates") or []
+
+    if len(coordinates) < 2:
+        return None, None, None
+
+    longitude, latitude = coordinates[0], coordinates[1]
+    elevation = coordinates[2] if len(coordinates) > 2 else None
+
+    return longitude, latitude, elevation
+
+
+def extract_node_station(feature):
+    """A registry feature as a station, or None when it names no station.
+
+    A feature without a WIGOS station identifier cannot be resolved against
+    OSCAR or against observed traffic, so it is skipped: the whole point of the
+    canonical record is that all three sources meet on that identifier.
+    """
+    if not feature:
+        return None
+
+    properties = feature.get("properties") or {}
+
+    wigos_id = (properties.get("wigos_station_identifier") or "").strip()
+    if not wigos_id:
+        return None
+
+    longitude, latitude, elevation = _position(feature.get("geometry"))
+
+    return NodeStation(
+        wigos_id=wigos_id,
+        name=properties.get("name") or "",
+        local_id=properties.get("traditional_station_identifier") or "",
+        latitude=latitude,
+        longitude=longitude,
+        elevation=elevation,
+        facility_type=properties.get("facility_type") or "",
+        territory=properties.get("territory_name") or "",
+        wmo_region=properties.get("wmo_region") or "",
+        raw=feature,
+    )
+
+
+def extract_node_stations(payload):
+    """Every station in a registry response, in the order returned."""
+    if not payload:
+        return []
+
+    stations = [
+        extract_node_station(feature) for feature in payload.get("features") or []
+    ]
+
+    return [station for station in stations if station is not None]

--- a/wis2watch/src/wis2watch/core/interpretation/ogcapi.py
+++ b/wis2watch/src/wis2watch/core/interpretation/ogcapi.py
@@ -1,0 +1,26 @@
+"""Paging an OGC API Features collection.
+
+Both of the endpoints WIS2Watch reads over HTTP -- a Global Discovery
+Catalogue's discovery metadata and a node's own station registry -- are OGC API
+Features collections, and both page the same way: each response links to the
+next one until there is none. The rule is written once here so that the two
+syncs cannot drift into reading it differently.
+
+The link is followed as given rather than rebuilt from an offset we compute,
+since it already carries whatever query the server needs to resume.
+"""
+
+#: The link relation naming the next page of a collection.
+NEXT = "next"
+
+
+def next_page_url(payload):
+    """Where the next page of a collection lives, or None on the last page."""
+    if not payload:
+        return None
+
+    for link in payload.get("links") or []:
+        if link.get("rel") == NEXT and link.get("href"):
+            return link["href"]
+
+    return None

--- a/wis2watch/src/wis2watch/core/models.py
+++ b/wis2watch/src/wis2watch/core/models.py
@@ -427,6 +427,27 @@ class StationSourceQuerySet(models.QuerySet):
             .order_by("station__name")
         )
 
+    def with_last_transmitted(self):
+        """Each declaration beside when its station was last heard transmitting.
+
+        Declared and transmitting are different questions, and only the
+        observation can answer the second: a registry declaration is confirmed
+        by every sync run, so its own timestamp says when the node last
+        repeated itself, never whether anything is still publishing. Reading
+        the observation alongside is what makes a silent station nameable.
+        """
+        transmitted = (
+            StationSource.objects.filter(
+                station_id=models.OuterRef("station_id"),
+                source_type=StationSource.OBSERVED,
+                last_seen__isnull=False,
+            )
+            .order_by("-last_seen")
+            .values("last_seen")[:1]
+        )
+
+        return self.annotate(last_transmitted=models.Subquery(transmitted))
+
 
 class StationSource(TimeStampedModel):
     """

--- a/wis2watch/src/wis2watch/core/node_stations.py
+++ b/wis2watch/src/wis2watch/core/node_stations.py
@@ -22,14 +22,13 @@ so that the rules above are testable without the network.
 
 import logging
 
-import requests
 from django.contrib.gis.geos import Point
 from django.db import transaction
 from django.utils import timezone as dj_timezone
 
-from .interpretation import extract_node_stations, next_page_url
+from .interpretation import extract_node_stations
 from .models import Station, StationSource, SyncLog
-from .sync import CREATED, ERRORED, UPDATED, SyncCounts
+from .sync import CREATED, ERRORED, UPDATED, SyncCounts, fetch_pages
 
 logger = logging.getLogger(__name__)
 
@@ -37,50 +36,28 @@ logger = logging.getLogger(__name__)
 #: default page size of a station endpoint is routinely ten.
 PAGE_SIZE = 500
 
-#: A ceiling on paging, so a registry whose ``next`` links cycle cannot spin.
-MAX_PAGES = 50
-
+#: How long a node is given to answer. Shorter than a catalogue's, because
+#: there are as many of these as there are centres and many never answer.
 FETCH_TIMEOUT = 30
 
-#: What a node may say about a station that the canonical record also holds.
-#: Filled in where nothing else has, never written over.
+#: What a node may say about a station that the canonical record also holds,
+#: named the same on both. Filled in where nothing else has, never written over.
 CANONICAL_FIELDS = ("name", "facility_type", "territory", "wmo_region")
 
 
 def fetch_station_pages(node):
     """Every page of a node's station registry, exactly as returned.
 
-    Paging follows the registry's own ``next`` link, which already carries
-    whatever query the node needs to resume; only the first request supplies
-    parameters. The response format is whatever the stored endpoint asks for,
-    so a page size is all that is added here.
+    The response format is whatever the stored endpoint asks for -- the URL a
+    wis2box node advertises names it already -- so a page size is all that is
+    added here.
     """
-    url = node.stations_url
-    params = {"limit": PAGE_SIZE}
-
-    for _ in range(MAX_PAGES):
-        response = requests.get(
-            url,
-            params=params,
-            timeout=FETCH_TIMEOUT,
-            headers={"Accept": "application/json"},
-            verify=node.verify_ssl,
-        )
-        response.raise_for_status()
-        payload = response.json()
-
-        yield payload
-
-        url = next_page_url(payload)
-        if not url:
-            return
-
-        params = None
-
-    logger.warning(
-        "Stopped paging %s after %s pages; its next links do not terminate",
-        node.centre_id,
-        MAX_PAGES,
+    return fetch_pages(
+        node.stations_url,
+        params={"limit": PAGE_SIZE},
+        verify=node.verify_ssl,
+        timeout=FETCH_TIMEOUT,
+        read_from=node.centre_id,
     )
 
 
@@ -111,17 +88,9 @@ def _fill_canonical_record(station, declared):
     letting an hourly sync undo a weekly OSCAR one.
     """
     filled = {
-        field: value
-        for field, value in zip(
-            CANONICAL_FIELDS,
-            (
-                declared.name,
-                declared.facility_type,
-                declared.territory,
-                declared.wmo_region,
-            ),
-        )
-        if value and not getattr(station, field)
+        field: getattr(declared, field)
+        for field in CANONICAL_FIELDS
+        if getattr(declared, field) and not getattr(station, field)
     }
 
     location = _declared_position(declared)

--- a/wis2watch/src/wis2watch/core/node_stations.py
+++ b/wis2watch/src/wis2watch/core/node_stations.py
@@ -1,0 +1,217 @@
+"""Station synchronisation from a node's own registry.
+
+A node's registry is what the centre itself claims to operate, which is one of
+the three station pictures this tool compares -- the others being what the
+country declares in OSCAR/Surface and what is observed transmitting. No
+catalogue carries it, so each node is asked directly.
+
+Two rules keep the three sources from fighting over one record:
+
+- **Declaring is not owning.** The canonical station is keyed on the WIGOS
+  identifier and shared by all three sources, so a node's declaration is
+  recorded as provenance beside it rather than as the station itself.
+- **Fill, do not overwrite.** A node fills in what nothing else has recorded,
+  and leaves alone what another source already has. The operator's own name and
+  identifier are kept on the declaration, so a finding can be put to a centre in
+  its own naming without that naming displacing OSCAR's.
+
+Reading a registry response is :mod:`wis2watch.core.interpretation`'s job. What
+is here is the writing -- and the page fetch, which is an argument to the sync
+so that the rules above are testable without the network.
+"""
+
+import logging
+
+import requests
+from django.contrib.gis.geos import Point
+from django.db import transaction
+from django.utils import timezone as dj_timezone
+
+from .interpretation import extract_node_stations, next_page_url
+from .models import Station, StationSource, SyncLog
+from .sync import CREATED, ERRORED, UPDATED, SyncCounts
+
+logger = logging.getLogger(__name__)
+
+#: Stations requested per page. Registries hold a few hundred at most, and the
+#: default page size of a station endpoint is routinely ten.
+PAGE_SIZE = 500
+
+#: A ceiling on paging, so a registry whose ``next`` links cycle cannot spin.
+MAX_PAGES = 50
+
+FETCH_TIMEOUT = 30
+
+#: What a node may say about a station that the canonical record also holds.
+#: Filled in where nothing else has, never written over.
+CANONICAL_FIELDS = ("name", "facility_type", "territory", "wmo_region")
+
+
+def fetch_station_pages(node):
+    """Every page of a node's station registry, exactly as returned.
+
+    Paging follows the registry's own ``next`` link, which already carries
+    whatever query the node needs to resume; only the first request supplies
+    parameters. The response format is whatever the stored endpoint asks for,
+    so a page size is all that is added here.
+    """
+    url = node.stations_url
+    params = {"limit": PAGE_SIZE}
+
+    for _ in range(MAX_PAGES):
+        response = requests.get(
+            url,
+            params=params,
+            timeout=FETCH_TIMEOUT,
+            headers={"Accept": "application/json"},
+            verify=node.verify_ssl,
+        )
+        response.raise_for_status()
+        payload = response.json()
+
+        yield payload
+
+        url = next_page_url(payload)
+        if not url:
+            return
+
+        params = None
+
+    logger.warning(
+        "Stopped paging %s after %s pages; its next links do not terminate",
+        node.centre_id,
+        MAX_PAGES,
+    )
+
+
+def _declared_position(declared):
+    """Where the node places the station, or None if it places it nowhere.
+
+    Elevation stands at zero where the registry gives none: the canonical
+    location is three-dimensional, and a station's position is worth keeping
+    even when its height is not stated.
+    """
+    if declared.latitude is None or declared.longitude is None:
+        return None
+
+    return Point(
+        declared.longitude,
+        declared.latitude,
+        declared.elevation if declared.elevation is not None else 0,
+        srid=4326,
+    )
+
+
+def _fill_canonical_record(station, declared):
+    """Fill in what nothing else has recorded about the station.
+
+    A node is one of three sources describing the same record, and the one
+    least likely to be authoritative about anything but its own naming. So it
+    supplies what is missing and steps over what is already there, rather than
+    letting an hourly sync undo a weekly OSCAR one.
+    """
+    filled = {
+        field: value
+        for field, value in zip(
+            CANONICAL_FIELDS,
+            (
+                declared.name,
+                declared.facility_type,
+                declared.territory,
+                declared.wmo_region,
+            ),
+        )
+        if value and not getattr(station, field)
+    }
+
+    location = _declared_position(declared)
+    if location and station.location is None:
+        filled["location"] = location
+
+    if not filled:
+        return
+
+    for field, value in filled.items():
+        setattr(station, field, value)
+
+    station.save(update_fields=[*filled, "modified"])
+
+
+def apply_declared_station(node, declared):
+    """Record that this node declares a station, reporting what happened.
+
+    Each station is applied in its own savepoint, so one the database refuses
+    is counted and stepped over rather than losing the rest of the run.
+
+    What is counted is the declaration rather than the station: a station
+    another source already created is still news about this node.
+    """
+    try:
+        with transaction.atomic():
+            station, _ = Station.objects.get_or_create(wigos_id=declared.wigos_id)
+
+            _fill_canonical_record(station, declared)
+
+            _, created = StationSource.objects.update_or_create(
+                station=station,
+                source_type=StationSource.NODE_REGISTRY,
+                node=node,
+                defaults={
+                    "local_name": declared.name,
+                    "local_id": declared.local_id,
+                    "raw_json": declared.raw,
+                    "last_seen": dj_timezone.now(),
+                },
+            )
+
+            return CREATED if created else UPDATED
+    except Exception as exc:
+        logger.warning(
+            "Could not apply station %s declared by %s: %s",
+            declared.wigos_id,
+            node.centre_id,
+            exc,
+        )
+
+        return ERRORED
+
+
+def sync_node_stations(node, fetch=None):
+    """Sync one node's station registry, returning the ``SyncLog`` of the run.
+
+    A node advertising no station registry returns None and is not logged: no
+    run was attempted, and an hourly failed log for every centre whose base URL
+    nobody has filled in would bury the nodes that really did fail.
+
+    ``fetch`` is how the registry's pages are read, defaulting to the network.
+    """
+    if not node.stations_url:
+        logger.debug("%s advertises no station registry", node.centre_id)
+
+        return None
+
+    fetch = fetch or fetch_station_pages
+
+    sync_log = SyncLog.objects.create(
+        node=node,
+        sync_type=SyncLog.NODE_STATIONS,
+        status=SyncLog.FAILED,
+    )
+
+    counts = SyncCounts()
+
+    try:
+        for payload in fetch(node):
+            for declared in extract_node_stations(payload):
+                counts.found += 1
+                counts.record(apply_declared_station(node, declared))
+    except Exception as exc:
+        logger.error("Station sync failed for %s: %s", node.centre_id, exc)
+
+        return counts.close(sync_log, SyncLog.FAILED, str(exc))
+
+    counts.close(sync_log, counts.status)
+
+    logger.info("Station sync for %s: %s", node.centre_id, sync_log.summary)
+
+    return sync_log

--- a/wis2watch/src/wis2watch/core/sync.py
+++ b/wis2watch/src/wis2watch/core/sync.py
@@ -1,192 +1,56 @@
-"""Synchronisation against a node's own endpoints.
+"""What became of a synchronisation run.
 
-Nodes and datasets are no longer read from here: the Global Discovery
-Catalogue is the sole writer of the registry, and lives in
-:mod:`wis2watch.core.catalogue`. What a node is still asked directly is its
-station registry, which no catalogue carries.
+Every sync WIS2Watch runs -- the registry from a Global Discovery Catalogue,
+the stations a node's own registry declares -- reads records from somewhere
+outside itself and writes what it can. They report the same four things, and a
+run that stepped over a record it could not store succeeded only partly. Saying
+that once is what keeps two sync logs comparable when they are read side by
+side on a node's page.
 """
 
-import logging
+from dataclasses import dataclass
 
-import requests
-from django.contrib.gis.geos import Point
 from django.utils import timezone as dj_timezone
 
-logger = logging.getLogger(__name__)
+from .models import SyncLog
+
+CREATED = "created"
+UPDATED = "updated"
+ERRORED = "errored"
 
 
-def sync_stations(node_id):
+@dataclass
+class SyncCounts:
+    """What became of the records a run read.
+
+    ``found`` is what the source offered that the run had any business with;
+    the rest is what became of it.
     """
-    Fetch and sync stations declared by a WIS2 node's own station registry.
 
-    Each station resolves to the canonical Station keyed on its WIGOS station
-    identifier, and the node's declaration of it is recorded as provenance.
+    found: int = 0
+    created: int = 0
+    updated: int = 0
+    errored: int = 0
 
-    Args:
-        node_id: ID of the WIS2Node
-    """
+    def record(self, outcome):
+        """Count one record's outcome: ``CREATED``, ``UPDATED`` or ``ERRORED``,
+        each of which names the field it counts into."""
+        setattr(self, outcome, getattr(self, outcome) + 1)
 
-    from .models import WIS2Node, Station, StationSource, SyncLog
+    @property
+    def status(self):
+        """A run that stepped over records succeeded only partly."""
+        return SyncLog.PARTIAL if self.errored else SyncLog.SUCCESS
 
-    try:
-        node = WIS2Node.objects.get(id=node_id)
-        logger.info(f"Starting stations sync for {node.name}")
-
-        # Create sync log
-        sync_log = SyncLog.objects.create(
-            node=node,
-            sync_type=SyncLog.NODE_STATIONS,
-            status=SyncLog.FAILED
-        )
-
-        # Fetch stations
-        response = requests.get(
-            node.stations_url,
-            timeout=30,
-            headers={'Accept': 'application/json'},
-            verify=node.verify_ssl,
-        )
-        response.raise_for_status()
-
-        data = response.json()
-        features = data.get('features', [])
-
-        stats = {
-            'found': len(features),
-            'created': 0,
-            'updated': 0,
-            'deleted': 0
-        }
-
-        for feature in features:
-            try:
-                properties = feature.get('properties', {})
-                geometry = feature.get('geometry', {})
-
-                wigos_id = properties.get('wigos_station_identifier')
-                if not wigos_id:
-                    logger.warning(f"Station missing WIGOS ID: {feature}")
-                    continue
-
-                # Parse coordinates (lon, lat, altitude)
-                location = None
-                coords = geometry.get('coordinates', [])
-                if len(coords) >= 2:
-                    lon, lat = coords[0], coords[1]
-                    alt = coords[2] if len(coords) >= 3 else 0
-                    location = Point(lon, lat, alt, srid=4326)
-
-                defaults = {
-                    'name': properties.get('name', ''),
-                    'facility_type': properties.get('facility_type', ''),
-                    'territory': properties.get('territory_name', ''),
-                    'wmo_region': properties.get('wmo_region', ''),
-                }
-
-                if location:
-                    defaults['location'] = location
-
-                station, _station_created = Station.objects.update_or_create(
-                    wigos_id=wigos_id, defaults=defaults
-                )
-
-                # Record that this node declares the station. The counts track
-                # declarations rather than canonical stations, so a station
-                # another node already created still counts as new here.
-                _declaration, declared = StationSource.objects.update_or_create(
-                    station=station,
-                    source_type=StationSource.NODE_REGISTRY,
-                    node=node,
-                    defaults={
-                        'local_name': properties.get('name', ''),
-                        'local_id': properties.get('traditional_station_identifier', ''),
-                        'raw_json': feature,
-                        'last_seen': dj_timezone.now(),
-                    }
-                )
-
-                if declared:
-                    stats['created'] += 1
-                    logger.info(f"Node {node.centre_id} now declares station: {wigos_id}")
-                else:
-                    stats['updated'] += 1
-                    logger.info(f"Updated station declaration: {wigos_id}")
-
-            except Exception as e:
-                logger.error(f"Error processing station {e}")
-                continue
-
-        # Update sync log
-        sync_log.status = SyncLog.SUCCESS
-        sync_log.items_found = stats['found']
-        sync_log.items_created = stats['created']
-        sync_log.items_updated = stats['updated']
-        sync_log.items_deleted = stats['deleted']
+    def close(self, sync_log, status, error_message=""):
+        """Close a sync log off with these counts."""
+        sync_log.status = status
+        sync_log.error_message = error_message
+        sync_log.items_found = self.found
+        sync_log.items_created = self.created
+        sync_log.items_updated = self.updated
+        sync_log.items_errored = self.errored
         sync_log.completed_at = dj_timezone.now()
         sync_log.save()
 
-        logger.info(
-            f"Stations sync completed for {node.name}: "
-            f"Found={stats['found']}, Created={stats['created']}, "
-            f"Updated={stats['updated']}"
-        )
-
-        return stats, None
-
-    except Exception as e:
-        logger.error(f"Error syncing stations for node {node_id}: {e}")
-
-        # Update sync log
-        try:
-            if 'sync_log' in locals():
-                sync_log.status = SyncLog.FAILED
-                sync_log.error_message = str(e)
-                sync_log.completed_at = dj_timezone.now()
-                sync_log.save()
-            return None, e
-        except Exception as e:
-            return None, e
-
-
-def health_check_nodes():
-    """
-    Perform health checks on all active nodes.
-    """
-
-    from .models import WIS2Node
-
-    nodes = WIS2Node.objects.all()
-    results = []
-
-    for node in nodes:
-        try:
-            # Try to fetch discovery metadata endpoint
-            response = requests.get(
-                node.discovery_metadata_url,
-                timeout=10,
-                headers={'Accept': 'application/json'},
-                verify=node.verify_ssl,
-            )
-
-            if response.status_code == 200:
-                node.status = 'active'
-                node.last_check = dj_timezone.now()
-                node.last_error = ''
-                results.append({'node': node.name, 'status': 'healthy'})
-            else:
-                node.status = 'error'
-                node.last_error = f"HTTP {response.status_code}"
-                results.append({'node': node.name, 'status': 'unhealthy'})
-
-            node.save()
-
-        except Exception as e:
-            node.status = 'error'
-            node.last_error = str(e)
-            node.last_check = dj_timezone.now()
-            node.save()
-            results.append({'node': node.name, 'status': 'error', 'error': str(e)})
-
-    logger.info(f"Health check completed for {len(results)} nodes")
-
-    return results
+        return sync_log

--- a/wis2watch/src/wis2watch/core/sync.py
+++ b/wis2watch/src/wis2watch/core/sync.py
@@ -1,22 +1,81 @@
-"""What became of a synchronisation run.
+"""What every synchronisation run does the same way.
 
 Every sync WIS2Watch runs -- the registry from a Global Discovery Catalogue,
-the stations a node's own registry declares -- reads records from somewhere
-outside itself and writes what it can. They report the same four things, and a
-run that stepped over a record it could not store succeeded only partly. Saying
-that once is what keeps two sync logs comparable when they are read side by
-side on a node's page.
+the stations a node's own registry declares -- reads an OGC API Features
+collection page by page and writes what it can. Two things are therefore said
+once, here, rather than once per sync:
+
+- **How a collection is read.** Page after page, following the server's own
+  ``next`` link, with a ceiling so that links which cycle cannot spin.
+- **What became of the records.** The same four counts, and a run that stepped
+  over a record it could not store succeeded only partly. That is what keeps
+  two sync logs comparable when they are read side by side on a node's page.
+
+What differs between the syncs -- which URL, which credentials, how long to
+wait -- stays with the sync that knows it.
 """
 
 from dataclasses import dataclass
 
+import requests
 from django.utils import timezone as dj_timezone
 
+from .interpretation import next_page_url
 from .models import SyncLog
 
 CREATED = "created"
 UPDATED = "updated"
 ERRORED = "errored"
+
+#: A ceiling on paging, so a collection whose ``next`` links cycle cannot spin.
+MAX_PAGES = 50
+
+FETCH_TIMEOUT = 60
+
+
+class PagingDidNotTerminate(Exception):
+    """Raised when a collection never stops offering another page.
+
+    A run that stopped at the ceiling has read part of a collection, and has no
+    way to know how much of it. That is a failed run rather than a short one:
+    reporting it as a success would leave a half-read registry indistinguishable
+    from a centre that really has only these stations.
+    """
+
+
+def fetch_pages(url, params=None, verify=True, timeout=FETCH_TIMEOUT, read_from=""):
+    """Every page of an OGC API Features collection, exactly as returned.
+
+    Paging follows the server's own ``next`` link rather than an offset we
+    compute, since that link already carries whatever query it needs to resume.
+    Only the first request supplies parameters.
+
+    ``read_from`` names what is being read, for the failure raised when the
+    collection never stops offering another page.
+    """
+    for _ in range(MAX_PAGES):
+        response = requests.get(
+            url,
+            params=params,
+            timeout=timeout,
+            headers={"Accept": "application/json"},
+            verify=verify,
+        )
+        response.raise_for_status()
+        payload = response.json()
+
+        yield payload
+
+        url = next_page_url(payload)
+        if not url:
+            return
+
+        params = None
+
+    raise PagingDidNotTerminate(
+        f"stopped paging {read_from} after {MAX_PAGES} pages; "
+        "its next links do not terminate"
+    )
 
 
 @dataclass

--- a/wis2watch/src/wis2watch/core/tasks.py
+++ b/wis2watch/src/wis2watch/core/tasks.py
@@ -6,10 +6,10 @@ from django.core.management import call_command
 
 from wis2watch.config.celery import app
 from .catalogue import sync_catalogues
+from .node_stations import sync_node_stations
 from .propagation import evaluate_propagation
 from .retention import expire_raw_messages
 from .rollups import update_rollups
-from .sync import sync_stations
 
 logger = get_task_logger(__name__)
 
@@ -50,34 +50,47 @@ def run_sync_catalogues():
     return [log.id for log in logs]
 
 
-@shared_task(bind=True, max_retries=3)
-def run_sync_stations(self, node_id):
-    stats, exc = sync_stations(node_id)
-    
-    if not stats and exc:
-        logger.error(f"[STATION SYNC] No stats returned for node {node_id}. Retrying...")
-        
-        raise self.retry(exc=exc, countdown=60 * (2 ** self.request.retries))
-    
-    return stats
+@shared_task
+def run_sync_node_stations(node_id):
+    """Ask one node what stations it declares.
+
+    Failures are diagnostic state rather than task failures: a node that cannot
+    be reached is recorded on its own sync log, and the next scheduled run asks
+    again. Retrying here would only duplicate the schedule.
+    """
+    from .models import WIS2Node
+
+    sync_log = sync_node_stations(WIS2Node.objects.get(id=node_id))
+
+    if sync_log is None:
+        return None
+
+    logger.info("[STATION SYNC] %s: %s", sync_log.node.centre_id, sync_log.summary)
+
+    return sync_log.id
 
 
 @shared_task
 def run_sync_all_node_stations():
-    """
-    Trigger a station registry sync for every node.
-    Should be run periodically (e.g., every hour).
+    """Ask every node for its stations, so new ones need no manual trigger.
+
+    One task per node rather than one run over all of them: each is an HTTP
+    fetch against a different centre, and many African nodes are slow or
+    unreachable from outside. Fanning out keeps one of those from holding up
+    the rest of the region.
     """
     from .models import WIS2Node
 
-    nodes = WIS2Node.objects.all()
+    node_ids = list(
+        WIS2Node.objects.exclude(stations_url="").values_list("id", flat=True)
+    )
 
-    logger.info(f"Starting station sync for {nodes.count()} nodes")
+    logger.info("[STATION SYNC] queueing %s nodes", len(node_ids))
 
-    for node in nodes:
-        run_sync_stations.delay(node.id)
+    for node_id in node_ids:
+        run_sync_node_stations.delay(node_id)
 
-    logger.info("Station sync tasks queued for all nodes")
+    return node_ids
 
 
 @shared_task

--- a/wis2watch/src/wis2watch/core/templates/wis2watchcore/node_details.html
+++ b/wis2watch/src/wis2watch/core/templates/wis2watchcore/node_details.html
@@ -349,7 +349,7 @@
                     <th>{% trans "Local ID" %}</th>
                     <th>{% trans "Facility Type" %}</th>
                     <th>{% trans "Location" %}</th>
-                    <th>{% trans "Last Seen" %}</th>
+                    <th>{% trans "Last Transmitted" %}</th>
                 </tr>
                 </thead>
                 <tbody>
@@ -370,7 +370,13 @@
                                 —
                             {% endif %}
                         </td>
-                        <td>{{ declaration.last_seen|date:"Y-m-d H:i:s"|default:"—" }}</td>
+                        <td>
+                            {% if declaration.last_transmitted %}
+                                {{ declaration.last_transmitted|date:"Y-m-d H:i:s" }}
+                            {% else %}
+                                {% trans "Never" %}
+                            {% endif %}
+                        </td>
                     </tr>
                 {% endfor %}
                 </tbody>

--- a/wis2watch/src/wis2watch/core/tests/fixtures/README.md
+++ b/wis2watch/src/wis2watch/core/tests/fixtures/README.md
@@ -5,7 +5,8 @@ interpretation tests never touch the network. They double as documentation of
 what these sources actually return, which is repeatedly not what their schemas
 suggest.
 
-All three were captured on **2026-08-11**.
+The first three were captured on **2026-08-11**, the node station registry on
+**2026-08-12**.
 
 ## `global_broker_notifications.jsonl`
 
@@ -69,6 +70,28 @@ Covered: every operational status OSCAR reports for the territory
 (`operational`, `partlyOperational`, `closed`, `unknown`), stations carrying
 more than one WIGOS identifier, a station with no elevation, and one with an
 elevation of zero.
+
+## `node_stations_gh_gmet.json`
+
+Ghana's own station registry
+(`https://wis2.meteo.gov.gh/oapi/collections/stations/items`), which is what a
+wis2box node publishes about the stations it operates. The envelope is as
+returned; the feature list is a nine-station subset of the 39 available, with
+`numberMatched`/`numberReturned` set to that subset.
+
+Covered: stations the operator gives a traditional identifier and stations it
+does not (32 of the 39 leave it empty), a station on the Greenwich meridian
+whose longitude is `0.0`, stations declaring no `topic` property, and the
+`barometer_height` the station CSV export reports.
+
+Every station in the registry carries a WIGOS station identifier and a
+three-dimensional position, so the skipped and unpositioned cases are asserted
+against hand-written features rather than captured ones.
+
+A registry longer than the page size links to its next page under `rel: next`,
+the same as a Global Discovery Catalogue does; this capture fits on one page
+and so carries no such link. The default page size of a station endpoint is
+routinely ten, which is why the fetch asks for more.
 
 ## Refreshing a fixture
 

--- a/wis2watch/src/wis2watch/core/tests/fixtures/node_stations_gh_gmet.json
+++ b/wis2watch/src/wis2watch/core/tests/fixtures/node_stations_gh_gmet.json
@@ -1,0 +1,284 @@
+{
+ "type": "FeatureCollection",
+ "numberMatched": 9,
+ "numberReturned": 9,
+ "features": [
+  {
+   "id": "0-288-0-65487",
+   "type": "Feature",
+   "properties": {
+    "name": "Fumbisi Baasa",
+    "wigos_station_identifier": "0-288-0-65487",
+    "traditional_station_identifier": "",
+    "barometer_height": 165.2,
+    "facility_type": "landFixed",
+    "territory_name": "GHA",
+    "wmo_region": "africa",
+    "url": "https://oscar.wmo.int/surface/#/search/station/stationReportDetails/0-288-0-65487",
+    "topic": "origin/a/wis2/gh-gmet/data/core/weather/surface-based-observations/synop",
+    "topics": [
+     "origin/a/wis2/gh-gmet/data/core/weather/surface-based-observations/synop"
+    ],
+    "status": "operational",
+    "id": "0-288-0-65487"
+   },
+   "geometry": {
+    "type": "Point",
+    "coordinates": [
+     -1.2927,
+     10.4195,
+     164.0
+    ]
+   }
+  },
+  {
+   "id": "0-20000-0-65457",
+   "type": "Feature",
+   "properties": {
+    "name": "AKIM ODA",
+    "wigos_station_identifier": "0-20000-0-65457",
+    "traditional_station_identifier": "65457",
+    "barometer_height": 139.4,
+    "facility_type": "landFixed",
+    "territory_name": "GHA",
+    "wmo_region": "africa",
+    "url": "https://oscar.wmo.int/surface/#/search/station/stationReportDetails/0-20000-0-65457",
+    "topic": "origin/a/wis2/gh-gmet/data/core/weather/surface-based-observations/synop",
+    "topics": [
+     "origin/a/wis2/gh-gmet/data/core/weather/surface-based-observations/synop"
+    ],
+    "status": "operational",
+    "id": "0-20000-0-65457"
+   },
+   "geometry": {
+    "type": "Point",
+    "coordinates": [
+     -0.9833333333,
+     5.9333333333,
+     139.4
+    ]
+   }
+  },
+  {
+   "id": "0-20000-0-65445",
+   "type": "Feature",
+   "properties": {
+    "name": "SEFWI BEKWAI",
+    "wigos_station_identifier": "0-20000-0-65445",
+    "traditional_station_identifier": "65445",
+    "barometer_height": 172.0,
+    "facility_type": "landFixed",
+    "territory_name": "GHA",
+    "wmo_region": "africa",
+    "url": "https://oscar.wmo.int/surface/#/search/station/stationReportDetails/0-20000-0-65445",
+    "topic": "origin/a/wis2/gh-gmet/data/core/weather/surface-based-observations/synop",
+    "topics": [
+     "origin/a/wis2/gh-gmet/data/core/weather/surface-based-observations/synop"
+    ],
+    "status": "operational",
+    "id": "0-20000-0-65445"
+   },
+   "geometry": {
+    "type": "Point",
+    "coordinates": [
+     -2.3333333333,
+     6.2,
+     170.8
+    ]
+   }
+  },
+  {
+   "id": "0-288-0-65471",
+   "type": "Feature",
+   "properties": {
+    "name": "SUHUM",
+    "wigos_station_identifier": "0-288-0-65471",
+    "traditional_station_identifier": "65471",
+    "facility_type": "landFixed",
+    "territory_name": "GHA",
+    "barometer_height": 191.2,
+    "wmo_region": "africa",
+    "url": "https://oscar.wmo.int/surface/#/search/station/stationReportDetails/0-288-0-65471",
+    "topics": [
+     "origin/a/wis2/gh-gmet/data/core/weather/surface-based-observations/synop"
+    ],
+    "status": "operational",
+    "id": "0-288-0-65471"
+   },
+   "geometry": {
+    "type": "Point",
+    "coordinates": [
+     -0.4531895,
+     6.0355832,
+     190
+    ]
+   }
+  },
+  {
+   "id": "0-288-0-65476",
+   "type": "Feature",
+   "properties": {
+    "name": "Tema",
+    "wigos_station_identifier": "0-288-0-65476",
+    "traditional_station_identifier": "",
+    "barometer_height": 13.2,
+    "facility_type": "landFixed",
+    "territory_name": "GHA",
+    "wmo_region": "africa",
+    "url": "https://oscar.wmo.int/surface/#/search/station/stationReportDetails/0-288-0-65476",
+    "topic": "origin/a/wis2/gh-gmet/data/core/weather/surface-based-observations/synop",
+    "topics": [
+     "origin/a/wis2/gh-gmet/data/core/weather/surface-based-observations/synop"
+    ],
+    "status": "operational",
+    "id": "0-288-0-65476"
+   },
+   "geometry": {
+    "type": "Point",
+    "coordinates": [
+     0.0,
+     5.62,
+     12.2
+    ]
+   }
+  },
+  {
+   "id": "0-288-0-65450",
+   "type": "Feature",
+   "properties": {
+    "name": "ABETIFI",
+    "wigos_station_identifier": "0-288-0-65450",
+    "traditional_station_identifier": "65450",
+    "facility_type": "landFixed",
+    "territory_name": "GHA",
+    "barometer_height": 595.9,
+    "wmo_region": "africa",
+    "url": "https://oscar.wmo.int/surface/#/search/station/stationReportDetails/0-288-0-65450",
+    "topics": [
+     "origin/a/wis2/gh-gmet/data/core/weather/surface-based-observations/synop"
+    ],
+    "status": "operational",
+    "id": "0-288-0-65450"
+   },
+   "geometry": {
+    "type": "Point",
+    "coordinates": [
+     -0.75,
+     6.66667,
+     594.7
+    ]
+   }
+  },
+  {
+   "id": "0-288-0-65492",
+   "type": "Feature",
+   "properties": {
+    "name": "Dormaa-Aboabo",
+    "wigos_station_identifier": "0-288-0-65492",
+    "traditional_station_identifier": "",
+    "barometer_height": 76.2,
+    "facility_type": "landFixed",
+    "territory_name": "GHA",
+    "wmo_region": "africa",
+    "url": "https://oscar.wmo.int/surface/#/search/station/stationReportDetails/0-288-0-65492",
+    "topic": "origin/a/wis2/gh-gmet/data/core/weather/surface-based-observations/synop",
+    "topics": [
+     "origin/a/wis2/gh-gmet/data/core/weather/surface-based-observations/synop"
+    ],
+    "status": "operational",
+    "id": "0-288-0-65492"
+   },
+   "geometry": {
+    "type": "Point",
+    "coordinates": [
+     -2.8054,
+     7.2153,
+     75.0
+    ]
+   }
+  },
+  {
+   "id": "0-288-0-65495",
+   "type": "Feature",
+   "properties": {
+    "name": "Anloga",
+    "wigos_station_identifier": "0-288-0-65495",
+    "traditional_station_identifier": "",
+    "barometer_height": 58.2,
+    "facility_type": "landFixed",
+    "territory_name": "GHA",
+    "wmo_region": "africa",
+    "url": "https://oscar.wmo.int/surface/#/search/station/stationReportDetails/0-288-0-65495",
+    "topic": "origin/a/wis2/gh-gmet/data/core/weather/surface-based-observations/synop",
+    "topics": [
+     "origin/a/wis2/gh-gmet/data/core/weather/surface-based-observations/synop"
+    ],
+    "status": "operational",
+    "id": "0-288-0-65495"
+   },
+   "geometry": {
+    "type": "Point",
+    "coordinates": [
+     0.8973,
+     5.7947,
+     57.0
+    ]
+   }
+  },
+  {
+   "id": "0-288-0-65478",
+   "type": "Feature",
+   "properties": {
+    "name": "Jirapa",
+    "wigos_station_identifier": "0-288-0-65478",
+    "traditional_station_identifier": "",
+    "barometer_height": 304.2,
+    "facility_type": "landFixed",
+    "territory_name": "GHA",
+    "wmo_region": "africa",
+    "url": "https://oscar.wmo.int/surface/#/search/station/stationReportDetails/0-288-0-65478",
+    "topic": "origin/a/wis2/gh-gmet/data/core/weather/surface-based-observations/synop",
+    "topics": [
+     "origin/a/wis2/gh-gmet/data/core/weather/surface-based-observations/synop"
+    ],
+    "status": "operational",
+    "id": "0-288-0-65478"
+   },
+   "geometry": {
+    "type": "Point",
+    "coordinates": [
+     -2.7194,
+     10.5346,
+     303.0
+    ]
+   }
+  }
+ ],
+ "links": [
+  {
+   "type": "application/geo+json",
+   "rel": "self",
+   "title": "This document as GeoJSON",
+   "href": "https://wis2.meteo.gov.gh/oapi/collections/stations/items?f=json&limit=500"
+  },
+  {
+   "rel": "alternate",
+   "type": "application/ld+json",
+   "title": "This document as RDF (JSON-LD)",
+   "href": "https://wis2.meteo.gov.gh/oapi/collections/stations/items?f=jsonld&limit=500"
+  },
+  {
+   "type": "text/html",
+   "rel": "alternate",
+   "title": "This document as HTML",
+   "href": "https://wis2.meteo.gov.gh/oapi/collections/stations/items?f=html&limit=500"
+  },
+  {
+   "type": "application/json",
+   "title": "Stations",
+   "rel": "collection",
+   "href": "https://wis2.meteo.gov.gh/oapi/collections/stations"
+  }
+ ],
+ "timeStamp": "2026-08-11T20:54:23.880475Z"
+}

--- a/wis2watch/src/wis2watch/core/tests/support.py
+++ b/wis2watch/src/wis2watch/core/tests/support.py
@@ -48,6 +48,30 @@ def at(stamp):
     return datetime.fromisoformat(stamp).replace(tzinfo=timezone.utc)
 
 
+def pages(*payloads):
+    """A page fetch returning fixed payloads, standing in for the network.
+
+    Every sync takes its page fetch as an argument for exactly this reason, so
+    the writing rules can be asserted against payloads the source really
+    returned without anything opening a socket.
+    """
+
+    def fetch(_source):
+        yield from payloads
+
+    return fetch
+
+
+def failing_fetch(message):
+    """A page fetch that fails the way an unreachable source would."""
+
+    def fetch(_source):
+        raise OSError(message)
+        yield  # pragma: no cover - never reached, keeps this a generator
+
+    return fetch
+
+
 def origin_broker(node, **kwargs):
     """A node's own broker, as a catalogue sync leaves it in the registry.
 

--- a/wis2watch/src/wis2watch/core/tests/test_admin.py
+++ b/wis2watch/src/wis2watch/core/tests/test_admin.py
@@ -20,6 +20,8 @@ from wis2watch.core.viewsets import (
     WIS2NodeViewSet,
 )
 
+from .support import at
+
 
 class AdminSmokeTests(TestCase):
     """The admin is where nodes, brokers and catalogues are configured by hand."""
@@ -195,6 +197,25 @@ class NodeDetailViewTests(TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "0-404-0-KE001")
+
+    def test_a_declared_station_that_has_never_transmitted_says_so(self):
+        """The declaration is confirmed hourly; only the observation is news."""
+        response = self.client.get(reverse("node_details", args=[self.node.id]))
+
+        self.assertContains(response, "Never")
+
+    def test_a_declared_station_shows_when_it_last_transmitted(self):
+        StationSource.objects.create(
+            station=Station.objects.get(wigos_id="0-404-0-KE001"),
+            source_type=StationSource.OBSERVED,
+            node=self.node,
+            last_seen=at("2026-08-11T10:45:00"),
+        )
+
+        response = self.client.get(reverse("node_details", args=[self.node.id]))
+
+        self.assertContains(response, "2026-08-11 10:45:00")
+        self.assertNotContains(response, "Never")
 
     def test_the_station_csv_preview_loads(self):
         response = self.client.get(reverse("preview_node_stations_csv", args=[self.node.id]))

--- a/wis2watch/src/wis2watch/core/tests/test_admin.py
+++ b/wis2watch/src/wis2watch/core/tests/test_admin.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 from django.urls import reverse
@@ -9,6 +11,7 @@ from wis2watch.core.models import (
     NodeLastSeen,
     Station,
     StationSource,
+    SyncLog,
     WIS2Node,
 )
 from wis2watch.core.viewsets import (
@@ -210,3 +213,30 @@ class NodeDetailViewTests(TestCase):
         self.assertIn("0-404-0-KE001", rows[1])
         self.assertIn("Nairobi JKIA", rows[1])
         self.assertIn("63740", rows[1])
+
+    def test_syncing_a_node_by_hand_asks_it_for_its_stations(self):
+        """Datasets come from the catalogue; a node is asked only for stations."""
+        with mock.patch("wis2watch.core.views.sync_node_stations") as sync:
+            sync.return_value = SyncLog(
+                node=self.node,
+                sync_type=SyncLog.NODE_STATIONS,
+                status=SyncLog.SUCCESS,
+            )
+
+            response = self.client.post(
+                reverse("node_details", args=[self.node.id]), {"node_id": self.node.id}
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(sync.call_args.args[0], self.node)
+
+    def test_a_node_that_advertises_no_station_registry_says_so(self):
+        self.node.stations_url = ""
+        self.node.node_type = "other"
+        self.node.save()
+
+        response = self.client.post(
+            reverse("node_details", args=[self.node.id]), {"node_id": self.node.id}
+        )
+
+        self.assertContains(response, "advertises no station registry")

--- a/wis2watch/src/wis2watch/core/tests/test_catalogue_sync.py
+++ b/wis2watch/src/wis2watch/core/tests/test_catalogue_sync.py
@@ -29,7 +29,7 @@ from wis2watch.core.models import (
     WIS2Node,
 )
 
-from .support import load_json_fixture
+from .support import failing_fetch, load_json_fixture, pages
 
 CATALOGUE = "gdc_discovery_metadata.json"
 
@@ -37,25 +37,6 @@ MONITORED_CENTRE_IDS = {"ke-meteo", "cg-met", "sz-swazimet", "gh-gmet"}
 
 KE_DATASET = "urn:wmo:md:ke-meteo:synop-dataset-surface-observations"
 CG_DATASET = "urn:wmo:md:cg-met:core.climate.surface-based-observations.climat"
-
-
-def pages(*payloads):
-    """A page fetch returning fixed payloads, standing in for the network."""
-
-    def fetch(catalogue):
-        yield from payloads
-
-    return fetch
-
-
-def failing_fetch(message):
-    """A page fetch that fails the way an unreachable catalogue would."""
-
-    def fetch(catalogue):
-        raise OSError(message)
-        yield  # pragma: no cover - never reached, keeps this a generator
-
-    return fetch
 
 
 class CatalogueSyncTestCase(TestCase):
@@ -389,7 +370,7 @@ class PageFetchTests(TestCase):
         return response
 
     def test_it_asks_the_discovery_metadata_collection_of_the_catalogue(self):
-        with mock.patch("wis2watch.core.catalogue.requests.get") as get:
+        with mock.patch("wis2watch.core.sync.requests.get") as get:
             get.return_value = self.response({"features": []})
 
             list(fetch_discovery_pages(self.catalogue))
@@ -406,7 +387,7 @@ class PageFetchTests(TestCase):
         }
         second = {"features": [], "links": [{"rel": "self", "href": "..."}]}
 
-        with mock.patch("wis2watch.core.catalogue.requests.get") as get:
+        with mock.patch("wis2watch.core.sync.requests.get") as get:
             get.side_effect = [self.response(first), self.response(second)]
 
             payloads = list(fetch_discovery_pages(self.catalogue))

--- a/wis2watch/src/wis2watch/core/tests/test_interpretation_node_stations.py
+++ b/wis2watch/src/wis2watch/core/tests/test_interpretation_node_stations.py
@@ -1,0 +1,105 @@
+"""Node station registry extraction, against a real registry response.
+
+The fixture is a trimmed capture of Ghana's own station registry. What a node
+declares is a GeoJSON feature per station: the WIGOS identifier is the station's
+identity, and the name and traditional identifier beside it are the operator's
+own, which is why they are read out separately rather than folded into the
+canonical record.
+"""
+
+from wis2watch.core.interpretation import extract_node_station, extract_node_stations
+
+from .support import NoNetworkTestCase, load_json_fixture
+
+REGISTRY = "node_stations_gh_gmet.json"
+
+
+def feature(wigos_id):
+    for candidate in load_json_fixture(REGISTRY)["features"]:
+        if candidate["properties"]["wigos_station_identifier"] == wigos_id:
+            return candidate
+
+    raise AssertionError(f"{wigos_id} is not in the fixture")
+
+
+class StationExtractionTests(NoNetworkTestCase):
+    def test_station_fields_are_taken_from_the_feature(self):
+        station = extract_node_station(feature("0-288-0-65487"))
+
+        self.assertEqual(station.wigos_id, "0-288-0-65487")
+        self.assertEqual(station.name, "Fumbisi Baasa")
+        self.assertEqual(station.longitude, -1.2927)
+        self.assertEqual(station.latitude, 10.4195)
+        self.assertEqual(station.elevation, 164.0)
+        self.assertEqual(station.facility_type, "landFixed")
+        self.assertEqual(station.territory, "GHA")
+        self.assertEqual(station.wmo_region, "africa")
+
+    def test_the_identifier_the_operator_assigns_is_kept_as_its_own(self):
+        station = extract_node_station(feature("0-20000-0-65457"))
+
+        self.assertEqual(station.name, "AKIM ODA")
+        self.assertEqual(station.local_id, "65457")
+
+    def test_a_station_the_operator_gives_no_identifier_of_its_own_has_none(self):
+        self.assertEqual(extract_node_station(feature("0-288-0-65487")).local_id, "")
+
+    def test_a_coordinate_of_zero_is_a_coordinate(self):
+        """Tema sits on the Greenwich meridian; its longitude is not absence."""
+        station = extract_node_station(feature("0-288-0-65476"))
+
+        self.assertEqual(station.longitude, 0.0)
+        self.assertEqual(station.latitude, 5.62)
+
+    def test_the_raw_feature_is_retained(self):
+        source = feature("0-288-0-65487")
+
+        self.assertEqual(extract_node_station(source).raw, source)
+
+
+class LocationTests(NoNetworkTestCase):
+    """A station whose position the registry does not give still exists."""
+
+    def positioned(self, geometry):
+        station = extract_node_station(
+            {
+                "properties": {"wigos_station_identifier": "0-288-0-65487"},
+                "geometry": geometry,
+            }
+        )
+
+        return (station.longitude, station.latitude, station.elevation)
+
+    def test_a_station_with_no_elevation_has_a_position_without_one(self):
+        self.assertEqual(self.positioned({"coordinates": [0.5, 6.1]}), (0.5, 6.1, None))
+
+    def test_a_station_with_no_usable_coordinates_has_no_position(self):
+        self.assertEqual(self.positioned({"coordinates": [0.5]}), (None, None, None))
+        self.assertEqual(self.positioned({"coordinates": []}), (None, None, None))
+        self.assertEqual(self.positioned({}), (None, None, None))
+        self.assertEqual(self.positioned(None), (None, None, None))
+
+
+class SkippedFeatureTests(NoNetworkTestCase):
+    def test_a_feature_with_no_wigos_identifier_is_skipped(self):
+        self.assertIsNone(extract_node_station({"properties": {"name": "Nowhere"}}))
+        self.assertIsNone(
+            extract_node_station({"properties": {"wigos_station_identifier": ""}})
+        )
+        self.assertIsNone(extract_node_station({}))
+        self.assertIsNone(extract_node_station(None))
+
+
+class RegistryResponseTests(NoNetworkTestCase):
+    def test_the_whole_captured_response_yields_a_station_each(self):
+        payload = load_json_fixture(REGISTRY)
+
+        stations = extract_node_stations(payload)
+
+        self.assertEqual(len(stations), len(payload["features"]))
+        self.assertTrue(all(station.wigos_id for station in stations))
+
+    def test_a_response_with_no_features_yields_nothing(self):
+        self.assertEqual(extract_node_stations({}), [])
+        self.assertEqual(extract_node_stations({"features": []}), [])
+        self.assertEqual(extract_node_stations(None), [])

--- a/wis2watch/src/wis2watch/core/tests/test_interpretation_ogcapi.py
+++ b/wis2watch/src/wis2watch/core/tests/test_interpretation_ogcapi.py
@@ -1,0 +1,38 @@
+"""Paging an OGC API Features collection.
+
+Both syncs that read one -- the catalogue's discovery metadata and a node's own
+station registry -- follow the same link, so the rule is asserted once here
+rather than once per sync.
+"""
+
+from wis2watch.core.interpretation import next_page_url
+
+from .support import NoNetworkTestCase, load_json_fixture
+
+
+class NextPageTests(NoNetworkTestCase):
+    def test_the_next_link_is_followed_exactly_as_given(self):
+        payload = {
+            "links": [
+                {"rel": "self", "href": "https://example.int/items?limit=5"},
+                {"rel": "next", "href": "https://example.int/items?offset=5&limit=5"},
+            ]
+        }
+
+        self.assertEqual(
+            next_page_url(payload), "https://example.int/items?offset=5&limit=5"
+        )
+
+    def test_a_last_page_has_nowhere_to_go(self):
+        self.assertIsNone(next_page_url({"links": [{"rel": "self", "href": "..."}]}))
+        self.assertIsNone(next_page_url({"links": []}))
+        self.assertIsNone(next_page_url({}))
+        self.assertIsNone(next_page_url(None))
+
+    def test_a_next_link_with_no_href_leads_nowhere(self):
+        self.assertIsNone(next_page_url({"links": [{"rel": "next", "href": ""}]}))
+
+    def test_a_captured_response_that_fits_on_one_page_has_no_next(self):
+        payload = load_json_fixture("node_stations_gh_gmet.json")
+
+        self.assertIsNone(next_page_url(payload))

--- a/wis2watch/src/wis2watch/core/tests/test_node_stations_sync.py
+++ b/wis2watch/src/wis2watch/core/tests/test_node_stations_sync.py
@@ -21,8 +21,9 @@ from django.utils import timezone as dj_timezone
 from wis2watch.core.models import Station, StationSource, SyncLog, WIS2Node
 from wis2watch.core.node_stations import fetch_station_pages, sync_node_stations
 from wis2watch.core.stations import node_stations_as_csv
+from wis2watch.core.sync import MAX_PAGES
 
-from .support import load_json_fixture
+from .support import failing_fetch, load_json_fixture, pages
 
 REGISTRY = "node_stations_gh_gmet.json"
 
@@ -38,25 +39,6 @@ DECLARED = {
     "0-288-0-65495",
     "0-288-0-65478",
 }
-
-
-def pages(*payloads):
-    """A page fetch returning fixed payloads, standing in for the network."""
-
-    def fetch(node):
-        yield from payloads
-
-    return fetch
-
-
-def failing_fetch(message):
-    """A page fetch that fails the way an unreachable node would."""
-
-    def fetch(node):
-        raise OSError(message)
-        yield  # pragma: no cover - never reached, keeps this a generator
-
-    return fetch
 
 
 def one_station(**properties):
@@ -369,7 +351,7 @@ class FetchTests(NodeStationsTestCase):
         return mock.Mock(json=mock.Mock(return_value=payload), raise_for_status=mock.Mock())
 
     def test_it_asks_the_node_for_the_stations_it_advertises(self):
-        with mock.patch("wis2watch.core.node_stations.requests.get") as get:
+        with mock.patch("wis2watch.core.sync.requests.get") as get:
             get.return_value = self.response({"features": []})
 
             list(fetch_station_pages(self.node))
@@ -384,7 +366,7 @@ class FetchTests(NodeStationsTestCase):
         }
         second = {"features": [], "links": [{"rel": "self", "href": "..."}]}
 
-        with mock.patch("wis2watch.core.node_stations.requests.get") as get:
+        with mock.patch("wis2watch.core.sync.requests.get") as get:
             get.side_effect = [self.response(first), self.response(second)]
 
             payloads = list(fetch_station_pages(self.node))
@@ -393,3 +375,19 @@ class FetchTests(NodeStationsTestCase):
         self.assertEqual(
             get.call_args_list[1].args[0], "https://wis2.meteo.gov.gh/page-2"
         )
+
+    def test_a_registry_that_never_stops_paging_fails_rather_than_half_reads(self):
+        """A run that stopped at the ceiling cannot say how much it missed."""
+        forever = {
+            "features": [],
+            "links": [{"rel": "next", "href": "https://wis2.meteo.gov.gh/page-on"}],
+        }
+
+        with mock.patch("wis2watch.core.sync.requests.get") as get:
+            get.return_value = self.response(forever)
+
+            sync_log = sync_node_stations(self.node)
+
+        self.assertEqual(sync_log.status, SyncLog.FAILED)
+        self.assertIn("do not terminate", sync_log.error_message)
+        self.assertEqual(get.call_count, MAX_PAGES)

--- a/wis2watch/src/wis2watch/core/tests/test_node_stations_sync.py
+++ b/wis2watch/src/wis2watch/core/tests/test_node_stations_sync.py
@@ -1,0 +1,395 @@
+"""Station synchronisation from a node's own registry.
+
+The sync runs against the committed capture of Ghana's registry rather than the
+network: the page fetch is an argument, so these tests exercise the writing
+rules against the features a node really returns.
+
+What is asserted here is the shape of the three-source station picture. A node
+declaring a station is provenance, not identity: the canonical record is keyed
+on the WIGOS identifier and shared with OSCAR and with observed traffic, while
+the operator's own name and identifier stay on the declaration.
+"""
+
+import csv
+from io import StringIO
+from unittest import mock
+
+from django.contrib.gis.geos import Point
+from django.test import TestCase
+from django.utils import timezone as dj_timezone
+
+from wis2watch.core.models import Station, StationSource, SyncLog, WIS2Node
+from wis2watch.core.node_stations import fetch_station_pages, sync_node_stations
+from wis2watch.core.stations import node_stations_as_csv
+
+from .support import load_json_fixture
+
+REGISTRY = "node_stations_gh_gmet.json"
+
+#: Every station the capture declares.
+DECLARED = {
+    "0-288-0-65487",
+    "0-20000-0-65457",
+    "0-20000-0-65445",
+    "0-288-0-65471",
+    "0-288-0-65476",
+    "0-288-0-65450",
+    "0-288-0-65492",
+    "0-288-0-65495",
+    "0-288-0-65478",
+}
+
+
+def pages(*payloads):
+    """A page fetch returning fixed payloads, standing in for the network."""
+
+    def fetch(node):
+        yield from payloads
+
+    return fetch
+
+
+def failing_fetch(message):
+    """A page fetch that fails the way an unreachable node would."""
+
+    def fetch(node):
+        raise OSError(message)
+        yield  # pragma: no cover - never reached, keeps this a generator
+
+    return fetch
+
+
+def one_station(**properties):
+    """A registry response declaring a single station."""
+    return {
+        "features": [
+            {
+                "properties": {
+                    "wigos_station_identifier": "0-288-0-65487",
+                    **properties,
+                },
+                "geometry": {"type": "Point", "coordinates": [-1.2927, 10.4195, 164.0]},
+            }
+        ]
+    }
+
+
+class NodeStationsTestCase(TestCase):
+    def setUp(self):
+        self.payload = load_json_fixture(REGISTRY)
+        self.node = WIS2Node.objects.create(
+            centre_id="gh-gmet",
+            name="Ghana Meteorological Agency",
+            base_url="https://wis2.meteo.gov.gh",
+        )
+
+    def sync(self, *payloads, node=None):
+        return sync_node_stations(
+            node or self.node, fetch=pages(*(payloads or (self.payload,)))
+        )
+
+    def declaration(self, wigos_id=None, node=None):
+        return StationSource.objects.get(
+            station__wigos_id=wigos_id or "0-288-0-65487",
+            source_type=StationSource.NODE_REGISTRY,
+            node=node or self.node,
+        )
+
+
+class DeclaredStationTests(NodeStationsTestCase):
+    """What a node's registry declares becomes stations and provenance."""
+
+    def test_every_declared_station_is_created(self):
+        self.sync()
+
+        self.assertEqual(set(Station.objects.values_list("wigos_id", flat=True)), DECLARED)
+
+    def test_each_station_records_that_this_node_declared_it(self):
+        self.sync()
+
+        self.assertEqual(
+            set(
+                StationSource.objects.filter(
+                    source_type=StationSource.NODE_REGISTRY, node=self.node
+                ).values_list("station__wigos_id", flat=True)
+            ),
+            DECLARED,
+        )
+
+    def test_the_locally_assigned_name_and_identifier_are_kept_on_the_declaration(self):
+        self.sync()
+
+        declaration = self.declaration("0-20000-0-65457")
+
+        self.assertEqual(declaration.local_name, "AKIM ODA")
+        self.assertEqual(declaration.local_id, "65457")
+
+    def test_the_declared_feature_is_kept_whole(self):
+        self.sync()
+
+        self.assertEqual(
+            self.declaration().raw_json["properties"]["wigos_station_identifier"],
+            "0-288-0-65487",
+        )
+
+    def test_a_declaration_records_when_the_node_last_confirmed_it(self):
+        before = dj_timezone.now()
+
+        self.sync()
+
+        self.assertGreaterEqual(self.declaration().last_seen, before)
+
+    def test_a_station_declared_by_two_nodes_is_one_station_declared_twice(self):
+        neighbour = WIS2Node.objects.create(
+            centre_id="ci-sodexam",
+            name="Côte d'Ivoire",
+            base_url="https://wis2.sodexam.ci",
+        )
+
+        self.sync()
+        self.sync(node=neighbour)
+
+        station = Station.objects.get(wigos_id="0-288-0-65487")
+
+        self.assertEqual(Station.objects.filter(wigos_id="0-288-0-65487").count(), 1)
+        self.assertEqual(
+            set(station.sources.values_list("node__centre_id", flat=True)),
+            {"gh-gmet", "ci-sodexam"},
+        )
+
+
+class CanonicalRecordTests(NodeStationsTestCase):
+    """The canonical record is shared, so a node fills it in rather than over."""
+
+    def test_a_station_nothing_else_knows_takes_what_the_node_says(self):
+        self.sync()
+
+        station = Station.objects.get(wigos_id="0-20000-0-65457")
+
+        self.assertEqual(station.name, "AKIM ODA")
+        self.assertEqual(station.facility_type, "landFixed")
+        self.assertEqual(station.territory, "GHA")
+        self.assertEqual(station.wmo_region, "africa")
+
+    def test_the_declared_position_is_kept_with_its_elevation(self):
+        self.sync()
+
+        location = Station.objects.get(wigos_id="0-288-0-65487").location
+
+        self.assertAlmostEqual(location.x, -1.2927)
+        self.assertAlmostEqual(location.y, 10.4195)
+        self.assertAlmostEqual(location.z, 164.0)
+
+    def test_a_position_on_the_meridian_is_a_position(self):
+        """Tema's longitude is zero, which is a place, not a missing value."""
+        self.sync()
+
+        location = Station.objects.get(wigos_id="0-288-0-65476").location
+
+        self.assertEqual(location.x, 0.0)
+        self.assertAlmostEqual(location.y, 5.62)
+
+    def test_a_station_the_registry_places_nowhere_is_still_declared(self):
+        self.sync({"features": [{"properties": {"wigos_station_identifier": "0-0-0-x"}}]})
+
+        self.assertIsNone(Station.objects.get(wigos_id="0-0-0-x").location)
+
+    def test_what_another_source_already_recorded_is_left_alone(self):
+        """OSCAR is the enrichment authority; the node's naming lives beside it."""
+        Station.objects.create(
+            wigos_id="0-20000-0-65457",
+            name="AKIM ODA (OSCAR)",
+            territory="Ghana",
+            location=Point(-0.98, 5.93, 139.0, srid=4326),
+        )
+
+        self.sync()
+
+        station = Station.objects.get(wigos_id="0-20000-0-65457")
+
+        self.assertEqual(station.name, "AKIM ODA (OSCAR)")
+        self.assertEqual(station.territory, "Ghana")
+        self.assertAlmostEqual(station.location.y, 5.93)
+        self.assertEqual(self.declaration("0-20000-0-65457").local_name, "AKIM ODA")
+
+    def test_what_no_other_source_recorded_is_filled_in(self):
+        Station.objects.create(wigos_id="0-20000-0-65457", operating_status="operational")
+
+        self.sync()
+
+        station = Station.objects.get(wigos_id="0-20000-0-65457")
+
+        self.assertEqual(station.name, "AKIM ODA")
+        self.assertIsNotNone(station.location)
+        self.assertEqual(station.operating_status, "operational")
+
+
+class SyncLogTests(NodeStationsTestCase):
+    """Every run is recorded, whatever became of it."""
+
+    def test_a_run_is_logged_against_the_node(self):
+        sync_log = self.sync()
+
+        self.assertEqual(sync_log.node, self.node)
+        self.assertEqual(sync_log.sync_type, SyncLog.NODE_STATIONS)
+        self.assertEqual(sync_log.status, SyncLog.SUCCESS)
+        self.assertIsNotNone(sync_log.completed_at)
+
+    def test_a_first_run_counts_every_station_as_declared_anew(self):
+        sync_log = self.sync()
+
+        self.assertEqual(sync_log.items_found, len(DECLARED))
+        self.assertEqual(sync_log.items_created, len(DECLARED))
+        self.assertEqual(sync_log.items_updated, 0)
+
+    def test_a_second_run_updates_rather_than_duplicates(self):
+        self.sync()
+        sync_log = self.sync()
+
+        self.assertEqual(sync_log.items_created, 0)
+        self.assertEqual(sync_log.items_updated, len(DECLARED))
+        self.assertEqual(Station.objects.count(), len(DECLARED))
+        self.assertEqual(StationSource.objects.count(), len(DECLARED))
+
+    def test_a_station_another_node_created_is_still_a_new_declaration(self):
+        Station.objects.create(wigos_id="0-288-0-65487")
+
+        sync_log = self.sync(one_station(name="Fumbisi Baasa"))
+
+        self.assertEqual(sync_log.items_created, 1)
+
+    def test_a_feature_naming_no_station_is_not_a_station(self):
+        payload = {
+            "features": [
+                {"properties": {"name": "Nowhere"}},
+                {"properties": {"wigos_station_identifier": "0-288-0-65487"}},
+            ]
+        }
+
+        sync_log = self.sync(payload)
+
+        self.assertEqual(sync_log.items_found, 1)
+        self.assertEqual(sync_log.items_created, 1)
+
+    def test_a_node_that_cannot_be_reached_records_why(self):
+        sync_log = sync_node_stations(
+            self.node, fetch=failing_fetch("connection refused")
+        )
+
+        self.assertEqual(sync_log.status, SyncLog.FAILED)
+        self.assertIn("connection refused", sync_log.error_message)
+        self.assertEqual(Station.objects.count(), 0)
+
+    def test_a_station_that_cannot_be_stored_does_not_lose_the_run(self):
+        long_id = "0-288-0-" + "x" * 200
+
+        sync_log = self.sync(
+            {
+                "features": [
+                    {"properties": {"wigos_station_identifier": long_id}},
+                    *self.payload["features"],
+                ]
+            }
+        )
+
+        self.assertEqual(sync_log.status, SyncLog.PARTIAL)
+        self.assertEqual(sync_log.items_errored, 1)
+        self.assertEqual(sync_log.items_created, len(DECLARED))
+        self.assertEqual(Station.objects.count(), len(DECLARED))
+
+    def test_every_page_of_a_paged_registry_is_read(self):
+        first = {"features": self.payload["features"][:4]}
+        second = {"features": self.payload["features"][4:]}
+
+        sync_log = self.sync(first, second)
+
+        self.assertEqual(sync_log.items_found, len(DECLARED))
+        self.assertEqual(Station.objects.count(), len(DECLARED))
+
+
+class StationExportTests(NodeStationsTestCase):
+    """The export reads what the sync wrote, against a real registry response."""
+
+    def exported(self):
+        output = StringIO()
+        node_stations_as_csv(self.node, output)
+
+        return list(csv.DictReader(StringIO(output.getvalue())))
+
+    def test_every_declared_station_is_exported(self):
+        self.sync()
+
+        self.assertEqual(
+            {row["wigos_station_identifier"] for row in self.exported()}, DECLARED
+        )
+
+    def test_a_row_carries_the_operators_own_naming_and_the_declared_position(self):
+        self.sync()
+
+        row = next(
+            row
+            for row in self.exported()
+            if row["wigos_station_identifier"] == "0-20000-0-65457"
+        )
+
+        self.assertEqual(row["station_name"], "AKIM ODA")
+        self.assertEqual(row["traditional_station_identifier"], "65457")
+        self.assertEqual(row["facility_type"], "landFixed")
+        self.assertEqual(row["barometer_height"], "139.4")
+        self.assertEqual(float(row["latitude"]), 5.9333333333)
+        self.assertEqual(float(row["longitude"]), -0.9833333333)
+        self.assertEqual(row["territory_name"], "GHA")
+
+    def test_another_nodes_declarations_are_not_exported(self):
+        neighbour = WIS2Node.objects.create(
+            centre_id="ci-sodexam",
+            name="Côte d'Ivoire",
+            base_url="https://wis2.sodexam.ci",
+        )
+
+        self.sync(node=neighbour)
+
+        self.assertEqual(self.exported(), [])
+
+
+class NoRegistryTests(TestCase):
+    """A node that advertises no station registry is not asked for one."""
+
+    def test_a_node_with_no_stations_endpoint_is_left_alone(self):
+        node = WIS2Node.objects.create(centre_id="ke-meteo", name="Kenya Met")
+
+        self.assertIsNone(sync_node_stations(node, fetch=failing_fetch("never called")))
+        self.assertEqual(SyncLog.objects.count(), 0)
+
+
+class FetchTests(NodeStationsTestCase):
+    """The fetch reads the node's own registry, and follows its paging."""
+
+    def response(self, payload):
+        return mock.Mock(json=mock.Mock(return_value=payload), raise_for_status=mock.Mock())
+
+    def test_it_asks_the_node_for_the_stations_it_advertises(self):
+        with mock.patch("wis2watch.core.node_stations.requests.get") as get:
+            get.return_value = self.response({"features": []})
+
+            list(fetch_station_pages(self.node))
+
+        self.assertEqual(get.call_args.args[0], self.node.stations_url)
+        self.assertIs(get.call_args.kwargs["verify"], True)
+
+    def test_it_follows_the_next_link_until_there_is_none(self):
+        first = {
+            "features": [],
+            "links": [{"rel": "next", "href": "https://wis2.meteo.gov.gh/page-2"}],
+        }
+        second = {"features": [], "links": [{"rel": "self", "href": "..."}]}
+
+        with mock.patch("wis2watch.core.node_stations.requests.get") as get:
+            get.side_effect = [self.response(first), self.response(second)]
+
+            payloads = list(fetch_station_pages(self.node))
+
+        self.assertEqual(payloads, [first, second])
+        self.assertEqual(
+            get.call_args_list[1].args[0], "https://wis2.meteo.gov.gh/page-2"
+        )

--- a/wis2watch/src/wis2watch/core/tests/test_tasks.py
+++ b/wis2watch/src/wis2watch/core/tests/test_tasks.py
@@ -1,0 +1,55 @@
+"""The scheduled work, as far as which nodes it asks and what it reports.
+
+Only the station tasks are covered here, and only their choosing: a centre that
+adds stations must be picked up without anyone triggering a sync, and a centre
+that advertises no registry must not be asked hourly for one. What the sync
+itself does is asserted against captured payloads elsewhere.
+"""
+
+from unittest import mock
+
+from django.test import TestCase
+
+from wis2watch.core.models import SyncLog, WIS2Node
+from wis2watch.core.tasks import run_sync_all_node_stations, run_sync_node_stations
+
+
+class NodeStationTaskTests(TestCase):
+    def setUp(self):
+        self.node = WIS2Node.objects.create(
+            centre_id="gh-gmet",
+            name="Ghana Meteorological Agency",
+            base_url="https://wis2.meteo.gov.gh",
+        )
+
+    def test_every_node_advertising_a_registry_is_queued(self):
+        with mock.patch(
+            "wis2watch.core.tasks.run_sync_node_stations.delay"
+        ) as queued:
+            self.assertEqual(run_sync_all_node_stations(), [self.node.id])
+
+        self.assertEqual(queued.call_args.args, (self.node.id,))
+
+    def test_a_node_advertising_no_registry_is_not_asked_for_one(self):
+        WIS2Node.objects.create(centre_id="ke-meteo", name="Kenya Met")
+
+        with mock.patch("wis2watch.core.tasks.run_sync_node_stations.delay"):
+            self.assertEqual(run_sync_all_node_stations(), [self.node.id])
+
+    def test_a_run_reports_the_log_it_wrote(self):
+        with mock.patch("wis2watch.core.tasks.sync_node_stations") as sync:
+            sync.return_value = SyncLog.objects.create(
+                node=self.node,
+                sync_type=SyncLog.NODE_STATIONS,
+                status=SyncLog.SUCCESS,
+            )
+
+            self.assertEqual(
+                run_sync_node_stations(self.node.id), sync.return_value.id
+            )
+
+    def test_a_node_that_was_not_asked_reports_nothing(self):
+        node = WIS2Node.objects.create(centre_id="ke-meteo", name="Kenya Met")
+
+        self.assertIsNone(run_sync_node_stations(node.id))
+        self.assertEqual(SyncLog.objects.count(), 0)

--- a/wis2watch/src/wis2watch/core/tests/test_tasks.py
+++ b/wis2watch/src/wis2watch/core/tests/test_tasks.py
@@ -23,12 +23,8 @@ class NodeStationTaskTests(TestCase):
         )
 
     def test_every_node_advertising_a_registry_is_queued(self):
-        with mock.patch(
-            "wis2watch.core.tasks.run_sync_node_stations.delay"
-        ) as queued:
+        with mock.patch("wis2watch.core.tasks.run_sync_node_stations.delay"):
             self.assertEqual(run_sync_all_node_stations(), [self.node.id])
-
-        self.assertEqual(queued.call_args.args, (self.node.id,))
 
     def test_a_node_advertising_no_registry_is_not_asked_for_one(self):
         WIS2Node.objects.create(centre_id="ke-meteo", name="Kenya Met")

--- a/wis2watch/src/wis2watch/core/views.py
+++ b/wis2watch/src/wis2watch/core/views.py
@@ -120,14 +120,15 @@ def node_details(request, node_id):
         HttpResponse: Rendered page with node details.
     """
 
+    node = get_object_or_404(WIS2Node, pk=node_id)
+
     if request.method == "POST":
         form = SyncNodeForm(request.POST)
         if form.is_valid():
-            node_id = form.cleaned_data['node_id']
-
             # Datasets come from the catalogue now, so syncing a node by hand
-            # asks it only for its station registry.
-            sync_log = sync_node_stations(get_object_or_404(WIS2Node, pk=node_id))
+            # asks it only for its station registry. The node is the page's
+            # own; the form carries its id so a stray post cannot sync another.
+            sync_log = sync_node_stations(node)
 
             if sync_log is None:
                 messages.warning(request, _("This node advertises no station registry."))
@@ -144,8 +145,6 @@ def node_details(request, node_id):
         else:
             messages.error(request, _("Invalid form submission."))
 
-    node = get_object_or_404(WIS2Node, pk=node_id)
-
     nodes_index_url_name = WIS2NodeViewSet().get_url_name("index")
     nodes_index_url = reverse_lazy(nodes_index_url_name)
 
@@ -155,7 +154,9 @@ def node_details(request, node_id):
         {"url": "", "label": node.name},
     ]
 
-    station_declarations = StationSource.objects.declared_by_node_registry(node)
+    station_declarations = StationSource.objects.declared_by_node_registry(
+        node
+    ).with_last_transmitted()
 
     context = {
         "breadcrumbs_items": breadcrumbs_items,

--- a/wis2watch/src/wis2watch/core/views.py
+++ b/wis2watch/src/wis2watch/core/views.py
@@ -9,9 +9,9 @@ from wagtail.admin import messages
 
 from .analysis import Staleness, default_volume_hours, node_overview
 from .forms import SyncNodeForm
-from .models import StationSource, WIS2Node
+from .models import StationSource, SyncLog, WIS2Node
+from .node_stations import sync_node_stations
 from .stations import node_stations_as_csv
-from .sync import sync_stations
 from .viewsets import WIS2NodeViewSet
 
 
@@ -127,13 +127,20 @@ def node_details(request, node_id):
 
             # Datasets come from the catalogue now, so syncing a node by hand
             # asks it only for its station registry.
-            result, error = sync_stations(node_id)
+            sync_log = sync_node_stations(get_object_or_404(WIS2Node, pk=node_id))
 
-            if error:
-                error = str(error)
-                messages.error(request, _("Error during synchronization: ") + error)
+            if sync_log is None:
+                messages.warning(request, _("This node advertises no station registry."))
+            elif sync_log.status == SyncLog.FAILED:
+                messages.error(
+                    request,
+                    _("Error during synchronization: ") + sync_log.error_message,
+                )
             else:
-                messages.success(request, _("Node synchronization completed successfully."))
+                messages.success(
+                    request,
+                    _("Station synchronization completed: ") + sync_log.summary,
+                )
         else:
             messages.error(request, _("Invalid form submission."))
 

--- a/wis2watch/src/wis2watch/ingest/store.py
+++ b/wis2watch/src/wis2watch/ingest/store.py
@@ -7,6 +7,11 @@ to nothing, and each absence is recorded rather than treated as a failure --
 a centre publishing without a catalogue record, a topic no dataset claims and
 a message carrying no station are all findings this tool exists to report.
 
+A station is the exception to resolving to nothing: one that names itself and
+that no registry declares is created here, along with the record that it was
+observed transmitting, because a station nobody declares is precisely the one
+worth asking a centre about.
+
 Only the message's own publication time is stored as ``time``. It is fixed for
 a given notification, which is what lets the same notification seen from two
 vantage points be matched, and what makes a redelivery a no-op.
@@ -15,12 +20,15 @@ vantage points be matched, and what makes a redelivery a no-op.
 import logging
 from dataclasses import dataclass
 
+from django.db.models import Q
+
 from ..core.interpretation import parse_notification, parse_topic
 from ..core.models import (
     Dataset,
     NodeLastSeen,
     NotificationMessage,
     Station,
+    StationSource,
     WIS2Node,
 )
 
@@ -114,11 +122,22 @@ class RegistryLookup:
         return None
 
     def station(self, wigos_id):
-        """The station an identifier names, or None if it is not known yet."""
+        """The station an identifier names, created if nothing declares it.
+
+        A station transmitting that no registry has heard of is the finding
+        this tool exists to make, so it is written down rather than dropped:
+        observation is one of the three sources a station can be known from,
+        and the only one that proves the station is alive.
+
+        Nothing is filled in beyond the identifier. What a station is called
+        and where it stands are OSCAR's and the node registry's to say; a
+        notification carries neither, and inventing them here would put words
+        in a source's mouth.
+        """
         if wigos_id not in self._stations:
-            self._stations[wigos_id] = Station.objects.filter(
+            self._stations[wigos_id], _ = Station.objects.get_or_create(
                 wigos_id=wigos_id
-            ).first()
+            )
 
         return self._stations[wigos_id]
 
@@ -138,10 +157,9 @@ def prepare_notification(source, topic, payload, lookup=None):
     lookup = lookup or RegistryLookup()
     parsed = parse_topic(topic)
 
-    # Attribution comes only from the message's own WIGOS station identifier,
-    # and only to a station already known. A transmitting station the registry
-    # has never heard of keeps its identifier on the row, so that the station
-    # sync can find it later and the gap is visible in the meantime.
+    # Attribution comes only from the message's own WIGOS station identifier.
+    # A station nothing declares is created rather than dropped: it is
+    # transmitting, which is the one thing a registry cannot tell us.
     station = (
         lookup.station(notification.wigos_station_id)
         if notification.is_attributed
@@ -212,6 +230,49 @@ def _record_last_seen(records):
             )
 
 
+def _record_observed_stations(records):
+    """Record each station a flush saw transmitting, and when it last did.
+
+    Per-station last-seen is what lets a single silent station be named rather
+    than a whole centre, and it is kept on the observation because that is the
+    only source that can speak to it: a registry declaring a station says
+    nothing about whether it has ever transmitted.
+
+    The node is the one whose topic carried the message, and may be none --
+    a centre with no catalogue record still has stations, and losing them
+    would hide exactly the traffic worth asking about.
+
+    As with a node's last-seen, time only moves forward: redeliveries and
+    messages that took the long way round say nothing new.
+    """
+    latest = {}
+
+    for record in records:
+        if record.station_id is None:
+            continue
+
+        seen = (record.station_id, record.node_id)
+
+        if seen not in latest or record.time > latest[seen]:
+            latest[seen] = record.time
+
+    for (station_id, node_id), seen_at in latest.items():
+        moved = StationSource.objects.filter(
+            Q(last_seen__lt=seen_at) | Q(last_seen__isnull=True),
+            station_id=station_id,
+            source_type=StationSource.OBSERVED,
+            node_id=node_id,
+        ).update(last_seen=seen_at)
+
+        if not moved:
+            StationSource.objects.get_or_create(
+                station_id=station_id,
+                source_type=StationSource.OBSERVED,
+                node_id=node_id,
+                defaults={"last_seen": seen_at},
+            )
+
+
 def store_notifications(source, received):
     """Store a flush of received ``(topic, payload)`` pairs.
 
@@ -250,5 +311,6 @@ def store_notifications(source, received):
     if records:
         _insert(records)
         _record_last_seen(records)
+        _record_observed_stations(records)
 
     return counts

--- a/wis2watch/src/wis2watch/ingest/store.py
+++ b/wis2watch/src/wis2watch/ingest/store.py
@@ -242,8 +242,10 @@ def _record_observed_stations(records):
     a centre with no catalogue record still has stations, and losing them
     would hide exactly the traffic worth asking about.
 
-    As with a node's last-seen, time only moves forward: redeliveries and
-    messages that took the long way round say nothing new.
+    Time only moves forward, for the reasons ``_record_last_seen`` gives about
+    a node's. The two are kept apart rather than generalised: they answer
+    different questions, and the row a station's answer lives on is one of the
+    three provenance records, which a node's is not.
     """
     latest = {}
 
@@ -251,10 +253,11 @@ def _record_observed_stations(records):
         if record.station_id is None:
             continue
 
-        seen = (record.station_id, record.node_id)
+        transmitter = (record.station_id, record.node_id)
+        seen_before = latest.get(transmitter)
 
-        if seen not in latest or record.time > latest[seen]:
-            latest[seen] = record.time
+        if seen_before is None or record.time > seen_before:
+            latest[transmitter] = record.time
 
     for (station_id, node_id), seen_at in latest.items():
         moved = StationSource.objects.filter(

--- a/wis2watch/src/wis2watch/ingest/tests/test_store.py
+++ b/wis2watch/src/wis2watch/ingest/tests/test_store.py
@@ -20,6 +20,7 @@ from wis2watch.core.models import (
     NodeLastSeen,
     NotificationMessage,
     Station,
+    StationSource,
     WIS2Node,
 )
 from wis2watch.core.tests.support import load_jsonl_fixture
@@ -45,6 +46,22 @@ def message_on(topic):
             return message
 
     raise AssertionError(f"no captured message on {topic}")
+
+
+def published_at(pubtime, topic=KE_TOPIC, notification_id=None):
+    """A captured message re-stamped with a publication time.
+
+    The UUID moves with the time by default, so that two stampings of one
+    capture are two notifications rather than a redelivery of one.
+    """
+    payload = message_on(topic)["payload"]
+    payload = dict(
+        payload,
+        id=notification_id or f"{payload['id']}-{pubtime}",
+        properties=dict(payload["properties"], pubtime=pubtime),
+    )
+
+    return (topic, payload)
 
 
 def store_one(source, topic, payload):
@@ -191,10 +208,11 @@ class StationAttributionTests(StoreTestCase):
         self.assertEqual(record.station, station)
         self.assertEqual(record.wigos_station_id, KE_STATION)
 
-    def test_a_station_the_registry_does_not_know_is_still_recorded_by_identifier(self):
+    def test_a_station_the_registry_does_not_know_is_created_from_the_message(self):
+        """A transmitting station is never invisible, declared or not."""
         record = self.store(KE_TOPIC)
 
-        self.assertIsNone(record.station)
+        self.assertEqual(record.station, Station.objects.get(wigos_id=KE_STATION))
         self.assertEqual(record.wigos_station_id, KE_STATION)
 
     def test_a_message_carrying_no_station_is_unattributed(self):
@@ -216,6 +234,149 @@ class StationAttributionTests(StoreTestCase):
 
         self.assertEqual(record.wigos_station_id, "")
         self.assertTrue(record.data_id)
+
+
+class ObservedStationTests(StoreTestCase):
+    """A station observed transmitting is recorded as one of the three sources.
+
+    Observation is provenance in its own right: a station transmitting that
+    nobody declares is the finding, so the ingest writes what it saw rather
+    than waiting for a registry to agree that the station exists.
+    """
+
+    def observation(self, wigos_id=KE_STATION, **naming):
+        return StationSource.objects.get(
+            station__wigos_id=wigos_id,
+            source_type=StationSource.OBSERVED,
+            **{"node": self.node, **naming},
+        )
+
+    def test_a_transmitting_station_records_that_it_was_observed(self):
+        self.store(KE_TOPIC)
+
+        self.assertEqual(self.observation().station.wigos_id, KE_STATION)
+
+    def test_an_observation_carries_no_naming_of_its_own(self):
+        """Nothing in a notification names a station beyond its identifier."""
+        self.store(KE_TOPIC)
+
+        self.assertEqual(self.observation().local_name, "")
+        self.assertEqual(self.observation().local_id, "")
+
+    def test_a_station_the_node_already_declares_gains_a_second_source(self):
+        station = Station.objects.create(wigos_id=KE_STATION, name="Wajir")
+        StationSource.objects.create(
+            station=station,
+            source_type=StationSource.NODE_REGISTRY,
+            node=self.node,
+            local_name="WAJIR",
+        )
+
+        self.store(KE_TOPIC)
+
+        self.assertEqual(station.sources.count(), 2)
+        self.assertEqual(Station.objects.get(wigos_id=KE_STATION).name, "Wajir")
+
+    def test_a_station_transmitting_from_an_unregistered_centre_is_still_recorded(self):
+        """The centre is unknown, which is no reason to lose the station."""
+        topic = "origin/a/wis2/dj-anm/data/recommended/weather/aviation/taf"
+        payload = dict(
+            message_on(topic)["payload"],
+            properties=dict(
+                message_on(topic)["payload"]["properties"],
+                wigos_station_identifier="0-262-0-63125",
+            ),
+        )
+
+        record = store_one(self.source, topic, payload)
+
+        self.assertEqual(record.station.wigos_id, "0-262-0-63125")
+        self.assertIsNone(self.observation("0-262-0-63125", node=None).node)
+
+    def test_a_message_carrying_no_station_observes_nothing(self):
+        message = message_on("origin/a/wis2/dj-anm/data/recommended/weather/aviation/taf")
+
+        store_one(self.source, message["topic"], message["payload"])
+
+        self.assertEqual(Station.objects.count(), 0)
+        self.assertEqual(StationSource.objects.count(), 0)
+
+
+class StationLastSeenTests(StoreTestCase):
+    """Per-station last-seen, so a single silent station can be named.
+
+    As with a node's, it is the notification's own publication time and only
+    ever moves forward: a redelivery says nothing new about when the station
+    was last transmitting.
+    """
+
+    def last_seen_of(self, wigos_id=KE_STATION):
+        return (
+            StationSource.objects.get(
+                station__wigos_id=wigos_id, source_type=StationSource.OBSERVED
+            )
+            .last_seen.isoformat()
+        )
+
+    def test_observing_a_station_records_when_it_last_transmitted(self):
+        store_notifications(self.source, [published_at("2026-08-11T10:00:00Z")])
+
+        self.assertEqual(self.last_seen_of(), "2026-08-11T10:00:00+00:00")
+
+    def test_a_later_message_moves_the_station_forward(self):
+        store_notifications(self.source, [published_at("2026-08-11T10:00:00Z")])
+        store_notifications(self.source, [published_at("2026-08-11T11:30:00Z")])
+
+        self.assertEqual(self.last_seen_of(), "2026-08-11T11:30:00+00:00")
+
+    def test_an_older_message_does_not_move_the_station_backwards(self):
+        store_notifications(self.source, [published_at("2026-08-11T11:30:00Z")])
+        store_notifications(self.source, [published_at("2026-08-11T10:00:00Z")])
+
+        self.assertEqual(self.last_seen_of(), "2026-08-11T11:30:00+00:00")
+
+    def test_a_flush_records_the_latest_message_the_station_sent(self):
+        store_notifications(
+            self.source,
+            [
+                published_at("2026-08-11T10:00:00Z"),
+                published_at("2026-08-11T12:15:00Z"),
+                published_at("2026-08-11T11:00:00Z"),
+            ],
+        )
+
+        self.assertEqual(self.last_seen_of(), "2026-08-11T12:15:00+00:00")
+        self.assertEqual(StationSource.objects.count(), 1)
+
+    def test_a_station_already_declared_by_the_node_gets_its_own_observed_time(self):
+        """A registry declaration says nothing about when anything transmitted."""
+        station = Station.objects.create(wigos_id=KE_STATION)
+        declared = StationSource.objects.create(
+            station=station,
+            source_type=StationSource.NODE_REGISTRY,
+            node=self.node,
+        )
+
+        store_notifications(self.source, [published_at("2026-08-11T10:00:00Z")])
+        declared.refresh_from_db()
+
+        self.assertEqual(self.last_seen_of(), "2026-08-11T10:00:00+00:00")
+        self.assertIsNone(declared.last_seen)
+
+    def test_the_same_message_seen_from_another_vantage_point_changes_nothing(self):
+        origin = MessageSource.objects.create(
+            name="ke-meteo origin broker",
+            source_type=MessageSource.ORIGIN_BROKER,
+            node=self.node,
+            host="wis.meteo.example.int",
+        )
+        received = [published_at("2026-08-11T10:00:00Z")]
+
+        store_notifications(self.source, received)
+        store_notifications(origin, received)
+
+        self.assertEqual(StationSource.objects.count(), 1)
+        self.assertEqual(self.last_seen_of(), "2026-08-11T10:00:00+00:00")
 
 
 class UnusableMessageTests(StoreTestCase):
@@ -329,34 +490,23 @@ class LastSeenTests(StoreTestCase):
     says nothing new about when the centre was last publishing.
     """
 
-    def published_at(self, pubtime, topic=KE_TOPIC, notification_id=None):
-        """A captured message re-stamped with a publication time."""
-        payload = message_on(topic)["payload"]
-        payload = dict(
-            payload,
-            id=notification_id or f"{payload['id']}-{pubtime}",
-            properties=dict(payload["properties"], pubtime=pubtime),
-        )
-
-        return (topic, payload)
-
     def last_seen_of(self, node):
         return NodeLastSeen.objects.get(node=node).last_message_at.isoformat()
 
     def test_storing_a_message_records_when_its_centre_was_last_heard_from(self):
-        store_notifications(self.source, [self.published_at("2026-08-11T10:00:00Z")])
+        store_notifications(self.source, [published_at("2026-08-11T10:00:00Z")])
 
         self.assertEqual(self.last_seen_of(self.node), "2026-08-11T10:00:00+00:00")
 
     def test_a_later_message_moves_last_seen_forward(self):
-        store_notifications(self.source, [self.published_at("2026-08-11T10:00:00Z")])
-        store_notifications(self.source, [self.published_at("2026-08-11T11:30:00Z")])
+        store_notifications(self.source, [published_at("2026-08-11T10:00:00Z")])
+        store_notifications(self.source, [published_at("2026-08-11T11:30:00Z")])
 
         self.assertEqual(self.last_seen_of(self.node), "2026-08-11T11:30:00+00:00")
 
     def test_an_older_message_does_not_move_last_seen_backwards(self):
-        store_notifications(self.source, [self.published_at("2026-08-11T11:30:00Z")])
-        store_notifications(self.source, [self.published_at("2026-08-11T10:00:00Z")])
+        store_notifications(self.source, [published_at("2026-08-11T11:30:00Z")])
+        store_notifications(self.source, [published_at("2026-08-11T10:00:00Z")])
 
         self.assertEqual(self.last_seen_of(self.node), "2026-08-11T11:30:00+00:00")
 
@@ -364,9 +514,9 @@ class LastSeenTests(StoreTestCase):
         store_notifications(
             self.source,
             [
-                self.published_at("2026-08-11T10:00:00Z"),
-                self.published_at("2026-08-11T12:15:00Z"),
-                self.published_at("2026-08-11T11:00:00Z"),
+                published_at("2026-08-11T10:00:00Z"),
+                published_at("2026-08-11T12:15:00Z"),
+                published_at("2026-08-11T11:00:00Z"),
             ],
         )
 
@@ -379,8 +529,8 @@ class LastSeenTests(StoreTestCase):
         store_notifications(
             self.source,
             [
-                self.published_at("2026-08-11T10:00:00Z"),
-                self.published_at("2026-08-11T09:00:00Z", topic=djibouti_topic),
+                published_at("2026-08-11T10:00:00Z"),
+                published_at("2026-08-11T09:00:00Z", topic=djibouti_topic),
             ],
         )
 
@@ -403,7 +553,7 @@ class LastSeenTests(StoreTestCase):
             node=self.node,
             host="wis.meteo.example.int",
         )
-        received = [self.published_at("2026-08-11T10:00:00Z")]
+        received = [published_at("2026-08-11T10:00:00Z")]
 
         store_notifications(self.source, received)
         store_notifications(origin, received)


### PR DESCRIPTION
Closes #9.

Two of the three station pictures land: what each node claims to operate, read from its own station registry endpoint, and what is actually transmitting, derived from observed notifications.

## What changed

**Observed stations** (`ingest/store.py`). A message naming a WIGOS station identifier nothing declares now creates that station, together with the record that it was observed transmitting. Per-station last-seen lives on that observation — the only source that can speak to whether a station is alive — and, like a node's, it is the notification's own publication time and only ever moves forward. The node is the one whose topic carried the message, and may be none: a centre with no catalogue record still has stations, and dropping them would hide exactly the traffic worth asking about. Nothing beyond the identifier is filled in; what a station is called and where it stands are OSCAR's and the node registry's to say.

**Node station registry sync** (`core/node_stations.py`, new). Each node's own endpoint is read, following the registry's `next` link — a station endpoint's default page size is routinely ten, so this matters. Each station is applied in its own savepoint and counted, every run is recorded as a `SyncLog`, and an unreachable node is diagnostic state rather than a task failure. Two rules keep the three sources from fighting over one record: a declaration is provenance, not identity; and a node fills in what nothing else has recorded rather than writing over it, so an hourly sync cannot undo a weekly OSCAR one. The operator's own name and identifier stay on the declaration.

**Interpretation seam.** `extract_node_station(s)` joins the seam, asserted against a captured response from Ghana's own registry (`node_stations_gh_gmet.json`, documented in the fixtures README). The OGC API Features paging rule both syncs follow is now written once in `interpretation/ogcapi.py`, and `SyncCounts` moves to `core/sync.py` so the catalogue and station syncs report runs the same way.

**Schedule.** The hourly fan-out now skips nodes that advertise no station registry, so a centre whose base URL nobody has filled in does not produce a failed log every hour, and per-node failures are no longer retried against the schedule.

**CSV export.** Already re-pointed at the node's declarations by the schema reset; this adds tests that run it against a really-synced registry response, including the barometer height it reads out of the declared feature.

## Testing

455 tests pass. New coverage: registry extraction against the capture (including a longitude of `0.0`, which is a place rather than a missing value), the sync's writing rules against seeded data, observed-station creation and per-station last-seen in the ingest, the station export end to end, and the fan-out's choice of nodes.