### PR TITLE
Node detail page

### DIFF
--- a/wis2watch/src/wis2watch/core/analysis/__init__.py
+++ b/wis2watch/src/wis2watch/core/analysis/__init__.py
@@ -13,20 +13,22 @@ them.
 """
 
 from .node_detail import (
+    NodeDatasetRow,
     NodeDetail,
     NodeStationRow,
     OriginBrokerState,
     StationStanding,
+    SyncRunRow,
+    SyncScope,
     node_detail,
 )
 from .overview import (
     CachePickup,
     NodeOverviewRow,
-    OriginReachability,
-    Staleness,
     default_volume_hours,
     node_overview,
 )
+from .reachability import OriginReachability
 from .silence import (
     DatasetSilenceRow,
     Expectation,
@@ -35,11 +37,13 @@ from .silence import (
     dataset_silence,
     silence_by_node,
 )
+from .staleness import Staleness
 
 __all__ = [
     "CachePickup",
     "DatasetSilenceRow",
     "Expectation",
+    "NodeDatasetRow",
     "NodeDetail",
     "NodeOverviewRow",
     "NodeSilence",
@@ -49,6 +53,8 @@ __all__ = [
     "Silence",
     "Staleness",
     "StationStanding",
+    "SyncRunRow",
+    "SyncScope",
     "dataset_silence",
     "default_volume_hours",
     "node_detail",

--- a/wis2watch/src/wis2watch/core/analysis/__init__.py
+++ b/wis2watch/src/wis2watch/core/analysis/__init__.py
@@ -12,6 +12,13 @@ confident wrong answer rather than an exception, and only real rows expose
 them.
 """
 
+from .node_detail import (
+    NodeDetail,
+    NodeStationRow,
+    OriginBrokerState,
+    StationStanding,
+    node_detail,
+)
 from .overview import (
     CachePickup,
     NodeOverviewRow,
@@ -33,13 +40,18 @@ __all__ = [
     "CachePickup",
     "DatasetSilenceRow",
     "Expectation",
+    "NodeDetail",
     "NodeOverviewRow",
     "NodeSilence",
+    "NodeStationRow",
+    "OriginBrokerState",
     "OriginReachability",
     "Silence",
     "Staleness",
+    "StationStanding",
     "dataset_silence",
     "default_volume_hours",
+    "node_detail",
     "node_overview",
     "silence_by_node",
 ]

--- a/wis2watch/src/wis2watch/core/analysis/node_detail.py
+++ b/wis2watch/src/wis2watch/core/analysis/node_detail.py
@@ -28,9 +28,24 @@ from django.db.models import Exists, OuterRef, Subquery
 from django.utils import timezone as dj_timezone
 from django.utils.translation import gettext_lazy as _
 
-from ..models import Dataset, MessageSource, NodeLastSeen, Station, StationSource, SyncLog
-from .overview import BEFORE_ANYTHING, OriginReachability, hours_between
-from .silence import DatasetSilenceRow, dataset_silence
+from ..models import (
+    Dataset,
+    GlobalDiscoveryCatalogue,
+    MessageSource,
+    NodeLastSeen,
+    Station,
+    StationSource,
+    SyncLog,
+)
+from .reachability import OriginReachability
+from .silence import (
+    BEFORE_ANYTHING,
+    DatasetSilenceRow,
+    dataset_silence,
+    hours_between,
+    with_last_active_hour,
+)
+from .staleness import default_stale_after_hours
 
 #: How many of each kind of sync run the page reads. Enough to show a run that
 #: has begun failing against the ones before it, and few enough that the page
@@ -45,24 +60,53 @@ from .silence import DatasetSilenceRow, dataset_silence
 DEFAULT_RUNS_PER_TYPE = 5
 
 
+class SyncScope:
+    """Whose run a sync run was.
+
+    A centre's datasets, topics and broker address all come from the catalogue
+    sync, which runs over the whole region and is recorded against the
+    catalogue rather than any one node. Left out, the page would answer "why
+    are this centre's datasets missing" with a table that structurally cannot
+    contain the run that creates them -- so the registry's runs are shown
+    beside the centre's own, saying which is which.
+    """
+
+    CENTRE = "centre"
+    REGISTRY = "registry"
+
+    CHOICES = [
+        (CENTRE, _("This centre")),
+        (REGISTRY, _("The registry")),
+    ]
+
+    LABELS = dict(CHOICES)
+
+
 class StationStanding:
     """What is known of one of a centre's stations.
 
-    Three states out of two facts -- whether the node's own registry declares
-    the station, and whether anything has been heard from it -- because the
-    two absences are different findings. A declared station nothing has heard
-    from is a station that has stopped, or never started; a station
-    transmitting that the registry declares nowhere is a registration gap, and
-    dropping it from the page because no declaration named it is exactly how a
-    transmitting station becomes invisible.
+    Out of two facts -- whether the node's own registry declares the station,
+    and when anything was last heard from it -- because each absence is a
+    different finding. A declared station nothing has heard from is one that
+    stopped or never started; one heard from long ago has stopped since; and a
+    station transmitting that the registry declares nowhere is a registration
+    gap, which dropping from the page because no declaration named it is
+    exactly how a transmitting station becomes invisible.
+
+    Quiet is judged against the same flat threshold the overview calls a centre
+    stale by, for the reasons ``wis2watch.core.analysis.staleness`` gives.
+    Without it every station ever heard from reads as working, and the one that
+    stopped in March sits at the bottom of the page in green.
     """
 
     TRANSMITTING = "transmitting"
+    GONE_QUIET = "gone_quiet"
     NEVER_TRANSMITTED = "never_transmitted"
     UNDECLARED = "undeclared"
 
     CHOICES = [
         (NEVER_TRANSMITTED, _("Declared, never heard from")),
+        (GONE_QUIET, _("Gone quiet")),
         (UNDECLARED, _("Transmitting, not declared")),
         (TRANSMITTING, _("Transmitting")),
     ]
@@ -72,7 +116,52 @@ class StationStanding:
     #: What has stopped first, then what was never declared, then what is
     #: working: the order someone reads a station list in when they came here
     #: because something is missing.
-    RANK = {NEVER_TRANSMITTED: 0, UNDECLARED: 1, TRANSMITTING: 2}
+    RANK = {NEVER_TRANSMITTED: 0, GONE_QUIET: 1, UNDECLARED: 2, TRANSMITTING: 3}
+
+    #: The standings that mean nothing has been heard from the station lately.
+    #: Named once because the page counts them and the rows report them, and
+    #: those are decided in different places.
+    SILENT = (NEVER_TRANSMITTED, GONE_QUIET)
+
+    @classmethod
+    def of(cls, *, declared, hours_quiet, stale_after):
+        """What one station's declarations and last transmission amount to."""
+        if hours_quiet is None:
+            return cls.NEVER_TRANSMITTED
+
+        if hours_quiet > stale_after:
+            return cls.GONE_QUIET
+
+        return cls.TRANSMITTING if declared else cls.UNDECLARED
+
+
+@dataclass(frozen=True)
+class NodeDatasetRow:
+    """One dataset of a centre's: what the registry says, and whether it is quiet.
+
+    The quiet is the silence module's own finding rather than a copy of it, so
+    that a dataset called silent here is silent by exactly the reasoning the
+    overview counts. A dataset the registry no longer calls active carries
+    none: nobody is waiting to hear from it, and a silence finding about it
+    would be a finding nobody should act on.
+    """
+
+    dataset_id: int
+    title: str
+    topic: str
+    identifier: str
+    policy: str
+    policy_label: str
+    status: str
+    status_label: str
+    last_synced: datetime | None
+    last_active_hour: datetime | None
+    quiet: DatasetSilenceRow | None
+
+    @property
+    def is_silent(self):
+        """Whether this dataset is past what is expected of it."""
+        return self.quiet is not None and self.quiet.is_silent
 
 
 @dataclass(frozen=True)
@@ -84,19 +173,14 @@ class NodeStationRow:
     name: str
     local_name: str
     local_id: str
+    facility_type: str
+    latitude: float | None
+    longitude: float | None
+    elevation: float | None
     declared_by_registry: bool
     last_transmitted: datetime | None
-
-    @property
-    def standing(self):
-        """What this station amounts to: stopped, undeclared or working."""
-        if self.last_transmitted is None:
-            return StationStanding.NEVER_TRANSMITTED
-
-        if not self.declared_by_registry:
-            return StationStanding.UNDECLARED
-
-        return StationStanding.TRANSMITTING
+    hours_quiet: float | None
+    standing: str
 
     @property
     def standing_label(self):
@@ -115,6 +199,30 @@ class NodeStationRow:
 
 
 @dataclass(frozen=True)
+class SyncRunRow:
+    """One run of a sync job, as the page reports it."""
+
+    run_id: int
+    scope: str
+    kind: str
+    kind_label: str
+    status: str
+    status_label: str
+    started_at: datetime
+    completed_at: datetime | None
+    items_found: int
+    items_created: int
+    items_updated: int
+    items_errored: int
+    error_message: str
+
+    @property
+    def scope_label(self):
+        """Whose run this was, for a table cell."""
+        return SyncScope.LABELS.get(self.scope, self.scope)
+
+
+@dataclass(frozen=True)
 class OriginBrokerState:
     """What is known about the centre's own broker, from outside.
 
@@ -125,7 +233,7 @@ class OriginBrokerState:
 
     reachability: str
     address: str
-    is_active: bool
+    connections_enabled: bool
     last_connected_at: datetime | None
     last_error: str
 
@@ -133,9 +241,9 @@ class OriginBrokerState:
     def unadvertised(cls):
         """A centre whose catalogue record names no broker of its own."""
         return cls(
-            reachability=OriginReachability.NOT_ADVERTISED,
+            reachability=OriginReachability.of(None, advertised=False),
             address="",
-            is_active=False,
+            connections_enabled=False,
             last_connected_at=None,
             last_error="",
         )
@@ -143,7 +251,7 @@ class OriginBrokerState:
     @property
     def reachability_label(self):
         """What the broker's state is called, for the page."""
-        return OriginReachability.LABELS.get(self.reachability, self.reachability)
+        return OriginReachability.label(self.reachability)
 
 
 @dataclass(frozen=True)
@@ -154,10 +262,10 @@ class NodeDetail:
     centre_id: str
     last_seen_at: datetime | None
     hours_since_last_seen: float | None
-    datasets: list[DatasetSilenceRow]
-    retired_datasets: list[Dataset]
+    datasets: list[NodeDatasetRow]
+    retired_datasets: list[NodeDatasetRow]
     stations: list[NodeStationRow]
-    sync_runs: list[SyncLog]
+    sync_runs: list[SyncRunRow]
     origin: OriginBrokerState
 
     @property
@@ -166,11 +274,19 @@ class NodeDetail:
         return sum(row.is_silent for row in self.datasets)
 
     @property
+    def declared_station_count(self):
+        """How many stations the centre's own registry declares.
+
+        Fewer than the stations listed, wherever the centre transmits for one
+        it has never declared -- and what the station export covers, which is
+        the registry's declarations alone.
+        """
+        return sum(row.declared_by_registry for row in self.stations)
+
+    @property
     def silent_station_count(self):
-        """How many of the centre's declared stations have never been heard from."""
-        return sum(
-            row.standing == StationStanding.NEVER_TRANSMITTED for row in self.stations
-        )
+        """How many of the centre's stations have not been heard from lately."""
+        return sum(row.standing in StationStanding.SILENT for row in self.stations)
 
 
 def node_detail(node, *, now=None, runs_per_type=DEFAULT_RUNS_PER_TYPE):
@@ -187,17 +303,16 @@ def node_detail(node, *, now=None, runs_per_type=DEFAULT_RUNS_PER_TYPE):
     """
     now = now or dj_timezone.now()
     last_seen_at = _last_seen_at(node)
+    live, retired = _datasets(node, now=now)
 
     return NodeDetail(
         node_id=node.pk,
         centre_id=node.centre_id,
         last_seen_at=last_seen_at,
         hours_since_last_seen=hours_between(last_seen_at, now),
-        datasets=dataset_silence(now=now, node=node),
-        retired_datasets=list(
-            Dataset.objects.filter(node=node).exclude(status=Dataset.ACTIVE)
-        ),
-        stations=_stations(node),
+        datasets=live,
+        retired_datasets=retired,
+        stations=_stations(node, now=now),
         sync_runs=_sync_runs(node, runs_per_type),
         origin=_origin(node),
     )
@@ -210,33 +325,106 @@ def _last_seen_at(node):
     return last_seen["last_message_at"] if last_seen else None
 
 
-def _sync_runs(node, runs_per_type):
-    """The centre's recent sync runs, no kind of run able to bury another.
+def _datasets(node, *, now):
+    """The centre's datasets, the live ones judged and the retired ones not.
 
-    Read a kind at a time and merged, which costs one small indexed query per
-    kind the node has ever had -- two or three -- and is what keeps the daily
-    run visible beside the hourly one.
+    Retired ones are kept because the page is what somebody reads when a
+    dataset's data has stopped arriving, and "the catalogue withdrew it" is one
+    of the answers -- an answer they cannot reach if the withdrawn dataset has
+    simply vanished from the page that was meant to explain it.
     """
-    # Ordered by nothing on purpose: a sync log's default ordering is by when
-    # it started, which a distinct over the kind alone would drag into the
-    # query and hand back one row per run rather than one per kind.
-    kinds = (
-        SyncLog.objects.filter(node=node)
-        .order_by()
-        .values_list("sync_type", flat=True)
-        .distinct()
+    datasets = {
+        dataset.pk: dataset
+        for dataset in with_last_active_hour(
+            Dataset.objects.filter(node=node), now=now
+        )
+    }
+
+    # The silent first and furthest overdue before them: the order the silence
+    # module put them in, which is the order somebody reads for what broke.
+    live = [
+        _dataset_row(datasets[quiet.dataset_id], quiet)
+        for quiet in dataset_silence(now=now, node=node)
+    ]
+    retired = [
+        _dataset_row(dataset, None)
+        for dataset in datasets.values()
+        if dataset.status != Dataset.ACTIVE
+    ]
+
+    return live, retired
+
+
+def _dataset_row(dataset, quiet):
+    """One dataset as a finding, judged or not."""
+    return NodeDatasetRow(
+        dataset_id=dataset.pk,
+        title=dataset.title,
+        topic=dataset.wmo_topic_hierarchy,
+        identifier=dataset.identifier,
+        policy=dataset.wmo_data_policy,
+        policy_label=dataset.get_wmo_data_policy_display(),
+        status=dataset.status,
+        status_label=dataset.get_status_display(),
+        last_synced=dataset.last_synced,
+        last_active_hour=dataset.last_active_hour,
+        quiet=quiet,
     )
 
-    runs = [
-        run
-        for kind in kinds
-        for run in SyncLog.objects.filter(node=node, sync_type=kind)[:runs_per_type]
-    ]
+
+def _sync_runs(node, runs_per_type):
+    """The runs that could explain what is missing, the centre's and the registry's."""
+    runs = _recent_runs(SyncLog.objects.filter(node=node), runs_per_type, SyncScope.CENTRE)
+
+    writer = GlobalDiscoveryCatalogue.objects.filter(is_writer=True).first()
+
+    if writer is not None:
+        runs += _recent_runs(
+            SyncLog.objects.filter(catalogue=writer), runs_per_type, SyncScope.REGISTRY
+        )
 
     return sorted(runs, key=lambda run: run.started_at, reverse=True)
 
 
-def _stations(node):
+def _recent_runs(runs, per_kind, scope):
+    """The most recent runs of each kind, so no kind can bury another.
+
+    Read a kind at a time and merged, which costs one small indexed query per
+    kind that has ever run -- two or three -- and is what keeps the daily run
+    visible beside the hourly one.
+    """
+    # Ordered by nothing on purpose: a sync log's default ordering is by when
+    # it started, which a distinct over the kind alone would drag into the
+    # query and hand back one row per run rather than one per kind.
+    kinds = runs.order_by().values_list("sync_type", flat=True).distinct()
+
+    return [
+        _sync_run_row(run, scope)
+        for kind in kinds
+        for run in runs.filter(sync_type=kind)[:per_kind]
+    ]
+
+
+def _sync_run_row(run, scope):
+    """One sync run as a finding."""
+    return SyncRunRow(
+        run_id=run.pk,
+        scope=scope,
+        kind=run.sync_type,
+        kind_label=run.get_sync_type_display(),
+        status=run.status,
+        status_label=run.get_status_display(),
+        started_at=run.started_at,
+        completed_at=run.completed_at,
+        items_found=run.items_found,
+        items_created=run.items_created,
+        items_updated=run.items_updated,
+        items_errored=run.items_errored,
+        error_message=run.error_message,
+    )
+
+
+def _stations(node, *, now):
     """Every station this centre declares or has been heard transmitting for.
 
     Started from the stations rather than from the declarations, because a
@@ -251,6 +439,8 @@ def _stations(node):
     stations on a centre's page that the centre has never claimed and never
     transmitted.
     """
+    stale_after = default_stale_after_hours()
+
     declared = StationSource.objects.filter(
         station=OuterRef("pk"),
         source_type=StationSource.NODE_REGISTRY,
@@ -265,6 +455,7 @@ def _stations(node):
         station=OuterRef("pk"),
         source_type=StationSource.OBSERVED,
         node=node,
+        last_seen__isnull=False,
     )
 
     stations = (
@@ -279,19 +470,36 @@ def _stations(node):
     )
 
     rows = [
-        NodeStationRow(
-            station_id=station.pk,
-            wigos_id=station.wigos_id,
-            name=station.name,
-            local_name=station.local_name or "",
-            local_id=station.local_id or "",
-            declared_by_registry=station.declared_by_registry,
-            last_transmitted=station.last_transmitted,
-        )
-        for station in stations
+        _station_row(station, now=now, stale_after=stale_after) for station in stations
     ]
 
     return sorted(rows, key=_reading_order)
+
+
+def _station_row(station, *, now, stale_after):
+    """One station as a finding."""
+    hours_quiet = hours_between(station.last_transmitted, now)
+    location = station.location
+
+    return NodeStationRow(
+        station_id=station.pk,
+        wigos_id=station.wigos_id,
+        name=station.name,
+        local_name=station.local_name or "",
+        local_id=station.local_id or "",
+        facility_type=station.get_facility_type_display(),
+        latitude=location.y if location else None,
+        longitude=location.x if location else None,
+        elevation=location.z if location and location.hasz else None,
+        declared_by_registry=station.declared_by_registry,
+        last_transmitted=station.last_transmitted,
+        hours_quiet=hours_quiet,
+        standing=StationStanding.of(
+            declared=station.declared_by_registry,
+            hours_quiet=hours_quiet,
+            stale_after=stale_after,
+        ),
+    )
 
 
 def _reading_order(row):
@@ -315,7 +523,7 @@ def _origin(node):
     return OriginBrokerState(
         reachability=OriginReachability.of(source.is_reachable),
         address=f"{source.host}:{source.port}",
-        is_active=source.is_active,
+        connections_enabled=source.is_active,
         last_connected_at=source.last_connected_at,
         last_error=source.last_error,
     )

--- a/wis2watch/src/wis2watch/core/analysis/node_detail.py
+++ b/wis2watch/src/wis2watch/core/analysis/node_detail.py
@@ -1,0 +1,321 @@
+"""One centre, in as much detail as is known of it.
+
+Where the overview flags a centre, this is what the flag is followed to. The
+overview deliberately reduces a centre to one line -- last seen, one silence
+verdict, one reachability -- and every one of those reductions hides the thing
+a diagnostician actually needs: which dataset stopped rather than the centre,
+which station went quiet rather than the node, and whether missing data is the
+centre publishing nothing or this tool having failed to read it.
+
+So the page answers the follow-up questions in one place. Per dataset, the last
+hour it published in beside what is expected of it, so a centre whose hourly
+observations are flowing while its daily bulletin has not appeared for a week
+reads as the second thing rather than as healthy. Per station, when it last
+transmitted, so a single silent station is nameable. And beside both, the two
+explanations that are about this tool rather than the centre: a sync run that
+failed, and a broker that does not answer from outside.
+
+Nothing here is derived a second way. Dataset silence is the same function the
+overview reduces to one badge, asked for one centre, so the page and the table
+can never disagree about whether a dataset is overdue -- which is the failure
+that would make a diagnostician stop trusting both.
+"""
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from django.db.models import Exists, OuterRef, Subquery
+from django.utils import timezone as dj_timezone
+from django.utils.translation import gettext_lazy as _
+
+from ..models import Dataset, MessageSource, NodeLastSeen, Station, StationSource, SyncLog
+from .overview import BEFORE_ANYTHING, OriginReachability, hours_between
+from .silence import DatasetSilenceRow, dataset_silence
+
+#: How many of each kind of sync run the page reads. Enough to show a run that
+#: has begun failing against the ones before it, and few enough that the page
+#: stays a page: the whole history of a node's syncs is the admin's to page
+#: through, not this.
+#:
+#: Per kind rather than in total, because the kinds run at wildly different
+#: rates. Link probes are sampled every hour and the station registry is read
+#: once a day, so the ten most recent runs of a healthy node are ten link
+#: probes -- and the failing station sync that explains the missing stations
+#: would be off the bottom of the one table that was meant to explain it.
+DEFAULT_RUNS_PER_TYPE = 5
+
+
+class StationStanding:
+    """What is known of one of a centre's stations.
+
+    Three states out of two facts -- whether the node's own registry declares
+    the station, and whether anything has been heard from it -- because the
+    two absences are different findings. A declared station nothing has heard
+    from is a station that has stopped, or never started; a station
+    transmitting that the registry declares nowhere is a registration gap, and
+    dropping it from the page because no declaration named it is exactly how a
+    transmitting station becomes invisible.
+    """
+
+    TRANSMITTING = "transmitting"
+    NEVER_TRANSMITTED = "never_transmitted"
+    UNDECLARED = "undeclared"
+
+    CHOICES = [
+        (NEVER_TRANSMITTED, _("Declared, never heard from")),
+        (UNDECLARED, _("Transmitting, not declared")),
+        (TRANSMITTING, _("Transmitting")),
+    ]
+
+    LABELS = dict(CHOICES)
+
+    #: What has stopped first, then what was never declared, then what is
+    #: working: the order someone reads a station list in when they came here
+    #: because something is missing.
+    RANK = {NEVER_TRANSMITTED: 0, UNDECLARED: 1, TRANSMITTING: 2}
+
+
+@dataclass(frozen=True)
+class NodeStationRow:
+    """One station of a centre's, and when it last said anything."""
+
+    station_id: int
+    wigos_id: str
+    name: str
+    local_name: str
+    local_id: str
+    declared_by_registry: bool
+    last_transmitted: datetime | None
+
+    @property
+    def standing(self):
+        """What this station amounts to: stopped, undeclared or working."""
+        if self.last_transmitted is None:
+            return StationStanding.NEVER_TRANSMITTED
+
+        if not self.declared_by_registry:
+            return StationStanding.UNDECLARED
+
+        return StationStanding.TRANSMITTING
+
+    @property
+    def standing_label(self):
+        """What this station's standing is called, for a table cell."""
+        return StationStanding.LABELS.get(self.standing, self.standing)
+
+    @property
+    def display_name(self):
+        """What to call the station, preferring the operator's own name.
+
+        The name a node assigns is the one its staff will recognise, and is
+        often the only one there is: a station created from observed traffic
+        alone has no canonical name until OSCAR is read for it.
+        """
+        return self.local_name or self.name or self.wigos_id
+
+
+@dataclass(frozen=True)
+class OriginBrokerState:
+    """What is known about the centre's own broker, from outside.
+
+    An address beside the verdict, because "not reachable" is only actionable
+    with the host and port that were dialled: half of what this reports is a
+    broker advertised at an address that was never open to begin with.
+    """
+
+    reachability: str
+    address: str
+    is_active: bool
+    last_connected_at: datetime | None
+    last_error: str
+
+    @classmethod
+    def unadvertised(cls):
+        """A centre whose catalogue record names no broker of its own."""
+        return cls(
+            reachability=OriginReachability.NOT_ADVERTISED,
+            address="",
+            is_active=False,
+            last_connected_at=None,
+            last_error="",
+        )
+
+    @property
+    def reachability_label(self):
+        """What the broker's state is called, for the page."""
+        return OriginReachability.LABELS.get(self.reachability, self.reachability)
+
+
+@dataclass(frozen=True)
+class NodeDetail:
+    """Everything this tool knows about one centre."""
+
+    node_id: int
+    centre_id: str
+    last_seen_at: datetime | None
+    hours_since_last_seen: float | None
+    datasets: list[DatasetSilenceRow]
+    retired_datasets: list[Dataset]
+    stations: list[NodeStationRow]
+    sync_runs: list[SyncLog]
+    origin: OriginBrokerState
+
+    @property
+    def silent_dataset_count(self):
+        """How many of the centre's datasets are past what is expected of them."""
+        return sum(row.is_silent for row in self.datasets)
+
+    @property
+    def silent_station_count(self):
+        """How many of the centre's declared stations have never been heard from."""
+        return sum(
+            row.standing == StationStanding.NEVER_TRANSMITTED for row in self.stations
+        )
+
+
+def node_detail(node, *, now=None, runs_per_type=DEFAULT_RUNS_PER_TYPE):
+    """One centre's page, as findings.
+
+    Args:
+        node: the centre to report on.
+        now: the instant quiet is measured up to.
+        runs_per_type: how many of the node's most recent runs of each kind
+            of sync to read.
+
+    Returns:
+        NodeDetail: the centre's datasets, stations, sync runs and broker.
+    """
+    now = now or dj_timezone.now()
+    last_seen_at = _last_seen_at(node)
+
+    return NodeDetail(
+        node_id=node.pk,
+        centre_id=node.centre_id,
+        last_seen_at=last_seen_at,
+        hours_since_last_seen=hours_between(last_seen_at, now),
+        datasets=dataset_silence(now=now, node=node),
+        retired_datasets=list(
+            Dataset.objects.filter(node=node).exclude(status=Dataset.ACTIVE)
+        ),
+        stations=_stations(node),
+        sync_runs=_sync_runs(node, runs_per_type),
+        origin=_origin(node),
+    )
+
+
+def _last_seen_at(node):
+    """When the centre was last heard publishing, or None if never."""
+    last_seen = NodeLastSeen.objects.filter(node=node).values("last_message_at").first()
+
+    return last_seen["last_message_at"] if last_seen else None
+
+
+def _sync_runs(node, runs_per_type):
+    """The centre's recent sync runs, no kind of run able to bury another.
+
+    Read a kind at a time and merged, which costs one small indexed query per
+    kind the node has ever had -- two or three -- and is what keeps the daily
+    run visible beside the hourly one.
+    """
+    # Ordered by nothing on purpose: a sync log's default ordering is by when
+    # it started, which a distinct over the kind alone would drag into the
+    # query and hand back one row per run rather than one per kind.
+    kinds = (
+        SyncLog.objects.filter(node=node)
+        .order_by()
+        .values_list("sync_type", flat=True)
+        .distinct()
+    )
+
+    runs = [
+        run
+        for kind in kinds
+        for run in SyncLog.objects.filter(node=node, sync_type=kind)[:runs_per_type]
+    ]
+
+    return sorted(runs, key=lambda run: run.started_at, reverse=True)
+
+
+def _stations(node):
+    """Every station this centre declares or has been heard transmitting for.
+
+    Started from the stations rather than from the declarations, because a
+    station is one station however many sources named it: listing the
+    declarations would give a station its node declares and has transmitted
+    two rows, and the whole point of the column is that those are two facts
+    about one thing.
+
+    OSCAR's declarations are not among them. OSCAR declares against a
+    territory rather than a centre, so what it says belongs to the country's
+    picture -- the declared-but-silent report -- and reading it here would put
+    stations on a centre's page that the centre has never claimed and never
+    transmitted.
+    """
+    declared = StationSource.objects.filter(
+        station=OuterRef("pk"),
+        source_type=StationSource.NODE_REGISTRY,
+        node=node,
+    )
+
+    # The centre's own observation, not the station's latest anywhere. A
+    # station may transmit under more than one centre's topics, and reading
+    # another centre's observation here would report this one as publishing
+    # something it never sent.
+    observed = StationSource.objects.filter(
+        station=OuterRef("pk"),
+        source_type=StationSource.OBSERVED,
+        node=node,
+    )
+
+    stations = (
+        Station.objects.filter(sources__node=node)
+        .distinct()
+        .annotate(
+            declared_by_registry=Exists(declared),
+            local_name=Subquery(declared.values("local_name")[:1]),
+            local_id=Subquery(declared.values("local_id")[:1]),
+            last_transmitted=Subquery(observed.values("last_seen")[:1]),
+        )
+    )
+
+    rows = [
+        NodeStationRow(
+            station_id=station.pk,
+            wigos_id=station.wigos_id,
+            name=station.name,
+            local_name=station.local_name or "",
+            local_id=station.local_id or "",
+            declared_by_registry=station.declared_by_registry,
+            last_transmitted=station.last_transmitted,
+        )
+        for station in stations
+    ]
+
+    return sorted(rows, key=_reading_order)
+
+
+def _reading_order(row):
+    """What has stopped first, and among those the longest quiet."""
+    return (
+        StationStanding.RANK.get(row.standing, len(StationStanding.RANK)),
+        row.last_transmitted or BEFORE_ANYTHING,
+        row.wigos_id,
+    )
+
+
+def _origin(node):
+    """The centre's own broker, as the page reports it."""
+    source = MessageSource.objects.filter(
+        node=node, source_type=MessageSource.ORIGIN_BROKER
+    ).first()
+
+    if source is None:
+        return OriginBrokerState.unadvertised()
+
+    return OriginBrokerState(
+        reachability=OriginReachability.of(source.is_reachable),
+        address=f"{source.host}:{source.port}",
+        is_active=source.is_active,
+        last_connected_at=source.last_connected_at,
+        last_error=source.last_error,
+    )

--- a/wis2watch/src/wis2watch/core/analysis/overview.py
+++ b/wis2watch/src/wis2watch/core/analysis/overview.py
@@ -106,6 +106,24 @@ class OriginReachability:
 
     LABELS = dict(CHOICES)
 
+    @classmethod
+    def of(cls, is_reachable, *, advertised=True):
+        """What a broker's stored reachability amounts to.
+
+        Read from the one field and from whether there is a broker at all,
+        because the overview and a centre's own page ask the same question of
+        the same record by different routes -- one annotated across the whole
+        region, one for a single node -- and two spellings of "null means not
+        attempted" would eventually disagree on the row that mattered.
+        """
+        if not advertised:
+            return cls.NOT_ADVERTISED
+
+        if is_reachable is None:
+            return cls.NOT_ATTEMPTED
+
+        return cls.REACHABLE if is_reachable else cls.UNREACHABLE
+
 
 class CachePickup:
     """Whether the Global Caches are carrying a centre's core data.
@@ -340,7 +358,7 @@ def _annotated_nodes(*, since):
 
 def _row(node, *, now, stale_after, silence):
     """One annotated node as a finding."""
-    quiet_for = _hours_between(node.last_seen_at, now)
+    quiet_for = hours_between(node.last_seen_at, now)
     node_silence = silence.get(node.pk) or NodeSilence.nothing_known()
 
     return NodeOverviewRow(
@@ -385,20 +403,12 @@ def _cache_pickup(node):
 
 def _origin_reachability(node):
     """What the centre's own broker is known to be doing."""
-    if not node.has_origin_broker:
-        return OriginReachability.NOT_ADVERTISED
-
-    if node.origin_reachable is None:
-        return OriginReachability.NOT_ATTEMPTED
-
-    return (
-        OriginReachability.REACHABLE
-        if node.origin_reachable
-        else OriginReachability.UNREACHABLE
+    return OriginReachability.of(
+        node.origin_reachable, advertised=node.has_origin_broker
     )
 
 
-def _hours_between(last_seen_at, now):
+def hours_between(last_seen_at, now):
     """How many hours a centre has been quiet, or None if it never spoke."""
     if last_seen_at is None:
         return None

--- a/wis2watch/src/wis2watch/core/analysis/overview.py
+++ b/wis2watch/src/wis2watch/core/analysis/overview.py
@@ -46,84 +46,15 @@ from ..models import (
     WIS2Node,
 )
 from ..rollups import floor_to_hour
-from .silence import NodeSilence, Silence, silence_by_node
+from .reachability import OriginReachability
+from .silence import BEFORE_ANYTHING, NodeSilence, Silence, hours_between, silence_by_node
+from .staleness import Staleness, default_stale_after_hours
 
 #: How much recent traffic the table reports on, in hours. Volume comes from
 #: the rollups, so the window is a whole number of hourly buckets ending with
 #: the one in progress -- there is no finer answer to be had, and pretending
 #: otherwise would make the column's heading a lie by a few minutes.
 DEFAULT_VOLUME_HOURS = 24
-
-#: Sorts before any real last-seen time, so the centres nothing has ever been
-#: heard from head the table and still tie-break by centre ID among themselves.
-BEFORE_ANYTHING = datetime.min.replace(tzinfo=timezone.utc)
-
-#: How long a centre may be quiet before the table calls it stale. A flat
-#: threshold, deliberately: it is what the table sorts by, and its job is to
-#: put the centres worth looking at first. Whether a centre's quiet is actually
-#: a fault is the silence column's question, judged per dataset against its own
-#: cadence.
-DEFAULT_STALE_AFTER_HOURS = 24
-
-
-class Staleness:
-    """How concerning a centre's quiet is."""
-
-    ACTIVE = "active"
-    STALE = "stale"
-    NEVER_SEEN = "never_seen"
-
-    CHOICES = [
-        (NEVER_SEEN, _("Never seen")),
-        (STALE, _("Stale")),
-        (ACTIVE, _("Active")),
-    ]
-
-    LABELS = dict(CHOICES)
-
-
-class OriginReachability:
-    """What is known about a centre's own broker, from outside.
-
-    Four states, because two of them are absences that mean different things.
-    A broker nothing has attempted yet is not a broker that failed, and a
-    centre whose catalogue record advertises no broker at all is neither --
-    calling any of these "unreachable" would report a fault that has not been
-    observed.
-    """
-
-    REACHABLE = "reachable"
-    UNREACHABLE = "unreachable"
-    NOT_ATTEMPTED = "not_attempted"
-    NOT_ADVERTISED = "not_advertised"
-
-    CHOICES = [
-        (UNREACHABLE, _("Not reachable")),
-        (NOT_ATTEMPTED, _("Not attempted yet")),
-        (NOT_ADVERTISED, _("No broker advertised")),
-        (REACHABLE, _("Reachable")),
-    ]
-
-    LABELS = dict(CHOICES)
-
-    @classmethod
-    def of(cls, is_reachable, *, advertised=True):
-        """What a broker's stored reachability amounts to.
-
-        Read from the one field and from whether there is a broker at all,
-        because the overview and a centre's own page ask the same question of
-        the same record by different routes -- one annotated across the whole
-        region, one for a single node -- and two spellings of "null means not
-        attempted" would eventually disagree on the row that mattered.
-        """
-        if not advertised:
-            return cls.NOT_ADVERTISED
-
-        if is_reachable is None:
-            return cls.NOT_ATTEMPTED
-
-        return cls.REACHABLE if is_reachable else cls.UNREACHABLE
-
 
 class CachePickup:
     """Whether the Global Caches are carrying a centre's core data.
@@ -205,11 +136,6 @@ class NodeOverviewRow:
         return OriginReachability.LABELS.get(
             self.origin_reachability, self.origin_reachability
         )
-
-
-def default_stale_after_hours():
-    """How long a centre may be quiet before the table calls it stale."""
-    return getattr(settings, "WIS2WATCH_STALE_AFTER_HOURS", DEFAULT_STALE_AFTER_HOURS)
 
 
 def default_volume_hours():
@@ -406,14 +332,6 @@ def _origin_reachability(node):
     return OriginReachability.of(
         node.origin_reachable, advertised=node.has_origin_broker
     )
-
-
-def hours_between(last_seen_at, now):
-    """How many hours a centre has been quiet, or None if it never spoke."""
-    if last_seen_at is None:
-        return None
-
-    return (now - last_seen_at).total_seconds() / 3600
 
 
 def _staleness(quiet_for, stale_after):

--- a/wis2watch/src/wis2watch/core/analysis/reachability.py
+++ b/wis2watch/src/wis2watch/core/analysis/reachability.py
@@ -1,0 +1,57 @@
+"""What is known about a centre's own broker, from outside.
+
+Its own module because two surfaces read it: the overview asks it of every
+centre at once, off annotations across the whole region, and a centre's page
+asks it of one broker record. The states and the rule that decides between
+them are written once here, so that the table and the page can never disagree
+about the same broker -- which is the kind of contradiction that costs a
+diagnostic tool its credibility on the row that mattered.
+"""
+
+from django.utils.translation import gettext_lazy as _
+
+
+class OriginReachability:
+    """What is known about a centre's own broker, from outside.
+
+    Four states, because two of them are absences that mean different things.
+    A broker nothing has attempted yet is not a broker that failed, and a
+    centre whose catalogue record advertises no broker at all is neither --
+    calling any of these "unreachable" would report a fault that has not been
+    observed.
+    """
+
+    REACHABLE = "reachable"
+    UNREACHABLE = "unreachable"
+    NOT_ATTEMPTED = "not_attempted"
+    NOT_ADVERTISED = "not_advertised"
+
+    CHOICES = [
+        (UNREACHABLE, _("Not reachable")),
+        (NOT_ATTEMPTED, _("Not attempted yet")),
+        (NOT_ADVERTISED, _("No broker advertised")),
+        (REACHABLE, _("Reachable")),
+    ]
+
+    LABELS = dict(CHOICES)
+
+    @classmethod
+    def of(cls, is_reachable, *, advertised=True):
+        """What a broker's stored reachability amounts to.
+
+        Read from the one field and from whether there is a broker at all,
+        because both absences are spelled as the absence of a value: no broker
+        record, and a broker record nothing has dialled yet.
+        """
+        if not advertised:
+            return cls.NOT_ADVERTISED
+
+        if is_reachable is None:
+            return cls.NOT_ATTEMPTED
+
+        return cls.REACHABLE if is_reachable else cls.UNREACHABLE
+
+    @classmethod
+    def label(cls, reachability):
+        """What a reachability is called, for a table cell or a page."""
+        return cls.LABELS.get(reachability, reachability)

--- a/wis2watch/src/wis2watch/core/analysis/silence.py
+++ b/wis2watch/src/wis2watch/core/analysis/silence.py
@@ -130,6 +130,16 @@ class DatasetSilenceRow:
         """What this dataset's silence is called, for a table cell."""
         return Silence.label(self.silence)
 
+    @property
+    def expectation_label(self):
+        """Where the expectation came from, for a table cell.
+
+        Shown beside the interval rather than instead of it, because a person
+        deciding whether to correct a baseline needs to know whether they are
+        looking at their own answer or the tool's.
+        """
+        return Expectation.LABELS.get(self.expectation, self.expectation)
+
 
 @dataclass(frozen=True)
 class NodeSilence:

--- a/wis2watch/src/wis2watch/core/analysis/silence.py
+++ b/wis2watch/src/wis2watch/core/analysis/silence.py
@@ -38,7 +38,7 @@ evidence, it is the tool not having existed yet.
 """
 
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from django.db.models import F, Min, OuterRef, Subquery
 from django.utils import timezone as dj_timezone
@@ -46,6 +46,18 @@ from django.utils.translation import gettext_lazy as _
 
 from ..models import Dataset, HourlyRollup
 from ..rollups import floor_to_hour
+
+#: Sorts before any real last-seen time, so whatever nothing has ever been
+#: heard from heads a table and still tie-breaks by name among its own kind.
+BEFORE_ANYTHING = datetime.min.replace(tzinfo=timezone.utc)
+
+
+def hours_between(last_seen_at, now):
+    """How many hours something has been quiet, or None if it never spoke."""
+    if last_seen_at is None:
+        return None
+
+    return (now - last_seen_at).total_seconds() / 3600
 
 
 class Expectation:
@@ -238,12 +250,22 @@ def _live_datasets(node, *, now):
         datasets = datasets.filter(node=node)
 
     return list(
-        datasets.annotate(
+        with_last_active_hour(datasets, now=now).annotate(
             learned_interval_hours=F("cadence_baseline__interval_hours"),
             learned_from=F("cadence_baseline__observations"),
-            last_active_hour=Subquery(_last_active_hour(now)),
         )
     )
+
+
+def with_last_active_hour(datasets, *, now):
+    """Each dataset beside the most recent hour it was seen publishing in.
+
+    Public because a dataset nobody is waiting to hear from still has a last
+    publication, and a page that lists one has the same question to answer as
+    this module does -- asked the same way, off the same index, rather than
+    spelled a second time somewhere the two could drift apart.
+    """
+    return datasets.annotate(last_active_hour=Subquery(_last_active_hour(now)))
 
 
 def _last_active_hour(now):

--- a/wis2watch/src/wis2watch/core/analysis/staleness.py
+++ b/wis2watch/src/wis2watch/core/analysis/staleness.py
@@ -1,0 +1,44 @@
+"""How long anything may be quiet before it is worth looking at.
+
+One flat threshold, deliberately, and its own module because two different
+surfaces judge two different things by it: the overview's staleness column,
+and whether a station a centre transmits for has stopped.
+
+Flat is the right shape for both. Whether a dataset's quiet is a fault is a
+question about that dataset's own rhythm, and ``wis2watch.core.analysis.
+silence`` answers it; this one is cruder on purpose -- it puts what is worth
+looking at first, and something quiet for a month is worth looking at whatever
+its rhythm was.
+
+Stations get no learned cadence of their own. A station transmits as often as
+the datasets it feeds publish, and there are tens of thousands of them, so
+learning a baseline each would be a great deal of machinery for a judgement
+this threshold already makes well enough: heard from lately, or not.
+"""
+
+from django.conf import settings
+from django.utils.translation import gettext_lazy as _
+
+#: How long anything may be quiet before it is called stale.
+DEFAULT_STALE_AFTER_HOURS = 24
+
+
+class Staleness:
+    """How concerning a centre's quiet is."""
+
+    ACTIVE = "active"
+    STALE = "stale"
+    NEVER_SEEN = "never_seen"
+
+    CHOICES = [
+        (NEVER_SEEN, _("Never seen")),
+        (STALE, _("Stale")),
+        (ACTIVE, _("Active")),
+    ]
+
+    LABELS = dict(CHOICES)
+
+
+def default_stale_after_hours():
+    """How long anything may be quiet before it is called stale."""
+    return getattr(settings, "WIS2WATCH_STALE_AFTER_HOURS", DEFAULT_STALE_AFTER_HOURS)

--- a/wis2watch/src/wis2watch/core/models.py
+++ b/wis2watch/src/wis2watch/core/models.py
@@ -572,27 +572,6 @@ class StationSourceQuerySet(models.QuerySet):
             .order_by("station__name")
         )
 
-    def with_last_transmitted(self):
-        """Each declaration beside when its station was last heard transmitting.
-
-        Declared and transmitting are different questions, and only the
-        observation can answer the second: a registry declaration is confirmed
-        by every sync run, so its own timestamp says when the node last
-        repeated itself, never whether anything is still publishing. Reading
-        the observation alongside is what makes a silent station nameable.
-        """
-        transmitted = (
-            StationSource.objects.filter(
-                station_id=models.OuterRef("station_id"),
-                source_type=StationSource.OBSERVED,
-                last_seen__isnull=False,
-            )
-            .order_by("-last_seen")
-            .values("last_seen")[:1]
-        )
-
-        return self.annotate(last_transmitted=models.Subquery(transmitted))
-
 
 class StationSource(TimeStampedModel):
     """

--- a/wis2watch/src/wis2watch/core/templates/wis2watchcore/node_details.html
+++ b/wis2watch/src/wis2watch/core/templates/wis2watchcore/node_details.html
@@ -43,40 +43,49 @@
             justify-content: flex-end;
         }
 
-        .dataset-card {
-            background: white;
-            border: 1px solid #e0e0e0;
-            border-radius: 5px;
-            margin-bottom: 25px;
-            overflow: hidden;
+        .detail-section {
+            margin-bottom: 35px;
         }
 
-        .dataset-header {
-            background: #f8f9fa;
-            padding: 15px 20px;
-            border-bottom: 1px solid #e0e0e0;
-            cursor: pointer;
+        .section-header {
             display: flex;
             justify-content: space-between;
             align-items: center;
-        }
-
-        .dataset-header:hover {
-            background: #e9ecef;
-        }
-
-        .dataset-title {
-            font-size: 1.1em;
-            font-weight: 600;
-            color: #333;
-            margin: 0;
-        }
-
-        .dataset-meta {
-            display: flex;
+            margin-bottom: 15px;
             gap: 15px;
-            margin-top: 8px;
+        }
+
+        .section-note {
+            color: #666;
+            font-size: 0.85em;
+            margin: 0 0 12px;
+        }
+
+        .detail-table {
+            width: 100%;
+            border-collapse: collapse;
+            background: #fff;
+        }
+
+        .detail-table th {
+            background: #f5f5f5;
+            padding: 10px;
+            text-align: left;
+            font-weight: 600;
+            color: #555;
+            border-bottom: 2px solid #ddd;
             font-size: 0.9em;
+        }
+
+        .detail-table td {
+            padding: 10px;
+            border-bottom: 1px solid #eee;
+            font-size: 0.9em;
+        }
+
+        .detail-table td.numeric,
+        .detail-table th.numeric {
+            text-align: right;
         }
 
         .badge {
@@ -87,7 +96,12 @@
             font-weight: 500;
         }
 
-        .badge-core {
+        .badge-core,
+        .badge-active,
+        .badge-reachable,
+        .badge-on_schedule,
+        .badge-transmitting,
+        .badge-success {
             background: #d4edda;
             color: #155724;
         }
@@ -97,103 +111,48 @@
             color: #004085;
         }
 
-        .badge-active {
-            background: #d4edda;
-            color: #155724;
+        .badge-undeclared,
+        .badge-partial {
+            background: #fff3cd;
+            color: #856404;
         }
 
-        .badge-inactive {
+        .badge-inactive,
+        .badge-deleted,
+        .badge-error,
+        .badge-unreachable,
+        .badge-silent,
+        .badge-never_transmitted,
+        .badge-failed {
             background: #f8d7da;
             color: #721c24;
         }
 
-        .dataset-content {
-            padding: 20px;
-            display: none;
-        }
-
-        .dataset-content.active {
-            display: block;
-        }
-
-        .dataset-details {
-            display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-            gap: 15px;
-            margin-bottom: 20px;
-            padding-bottom: 20px;
-            border-bottom: 1px solid #e0e0e0;
-        }
-
-        .stations-section {
-            margin-top: 20px;
-        }
-
-        .stations-header {
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            margin-bottom: 15px;
-        }
-
-        .stations-title {
-            font-size: 1em;
-            font-weight: 600;
+        .badge-not_attempted,
+        .badge-not_advertised,
+        .badge-unknown {
+            background: #eee;
             color: #555;
         }
 
-        .station-count {
-            color: #666;
-            font-size: 0.9em;
-        }
-
-        .stations-table {
-            width: 100%;
-            border-collapse: collapse;
-            background: white;
-        }
-
-        .stations-table th {
-            background: #f5f5f5;
-            padding: 10px;
-            text-align: left;
-            font-weight: 600;
+        .row-detail {
+            margin-top: 4px;
             color: #555;
-            border-bottom: 2px solid #ddd;
-            font-size: 0.9em;
+            font-size: 0.8em;
         }
 
-        .stations-table td {
-            padding: 10px;
-            border-bottom: 1px solid #eee;
-            font-size: 0.9em;
+        .row-error {
+            margin-top: 4px;
+            color: #721c24;
+            font-size: 0.8em;
         }
 
-        .stations-table tr:hover {
-            background: #f9f9f9;
-        }
-
-        .no-stations {
+        .empty-state {
             text-align: center;
             padding: 30px;
             color: #999;
             font-style: italic;
         }
-
-        .empty-state {
-            text-align: center;
-            padding: 50px;
-            color: #999;
-        }
-
-        .toggle-icon {
-            transition: transform 0.3s;
-        }
-
-        .toggle-icon.rotated {
-            transform: rotate(180deg);
-        }
-
     </style>
 {% endblock %}
 
@@ -204,15 +163,15 @@
         <div class="node-info">
             <div class="info-item">
                 <span class="info-label">{% trans "Country" %}</span>
-                <span class="info-value">{{ node.country.name }}</span>
+                <span class="info-value">{{ node.country.name|default:"—" }}</span>
+            </div>
+            <div class="info-item">
+                <span class="info-label">{% trans "Centre ID" %}</span>
+                <span class="info-value"><code>{{ node.centre_id|default:"—" }}</code></span>
             </div>
             <div class="info-item">
                 <span class="info-label">{% trans "Node Type" %}</span>
                 <span class="info-value">{{ node.get_node_type_display }}</span>
-            </div>
-            <div class="info-item">
-                <span class="info-label">{% trans "Centre ID" %}</span>
-                <span class="info-value">{{ node.centre_id|default:"—" }}</span>
             </div>
             <div class="info-item">
                 <span class="info-label">{% trans "Status" %}</span>
@@ -221,17 +180,31 @@
                 </span>
             </div>
             <div class="info-item">
-                <span class="info-label">{% trans "Base URL" %}</span>
+                <span class="info-label">{% trans "Last heard publishing" %}</span>
                 <span class="info-value">
-                    <a href="{{ node.base_url }}" target="_blank">{{ node.base_url }}</a>
+                    {% if detail.last_seen_at %}
+                        {{ detail.last_seen_at|date:"Y-m-d H:i" }}
+                        <div class="row-detail">
+                            {% blocktrans with hours=detail.hours_since_last_seen|floatformat:1 %}quiet for {{ hours }}h{% endblocktrans %}
+                        </div>
+                    {% else %}
+                        {% trans "never heard from" %}
+                    {% endif %}
                 </span>
             </div>
             <div class="info-item">
-                <span class="info-label">{% trans "Last Check" %}</span>
-                <span class="info-value">{{ node.last_check|date:"Y-m-d H:i:s"|default:"—" }}</span>
+                <span class="info-label">{% trans "Base URL" %}</span>
+                <span class="info-value">
+                    {% if node.base_url %}
+                        <a href="{{ node.base_url }}" target="_blank">{{ node.base_url }}</a>
+                    {% else %}
+                        —
+                    {% endif %}
+                </span>
             </div>
         </div>
     </div>
+
     <div class="action-buttons">
         <form method="post">
             {% csrf_token %}
@@ -246,6 +219,16 @@
             </button>
         </form>
 
+        <a href="{{ overview_url }}"
+           class="button bicolor button--icon button-secondary">
+             <span class="icon-wrapper">
+                 <svg class="icon icon-arrow-left icon" aria-hidden="true">
+                     <use href="#icon-arrow-left"></use>
+                 </svg>
+             </span>
+            {% trans "Back to Overview" %}
+        </a>
+
         <a href="{{ nodes_index_url }}"
            class="button bicolor button--icon button-secondary">
              <span class="icon-wrapper">
@@ -257,64 +240,165 @@
         </a>
     </div>
 
-    <!-- Datasets Section -->
-    <h3>{% trans "Datasets" %} ({{ node.datasets.count }})</h3>
-
-    {% if node.datasets.all %}
-        {% for dataset in node.datasets.all %}
-            <div class="dataset-card">
-                <div class="dataset-header" onclick="toggleDataset({{ dataset.id }})">
-                    <div>
-                        <h4 class="dataset-title">{{ dataset.title }}</h4>
-                        <div class="dataset-meta">
-                        <span class="badge badge-{{ dataset.wmo_data_policy }}">
-                            {{ dataset.get_wmo_data_policy_display }}
-                        </span>
-                            <span class="badge badge-{{ dataset.status }}">
-                            {{ dataset.get_status_display }}
-                        </span>
-                        </div>
-                    </div>
-                    <span class="toggle-icon" id="toggle-{{ dataset.id }}">▼</span>
-                </div>
-
-                <div class="dataset-content" id="content-{{ dataset.id }}">
-                    <div class="dataset-details">
-                        <div class="info-item">
-                            <span class="info-label">{% trans "Identifier" %}</span>
-                            <span class="info-value">{{ dataset.identifier }}</span>
-                        </div>
-                        <div class="info-item">
-                            <span class="info-label">{% trans "WMO Topic Hierarchy" %}</span>
-                            <span class="info-value"><code>{{ dataset.wmo_topic_hierarchy }}</code></span>
-                        </div>
-                        <div class="info-item">
-                            <span class="info-label">{% trans "Created" %}</span>
-                            <span class="info-value">{{ dataset.metadata_created|date:"Y-m-d H:i:s"|default:"—" }}</span>
-                        </div>
-                        <div class="info-item">
-                            <span class="info-label">{% trans "Updated" %}</span>
-                            <span class="info-value">{{ dataset.metadata_updated|date:"Y-m-d H:i:s"|default:"—" }}</span>
-                        </div>
-                        <div class="info-item">
-                            <span class="info-label">{% trans "Last Synced" %}</span>
-                            <span class="info-value">{{ dataset.last_synced|date:"Y-m-d H:i:s"|default:"—" }}</span>
-                        </div>
-                    </div>
-                </div>
+    <!-- The centre's own broker -->
+    <div class="detail-section">
+        <div class="section-header">
+            <h3>{% trans "This centre's own broker" %}</h3>
+            <span class="badge badge-{{ detail.origin.reachability }}">
+                {{ detail.origin.reachability_label }}
+            </span>
+        </div>
+        <p class="section-note">
+            {% trans "Whether this centre's broker answers from outside. A centre publishing where nobody can reach it looks the same as a centre that has stopped, until this column says otherwise." %}
+        </p>
+        <div class="node-info">
+            <div class="info-item">
+                <span class="info-label">{% trans "Address" %}</span>
+                <span class="info-value"><code>{{ detail.origin.address|default:"—" }}</code></span>
             </div>
-        {% endfor %}
-    {% else %}
-        <div class="empty-state">
-            <p>{% trans "No datasets found for this node" %}</p>
+            <div class="info-item">
+                <span class="info-label">{% trans "Last connected" %}</span>
+                <span class="info-value">
+                    {{ detail.origin.last_connected_at|date:"Y-m-d H:i"|default:"—" }}
+                </span>
+            </div>
+            <div class="info-item">
+                <span class="info-label">{% trans "Connection attempted" %}</span>
+                <span class="info-value">
+                    {% if detail.origin.is_active %}{% trans "Yes" %}{% else %}{% trans "No" %}{% endif %}
+                </span>
+            </div>
+            <div class="info-item">
+                <span class="info-label">{% trans "Last connection error" %}</span>
+                <span class="info-value">
+                    {% if detail.origin.last_error %}
+                        <span class="row-error">{{ detail.origin.last_error }}</span>
+                    {% else %}
+                        —
+                    {% endif %}
+                </span>
+            </div>
+        </div>
+    </div>
+
+    <!-- Datasets -->
+    <div class="detail-section">
+        <div class="section-header">
+            <h3>{% trans "Datasets" %} ({{ detail.datasets|length }})</h3>
+            {% if detail.silent_dataset_count %}
+                <span class="badge badge-silent">
+                    {% blocktrans with silent=detail.silent_dataset_count %}{{ silent }} overdue{% endblocktrans %}
+                </span>
+            {% endif %}
+        </div>
+        <p class="section-note">
+            {% trans "Each dataset judged against its own cadence, learned from its history or stated by hand, so that which part of this centre's output stopped is readable rather than that something did." %}
+        </p>
+
+        {% if detail.datasets %}
+            <table class="listing detail-table">
+                <thead>
+                <tr>
+                    <th>{% trans "Dataset" %}</th>
+                    <th>{% trans "Last published" %}</th>
+                    <th class="numeric">{% trans "Quiet for" %}</th>
+                    <th>{% trans "Expected every" %}</th>
+                    <th>{% trans "Silence" %}</th>
+                </tr>
+                </thead>
+                <tbody>
+                {% for row in detail.datasets %}
+                    <tr>
+                        <td>
+                            {{ row.title }}
+                            <div class="row-detail"><code>{{ row.topic }}</code></div>
+                        </td>
+                        <td>
+                            {% if row.last_active_hour %}
+                                {{ row.last_active_hour|date:"Y-m-d H:i" }}
+                                <div class="row-detail" title="{% trans 'Publication times are held as hourly buckets, so the hour is as precise an answer as the history holds' %}">
+                                    {% trans "hour beginning" %}
+                                </div>
+                            {% else %}
+                                {% trans "never seen publishing" %}
+                            {% endif %}
+                        </td>
+                        <td class="numeric">
+                            {% blocktrans with hours=row.hours_quiet|floatformat:1 %}{{ hours }}h{% endblocktrans %}
+                        </td>
+                        <td>
+                            {% if row.expected_interval_hours %}
+                                {% blocktrans with hours=row.expected_interval_hours|floatformat:1 %}{{ hours }}h{% endblocktrans %}
+                                <div class="row-detail">
+                                    {{ row.expectation_label }}{% if row.observations %},
+                                    {% blocktrans with gaps=row.observations %}from {{ gaps }} observed gaps{% endblocktrans %}{% endif %}
+                                </div>
+                            {% else %}
+                                —
+                                <div class="row-detail">{{ row.expectation_label }}</div>
+                            {% endif %}
+                        </td>
+                        <td>
+                            <span class="badge badge-{{ row.silence }}">{{ row.silence_label }}</span>
+                            {% if row.is_silent %}
+                                <div class="row-detail">
+                                    {% blocktrans with hours=row.overdue_hours|floatformat:1 %}{{ hours }}h past due{% endblocktrans %}
+                                </div>
+                            {% endif %}
+                        </td>
+                    </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+        {% else %}
+            <div class="empty-state">
+                {% trans "The registry knows of no live dataset for this centre" %}
+            </div>
+        {% endif %}
+    </div>
+
+    {% if detail.retired_datasets %}
+        <div class="detail-section">
+            <h3>{% trans "Datasets no longer published" %} ({{ detail.retired_datasets|length }})</h3>
+            <p class="section-note">
+                {% trans "Kept for the record, and not judged for silence: nobody is waiting to hear from them." %}
+            </p>
+            <table class="listing detail-table">
+                <thead>
+                <tr>
+                    <th>{% trans "Dataset" %}</th>
+                    <th>{% trans "Status" %}</th>
+                    <th>{% trans "Last synced" %}</th>
+                </tr>
+                </thead>
+                <tbody>
+                {% for dataset in detail.retired_datasets %}
+                    <tr>
+                        <td>
+                            {{ dataset.title }}
+                            <div class="row-detail"><code>{{ dataset.wmo_topic_hierarchy }}</code></div>
+                        </td>
+                        <td>
+                            <span class="badge badge-{{ dataset.status }}">{{ dataset.get_status_display }}</span>
+                        </td>
+                        <td>{{ dataset.last_synced|date:"Y-m-d H:i"|default:"—" }}</td>
+                    </tr>
+                {% endfor %}
+                </tbody>
+            </table>
         </div>
     {% endif %}
 
-    <!-- Stations Section -->
-    <div class="stations-section">
-        <div class="stations-header">
-            <h3 class="stations-title">
-                {% trans "Stations declared by this node" %} ({{ station_count }})
+    <!-- Stations -->
+    <div class="detail-section">
+        <div class="section-header">
+            <h3>
+                {% trans "Stations" %} ({{ station_count }})
+                {% if detail.silent_station_count %}
+                    <span class="badge badge-never_transmitted">
+                        {% blocktrans with silent=detail.silent_station_count %}{{ silent }} never heard from{% endblocktrans %}
+                    </span>
+                {% endif %}
             </h3>
             {% if station_count %}
                 <div>
@@ -339,63 +423,93 @@
                 </div>
             {% endif %}
         </div>
+        <p class="section-note">
+            {% trans "Every station this centre declares or has been heard transmitting for, the longest quiet first. A station transmitting that the centre's registry declares nowhere is listed too — it is a registration gap, not an absence." %}
+        </p>
 
-        {% if station_declarations %}
-            <table class="listing stations-table">
+        {% if detail.stations %}
+            <table class="listing detail-table">
                 <thead>
                 <tr>
                     <th>{% trans "WIGOS ID" %}</th>
                     <th>{% trans "Name" %}</th>
                     <th>{% trans "Local ID" %}</th>
-                    <th>{% trans "Facility Type" %}</th>
-                    <th>{% trans "Location" %}</th>
-                    <th>{% trans "Last Transmitted" %}</th>
+                    <th>{% trans "Last transmitted" %}</th>
+                    <th>{% trans "Standing" %}</th>
                 </tr>
                 </thead>
                 <tbody>
-                {% for declaration in station_declarations %}
+                {% for row in detail.stations %}
                     <tr>
-                        <td><code>{{ declaration.station.wigos_id }}</code></td>
-                        <td>{{ declaration.local_name|default:declaration.station.name }}</td>
-                        <td>{{ declaration.local_id|default:"—" }}</td>
-                        <td>{{ declaration.station.get_facility_type_display|default:"—" }}</td>
+                        <td><code>{{ row.wigos_id }}</code></td>
+                        <td>{{ row.display_name }}</td>
+                        <td>{{ row.local_id|default:"—" }}</td>
                         <td>
-                            {% if declaration.station.location %}
-                                {{ declaration.station.location.y|floatformat:4 }}°,
-                                {{ declaration.station.location.x|floatformat:4 }}°
-                                {% if declaration.station.location.z %}
-                                    ({{ declaration.station.location.z|floatformat:0 }}m)
-                                {% endif %}
+                            {% if row.last_transmitted %}
+                                {{ row.last_transmitted|date:"Y-m-d H:i" }}
                             {% else %}
-                                —
+                                {% trans "never" %}
                             {% endif %}
                         </td>
                         <td>
-                            {% if declaration.last_transmitted %}
-                                {{ declaration.last_transmitted|date:"Y-m-d H:i:s" }}
-                            {% else %}
-                                {% trans "Never" %}
-                            {% endif %}
+                            <span class="badge badge-{{ row.standing }}">{{ row.standing_label }}</span>
                         </td>
                     </tr>
                 {% endfor %}
                 </tbody>
             </table>
         {% else %}
-            <div class="no-stations">
-                {% trans "This node's station registry has declared no stations" %}
+            <div class="empty-state">
+                {% trans "No station is declared by this centre's registry, and none has been heard transmitting under its topics" %}
             </div>
         {% endif %}
     </div>
 
+    <!-- Sync runs -->
+    <div class="detail-section">
+        <h3>{% trans "Recent sync runs" %}</h3>
+        <p class="section-note">
+            {% trans "What this tool last managed to read from the centre. A dataset missing here and nowhere else is this tool's failure rather than the centre's." %}
+        </p>
 
-    <script>
-        function toggleDataset(datasetId) {
-            const content = document.getElementById('content-' + datasetId);
-            const icon = document.getElementById('toggle-' + datasetId);
-
-            content.classList.toggle('active');
-            icon.classList.toggle('rotated');
-        }
-    </script>
+        {% if detail.sync_runs %}
+            <table class="listing detail-table">
+                <thead>
+                <tr>
+                    <th>{% trans "Started" %}</th>
+                    <th>{% trans "Run" %}</th>
+                    <th>{% trans "Outcome" %}</th>
+                    <th class="numeric">{% trans "Found" %}</th>
+                    <th class="numeric">{% trans "Created" %}</th>
+                    <th class="numeric">{% trans "Updated" %}</th>
+                    <th class="numeric">{% trans "Errored" %}</th>
+                </tr>
+                </thead>
+                <tbody>
+                {% for run in detail.sync_runs %}
+                    <tr>
+                        <td>{{ run.started_at|date:"Y-m-d H:i" }}</td>
+                        <td>{{ run.get_sync_type_display }}</td>
+                        <td>
+                            <span class="badge badge-{{ run.status }}">{{ run.get_status_display }}</span>
+                            {% if run.error_message %}
+                                <div class="row-error" title="{{ run.error_message }}">
+                                    {{ run.error_message|truncatechars:80 }}
+                                </div>
+                            {% endif %}
+                        </td>
+                        <td class="numeric">{{ run.items_found }}</td>
+                        <td class="numeric">{{ run.items_created }}</td>
+                        <td class="numeric">{{ run.items_updated }}</td>
+                        <td class="numeric">{{ run.items_errored }}</td>
+                    </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+        {% else %}
+            <div class="empty-state">
+                {% trans "Nothing has been synced from this centre yet" %}
+            </div>
+        {% endif %}
+    </div>
 {% endblock %}

--- a/wis2watch/src/wis2watch/core/templates/wis2watchcore/node_details.html
+++ b/wis2watch/src/wis2watch/core/templates/wis2watchcore/node_details.html
@@ -112,6 +112,7 @@
         }
 
         .badge-undeclared,
+        .badge-gone_quiet,
         .badge-partial {
             background: #fff3cd;
             color: #856404;
@@ -263,9 +264,10 @@
                 </span>
             </div>
             <div class="info-item">
-                <span class="info-label">{% trans "Connection attempted" %}</span>
-                <span class="info-value">
-                    {% if detail.origin.is_active %}{% trans "Yes" %}{% else %}{% trans "No" %}{% endif %}
+                <span class="info-label">{% trans "Connections enabled" %}</span>
+                <span class="info-value"
+                      title="{% trans 'Whether this tool is set to dial this broker at all. A disabled broker is never attempted, so nothing is learned about it.' %}">
+                    {% if detail.origin.connections_enabled %}{% trans "Yes" %}{% else %}{% trans "No" %}{% endif %}
                 </span>
             </div>
             <div class="info-item">
@@ -300,6 +302,7 @@
                 <thead>
                 <tr>
                     <th>{% trans "Dataset" %}</th>
+                    <th>{% trans "Policy" %}</th>
                     <th>{% trans "Last published" %}</th>
                     <th class="numeric">{% trans "Quiet for" %}</th>
                     <th>{% trans "Expected every" %}</th>
@@ -310,8 +313,16 @@
                 {% for row in detail.datasets %}
                     <tr>
                         <td>
-                            {{ row.title }}
+                            <span title="{{ row.identifier }}">{{ row.title }}</span>
                             <div class="row-detail"><code>{{ row.topic }}</code></div>
+                            {% if row.last_synced %}
+                                <div class="row-detail">
+                                    {% blocktrans with synced=row.last_synced|date:"Y-m-d H:i" %}catalogue read {{ synced }}{% endblocktrans %}
+                                </div>
+                            {% endif %}
+                        </td>
+                        <td>
+                            <span class="badge badge-{{ row.policy }}">{{ row.policy_label }}</span>
                         </td>
                         <td>
                             {% if row.last_active_hour %}
@@ -324,25 +335,25 @@
                             {% endif %}
                         </td>
                         <td class="numeric">
-                            {% blocktrans with hours=row.hours_quiet|floatformat:1 %}{{ hours }}h{% endblocktrans %}
+                            {% blocktrans with hours=row.quiet.hours_quiet|floatformat:1 %}{{ hours }}h{% endblocktrans %}
                         </td>
                         <td>
-                            {% if row.expected_interval_hours %}
-                                {% blocktrans with hours=row.expected_interval_hours|floatformat:1 %}{{ hours }}h{% endblocktrans %}
+                            {% if row.quiet.expected_interval_hours %}
+                                {% blocktrans with hours=row.quiet.expected_interval_hours|floatformat:1 %}{{ hours }}h{% endblocktrans %}
                                 <div class="row-detail">
-                                    {{ row.expectation_label }}{% if row.observations %},
-                                    {% blocktrans with gaps=row.observations %}from {{ gaps }} observed gaps{% endblocktrans %}{% endif %}
+                                    {{ row.quiet.expectation_label }}{% if row.quiet.observations %},
+                                    {% blocktrans with gaps=row.quiet.observations %}from {{ gaps }} observed gaps{% endblocktrans %}{% endif %}
                                 </div>
                             {% else %}
                                 —
-                                <div class="row-detail">{{ row.expectation_label }}</div>
+                                <div class="row-detail">{{ row.quiet.expectation_label }}</div>
                             {% endif %}
                         </td>
                         <td>
-                            <span class="badge badge-{{ row.silence }}">{{ row.silence_label }}</span>
+                            <span class="badge badge-{{ row.quiet.silence }}">{{ row.quiet.silence_label }}</span>
                             {% if row.is_silent %}
                                 <div class="row-detail">
-                                    {% blocktrans with hours=row.overdue_hours|floatformat:1 %}{{ hours }}h past due{% endblocktrans %}
+                                    {% blocktrans with hours=row.quiet.overdue_hours|floatformat:1 %}{{ hours }}h past due{% endblocktrans %}
                                 </div>
                             {% endif %}
                         </td>
@@ -368,20 +379,28 @@
                 <tr>
                     <th>{% trans "Dataset" %}</th>
                     <th>{% trans "Status" %}</th>
+                    <th>{% trans "Last published" %}</th>
                     <th>{% trans "Last synced" %}</th>
                 </tr>
                 </thead>
                 <tbody>
-                {% for dataset in detail.retired_datasets %}
+                {% for row in detail.retired_datasets %}
                     <tr>
                         <td>
-                            {{ dataset.title }}
-                            <div class="row-detail"><code>{{ dataset.wmo_topic_hierarchy }}</code></div>
+                            <span title="{{ row.identifier }}">{{ row.title }}</span>
+                            <div class="row-detail"><code>{{ row.topic }}</code></div>
                         </td>
                         <td>
-                            <span class="badge badge-{{ dataset.status }}">{{ dataset.get_status_display }}</span>
+                            <span class="badge badge-{{ row.status }}">{{ row.status_label }}</span>
                         </td>
-                        <td>{{ dataset.last_synced|date:"Y-m-d H:i"|default:"—" }}</td>
+                        <td>
+                            {% if row.last_active_hour %}
+                                {{ row.last_active_hour|date:"Y-m-d H:i" }}
+                            {% else %}
+                                {% trans "never seen publishing" %}
+                            {% endif %}
+                        </td>
+                        <td>{{ row.last_synced|date:"Y-m-d H:i"|default:"—" }}</td>
                     </tr>
                 {% endfor %}
                 </tbody>
@@ -393,14 +412,14 @@
     <div class="detail-section">
         <div class="section-header">
             <h3>
-                {% trans "Stations" %} ({{ station_count }})
+                {% trans "Stations" %} ({{ detail.stations|length }})
                 {% if detail.silent_station_count %}
                     <span class="badge badge-never_transmitted">
-                        {% blocktrans with silent=detail.silent_station_count %}{{ silent }} never heard from{% endblocktrans %}
+                        {% blocktrans with silent=detail.silent_station_count %}{{ silent }} not heard from lately{% endblocktrans %}
                     </span>
                 {% endif %}
             </h3>
-            {% if station_count %}
+            {% if detail.declared_station_count %}
                 <div>
                     <a href="{% url 'preview_node_stations_csv' node.id %}"
                        class="button bicolor button--icon button-secondary button-small">
@@ -424,7 +443,7 @@
             {% endif %}
         </div>
         <p class="section-note">
-            {% trans "Every station this centre declares or has been heard transmitting for, the longest quiet first. A station transmitting that the centre's registry declares nowhere is listed too — it is a registration gap, not an absence." %}
+            {% trans "Every station this centre declares or has been heard transmitting for, the longest quiet first. A station transmitting that the centre's registry declares nowhere is listed too — it is a registration gap, not an absence. The CSV export covers the registry's declarations alone." %}
         </p>
 
         {% if detail.stations %}
@@ -434,6 +453,8 @@
                     <th>{% trans "WIGOS ID" %}</th>
                     <th>{% trans "Name" %}</th>
                     <th>{% trans "Local ID" %}</th>
+                    <th>{% trans "Facility type" %}</th>
+                    <th>{% trans "Location" %}</th>
                     <th>{% trans "Last transmitted" %}</th>
                     <th>{% trans "Standing" %}</th>
                 </tr>
@@ -444,15 +465,32 @@
                         <td><code>{{ row.wigos_id }}</code></td>
                         <td>{{ row.display_name }}</td>
                         <td>{{ row.local_id|default:"—" }}</td>
+                        <td>{{ row.facility_type|default:"—" }}</td>
+                        <td>
+                            {% if row.latitude is not None %}
+                                {{ row.latitude|floatformat:4 }}°, {{ row.longitude|floatformat:4 }}°
+                                {% if row.elevation %}
+                                    ({{ row.elevation|floatformat:0 }}m)
+                                {% endif %}
+                            {% else %}
+                                —
+                            {% endif %}
+                        </td>
                         <td>
                             {% if row.last_transmitted %}
                                 {{ row.last_transmitted|date:"Y-m-d H:i" }}
+                                <div class="row-detail">
+                                    {% blocktrans with hours=row.hours_quiet|floatformat:1 %}{{ hours }}h ago{% endblocktrans %}
+                                </div>
                             {% else %}
                                 {% trans "never" %}
                             {% endif %}
                         </td>
                         <td>
                             <span class="badge badge-{{ row.standing }}">{{ row.standing_label }}</span>
+                            {% if row.standing == "gone_quiet" and not row.declared_by_registry %}
+                                <div class="row-detail">{% trans "not declared by the registry" %}</div>
+                            {% endif %}
                         </td>
                     </tr>
                 {% endfor %}
@@ -469,7 +507,7 @@
     <div class="detail-section">
         <h3>{% trans "Recent sync runs" %}</h3>
         <p class="section-note">
-            {% trans "What this tool last managed to read from the centre. A dataset missing here and nowhere else is this tool's failure rather than the centre's." %}
+            {% trans "What this tool last managed to read, from the centre itself and from the catalogue its datasets and broker address come from. A dataset missing here and nowhere else is this tool's failure rather than the centre's." %}
         </p>
 
         {% if detail.sync_runs %}
@@ -478,6 +516,7 @@
                 <tr>
                     <th>{% trans "Started" %}</th>
                     <th>{% trans "Run" %}</th>
+                    <th>{% trans "Covers" %}</th>
                     <th>{% trans "Outcome" %}</th>
                     <th class="numeric">{% trans "Found" %}</th>
                     <th class="numeric">{% trans "Created" %}</th>
@@ -489,9 +528,10 @@
                 {% for run in detail.sync_runs %}
                     <tr>
                         <td>{{ run.started_at|date:"Y-m-d H:i" }}</td>
-                        <td>{{ run.get_sync_type_display }}</td>
+                        <td>{{ run.kind_label }}</td>
+                        <td>{{ run.scope_label }}</td>
                         <td>
-                            <span class="badge badge-{{ run.status }}">{{ run.get_status_display }}</span>
+                            <span class="badge badge-{{ run.status }}">{{ run.status_label }}</span>
                             {% if run.error_message %}
                                 <div class="row-error" title="{{ run.error_message }}">
                                     {{ run.error_message|truncatechars:80 }}

--- a/wis2watch/src/wis2watch/core/tests/test_admin.py
+++ b/wis2watch/src/wis2watch/core/tests/test_admin.py
@@ -415,7 +415,7 @@ class NodeDetailViewTests(TestCase):
             station=Station.objects.create(wigos_id="0-404-0-KE999"),
             source_type=StationSource.OBSERVED,
             node=self.node,
-            last_seen=at("2026-08-11T10:45:00"),
+            last_seen=dj_timezone.now(),
         )
 
         response = self.page()
@@ -465,6 +465,41 @@ class NodeDetailViewTests(TestCase):
 
         self.assertContains(response, "Failed")
         self.assertContains(response, "Read timed out reading the station registry")
+
+    def test_the_catalogue_run_the_datasets_come_from_is_on_the_page(self):
+        SyncLog.objects.create(
+            catalogue=GlobalDiscoveryCatalogue.objects.create(
+                centre_id="int-wmo-global-discovery",
+                name="WMO Global Discovery Catalogue",
+                base_url="https://gdc.example.int",
+                is_writer=True,
+            ),
+            sync_type=SyncLog.CATALOGUE,
+            status=SyncLog.FAILED,
+            error_message="The catalogue could not be read",
+        )
+
+        response = self.page()
+
+        self.assertContains(response, "The registry")
+        self.assertContains(response, "The catalogue could not be read")
+
+    def test_the_station_export_is_offered_only_where_the_registry_declared_one(self):
+        """The export covers declarations; a transmitting station is not one."""
+        StationSource.objects.filter(source_type=StationSource.NODE_REGISTRY).delete()
+        StationSource.objects.create(
+            station=Station.objects.get(wigos_id="0-404-0-KE001"),
+            source_type=StationSource.OBSERVED,
+            node=self.node,
+            last_seen=dj_timezone.now(),
+        )
+
+        response = self.page()
+
+        self.assertContains(response, "0-404-0-KE001")
+        self.assertNotContains(
+            response, reverse("get_node_stations_csv", args=[self.node.id])
+        )
 
     def test_a_broker_that_does_not_answer_is_on_the_page_with_what_it_said(self):
         MessageSource.objects.create(

--- a/wis2watch/src/wis2watch/core/tests/test_admin.py
+++ b/wis2watch/src/wis2watch/core/tests/test_admin.py
@@ -153,6 +153,16 @@ class NodeOverviewViewTests(TestCase):
 
         self.assertContains(response, "never heard from")
 
+    def test_each_centre_is_a_link_to_its_own_page(self):
+        """The table says which centre to look at; the page says what stopped."""
+        response = self.client.get(reverse("node_overview"))
+
+        for node in (self.quiet, self.talking):
+            with self.subTest(centre_id=node.centre_id):
+                self.assertContains(
+                    response, reverse("node_details", args=[node.id])
+                )
+
     def test_the_staleness_asked_for_reaches_the_findings(self):
         """What the analysis does with it is its own tests' business."""
         response = self.client.get(reverse("node_overview"), {"staleness": "never_seen"})
@@ -341,6 +351,13 @@ class DatasetAdminTests(TestCase):
 
 
 class NodeDetailViewTests(TestCase):
+    """One centre's page, where the overview's flag is followed to.
+
+    What is asserted here is that each finding reaches the screen: the
+    analysis has its own tests for what the findings say, and a finding
+    computed and not rendered is a finding that stayed in the database.
+    """
+
     def setUp(self):
         self.client.force_login(
             get_user_model().objects.create_superuser("diagnostician", password="s3cret")
@@ -366,17 +383,18 @@ class NodeDetailViewTests(TestCase):
             raw_json={"properties": {"barometer_height": 1624.0}},
         )
 
+    def page(self):
+        return self.client.get(reverse("node_details", args=[self.node.id]))
+
     def test_the_node_detail_page_loads(self):
-        response = self.client.get(reverse("node_details", args=[self.node.id]))
+        response = self.page()
 
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "0-404-0-KE001")
 
     def test_a_declared_station_that_has_never_transmitted_says_so(self):
         """The declaration is confirmed hourly; only the observation is news."""
-        response = self.client.get(reverse("node_details", args=[self.node.id]))
-
-        self.assertContains(response, "Never")
+        self.assertContains(self.page(), "Declared, never heard from")
 
     def test_a_declared_station_shows_when_it_last_transmitted(self):
         StationSource.objects.create(
@@ -386,10 +404,91 @@ class NodeDetailViewTests(TestCase):
             last_seen=at("2026-08-11T10:45:00"),
         )
 
-        response = self.client.get(reverse("node_details", args=[self.node.id]))
+        response = self.page()
 
-        self.assertContains(response, "2026-08-11 10:45:00")
-        self.assertNotContains(response, "Never")
+        self.assertContains(response, "2026-08-11 10:45")
+        self.assertNotContains(response, "Declared, never heard from")
+
+    def test_a_station_transmitting_that_no_registry_declares_is_on_the_page(self):
+        """A transmitting station is never invisible, declared or not."""
+        StationSource.objects.create(
+            station=Station.objects.create(wigos_id="0-404-0-KE999"),
+            source_type=StationSource.OBSERVED,
+            node=self.node,
+            last_seen=at("2026-08-11T10:45:00"),
+        )
+
+        response = self.page()
+
+        self.assertContains(response, "0-404-0-KE999")
+        self.assertContains(response, "Transmitting, not declared")
+
+    def test_a_dataset_shows_when_it_last_published_and_what_is_expected(self):
+        dataset = Dataset.objects.create(
+            node=self.node,
+            identifier="urn:wmo:md:ke-kmd:synop",
+            title="Surface observations",
+            wmo_data_policy=Dataset.CORE,
+            wmo_topic_hierarchy="origin/a/wis2/ke-kmd/data/core/weather/synop",
+            raw_json={},
+            expected_interval_override_hours=6,
+        )
+        HourlyRollup.objects.create(
+            hour=at("2026-08-01T00:00:00"),
+            source=MessageSource.objects.create(
+                name="Global Broker",
+                source_type=MessageSource.GLOBAL_BROKER,
+                host="globalbroker.example.int",
+            ),
+            node=self.node,
+            dataset=dataset,
+            message_count=3,
+        )
+
+        response = self.page()
+
+        self.assertContains(response, "Surface observations")
+        self.assertContains(response, "2026-08-01 00:00")
+        self.assertContains(response, "Set by hand")
+        self.assertContains(response, "Silent")
+
+    def test_a_failing_sync_run_is_on_the_page_with_what_it_said(self):
+        """Missing data traced to a failing sync, without leaving the page."""
+        SyncLog.objects.create(
+            node=self.node,
+            sync_type=SyncLog.NODE_STATIONS,
+            status=SyncLog.FAILED,
+            error_message="Read timed out reading the station registry",
+        )
+
+        response = self.page()
+
+        self.assertContains(response, "Failed")
+        self.assertContains(response, "Read timed out reading the station registry")
+
+    def test_a_broker_that_does_not_answer_is_on_the_page_with_what_it_said(self):
+        MessageSource.objects.create(
+            name="ke-kmd origin broker",
+            source_type=MessageSource.ORIGIN_BROKER,
+            node=self.node,
+            centre_id="ke-kmd",
+            host="wis.kmd.test",
+            port=8883,
+            is_reachable=False,
+            last_error="Could not reach wis.kmd.test:8883",
+        )
+
+        response = self.page()
+
+        self.assertContains(response, "Not reachable")
+        self.assertContains(response, "wis.kmd.test:8883")
+        self.assertContains(response, "Could not reach wis.kmd.test:8883")
+
+    def test_a_centre_advertising_no_broker_of_its_own_is_not_called_unreachable(self):
+        response = self.page()
+
+        self.assertContains(response, "No broker advertised")
+        self.assertNotContains(response, "Not reachable")
 
     def test_the_station_csv_preview_loads(self):
         response = self.client.get(reverse("preview_node_stations_csv", args=[self.node.id]))

--- a/wis2watch/src/wis2watch/core/tests/test_node_detail.py
+++ b/wis2watch/src/wis2watch/core/tests/test_node_detail.py
@@ -14,6 +14,7 @@ because the query started from the declarations.
 
 from datetime import timedelta
 
+from django.contrib.gis.geos import Point
 from django.test import TestCase
 
 from wis2watch.core.analysis import (
@@ -21,11 +22,13 @@ from wis2watch.core.analysis import (
     OriginReachability,
     Silence,
     StationStanding,
+    SyncScope,
     node_detail,
 )
 from wis2watch.core.models import (
     CadenceBaseline,
     Dataset,
+    GlobalDiscoveryCatalogue,
     HourlyRollup,
     MessageSource,
     NodeLastSeen,
@@ -56,6 +59,14 @@ class NodeDetailTestCase(TestCase):
             NodeLastSeen.objects.create(node=node, last_message_at=last_seen)
 
         return node
+
+    def catalogue(self, centre_id="int-wmo-global-discovery", is_writer=False):
+        return GlobalDiscoveryCatalogue.objects.create(
+            centre_id=centre_id,
+            name=centre_id,
+            base_url=f"https://{centre_id}.example.int",
+            is_writer=is_writer,
+        )
 
     def dataset(self, name="synop", *, node=None, expects=None, status=Dataset.ACTIVE):
         node = node or self.kenya
@@ -153,9 +164,19 @@ class DatasetTests(NodeDetailTestCase):
         row = self.by_title()["synop"]
 
         self.assertEqual(row.last_active_hour, NOW - timedelta(hours=30))
-        self.assertEqual(row.expected_interval_hours, 6)
-        self.assertEqual(row.expectation, Expectation.LEARNED)
-        self.assertEqual(row.silence, Silence.SILENT)
+        self.assertEqual(row.quiet.expected_interval_hours, 6)
+        self.assertEqual(row.quiet.expectation, Expectation.LEARNED)
+        self.assertEqual(row.quiet.silence, Silence.SILENT)
+
+    def test_a_dataset_carries_what_the_catalogue_says_of_it(self):
+        """The registry's own description, beside the judgement of it."""
+        self.dataset("synop")
+
+        row = self.by_title()["synop"]
+
+        self.assertEqual(row.identifier, "urn:wmo:md:ke-meteo:synop")
+        self.assertEqual(row.topic, "origin/a/wis2/ke-meteo/data/core/synop")
+        self.assertEqual(row.policy, Dataset.CORE)
 
     def test_a_stated_expectation_is_the_one_the_page_judges_against(self):
         climate = self.dataset("climate", expects=24 * 30)
@@ -164,17 +185,17 @@ class DatasetTests(NodeDetailTestCase):
 
         row = self.by_title()["climate"]
 
-        self.assertEqual(row.expected_interval_hours, 24 * 30)
-        self.assertEqual(row.expectation, Expectation.OVERRIDDEN)
-        self.assertEqual(row.silence, Silence.ON_SCHEDULE)
+        self.assertEqual(row.quiet.expected_interval_hours, 24 * 30)
+        self.assertEqual(row.quiet.expectation, Expectation.OVERRIDDEN)
+        self.assertEqual(row.quiet.silence, Silence.ON_SCHEDULE)
 
     def test_a_dataset_with_nothing_to_expect_of_it_is_not_called_silent(self):
         self.last_published(self.dataset("synop"), 500)
 
         row = self.by_title()["synop"]
 
-        self.assertIsNone(row.expected_interval_hours)
-        self.assertEqual(row.silence, Silence.UNKNOWN)
+        self.assertIsNone(row.quiet.expected_interval_hours)
+        self.assertEqual(row.quiet.silence, Silence.UNKNOWN)
 
     def test_another_centres_datasets_are_not_this_centres(self):
         djibouti = self.node("dj-anm")
@@ -186,12 +207,18 @@ class DatasetTests(NodeDetailTestCase):
     def test_a_dataset_the_catalogue_no_longer_lists_is_shown_apart_from_the_rest(self):
         """Retired datasets stay on the page, and no silence is claimed of them."""
         self.dataset("synop")
-        self.dataset("withdrawn", status=Dataset.DELETED)
+        withdrawn = self.dataset("withdrawn", status=Dataset.DELETED)
+        self.last_published(withdrawn, 300)
 
         detail = self.detail()
 
         self.assertEqual([row.title for row in detail.datasets], ["synop"])
-        self.assertEqual([dataset.title for dataset in detail.retired_datasets], ["withdrawn"])
+
+        retired = detail.retired_datasets[0]
+
+        self.assertEqual(retired.title, "withdrawn")
+        self.assertIsNone(retired.quiet)
+        self.assertEqual(retired.last_active_hour, NOW - timedelta(hours=300))
 
 
 class StationTests(NodeDetailTestCase):
@@ -208,6 +235,16 @@ class StationTests(NodeDetailTestCase):
 
         self.assertEqual(row.last_transmitted, NOW - timedelta(hours=3))
         self.assertEqual(row.standing, StationStanding.TRANSMITTING)
+
+    def test_a_station_heard_from_long_ago_is_not_called_transmitting(self):
+        """Green for a station last heard from in March is how one is missed."""
+        self.declare("0-20000-0-63708")
+        self.transmitted("0-20000-0-63708", hours_ago=30 * 24)
+
+        row = self.by_wigos_id()["0-20000-0-63708"]
+
+        self.assertEqual(row.standing, StationStanding.GONE_QUIET)
+        self.assertEqual(row.hours_quiet, 30 * 24)
 
     def test_a_declared_station_nothing_has_heard_from_is_named(self):
         self.declare("0-20000-0-63708")
@@ -270,6 +307,20 @@ class StationTests(NodeDetailTestCase):
 
         self.assertEqual(self.detail().stations, [])
 
+    def test_a_station_carries_where_it_is_and_what_kind_it_is(self):
+        """A silent station is followed up by whoever can reach the site."""
+        station = self.declare("0-20000-0-63708")
+        Station.objects.filter(pk=station.pk).update(
+            facility_type="landFixed",
+            location=Point(36.75, -1.30, 1798.0, srid=4326),
+        )
+
+        row = self.by_wigos_id()["0-20000-0-63708"]
+
+        self.assertEqual(row.facility_type, "Land Fixed")
+        self.assertEqual((row.longitude, row.latitude), (36.75, -1.30))
+        self.assertEqual(row.elevation, 1798.0)
+
     def test_the_silent_come_first_and_among_them_the_longest_quiet(self):
         self.declare("0-20000-0-00001")
         self.transmitted("0-20000-0-00001", hours_ago=1)
@@ -281,6 +332,16 @@ class StationTests(NodeDetailTestCase):
             [row.wigos_id for row in self.detail().stations],
             ["0-20000-0-00003", "0-20000-0-00002", "0-20000-0-00001"],
         )
+
+    def test_what_the_export_covers_is_counted_apart_from_what_is_listed(self):
+        """The export is the registry's declarations; the list is more than them."""
+        self.declare("0-20000-0-63708")
+        self.transmitted("0-20000-0-63999")
+
+        detail = self.detail()
+
+        self.assertEqual(len(detail.stations), 2)
+        self.assertEqual(detail.declared_station_count, 1)
 
 
 class SyncRunTests(NodeDetailTestCase):
@@ -311,8 +372,9 @@ class SyncRunTests(NodeDetailTestCase):
 
         runs = self.detail().sync_runs
 
-        self.assertEqual(runs[0].pk, failed.pk)
+        self.assertEqual(runs[0].run_id, failed.pk)
         self.assertEqual(runs[0].error_message, "Connection refused")
+        self.assertEqual(runs[0].scope, SyncScope.CENTRE)
 
     def test_only_a_bounded_number_of_runs_is_read(self):
         for hours_ago in range(1, 8):
@@ -329,8 +391,8 @@ class SyncRunTests(NodeDetailTestCase):
 
         runs = self.detail(runs_per_type=3).sync_runs
 
-        self.assertIn(stations.pk, [run.pk for run in runs])
-        self.assertEqual(runs[-1].pk, stations.pk)
+        self.assertIn(stations.pk, [run.run_id for run in runs])
+        self.assertEqual(runs[-1].run_id, stations.pk)
 
     def test_another_centres_runs_are_not_this_centres(self):
         djibouti = self.node("dj-anm")
@@ -340,6 +402,38 @@ class SyncRunTests(NodeDetailTestCase):
         self.assertEqual(len(self.detail().sync_runs), 1)
 
     def test_a_centre_nothing_has_synced_reports_no_runs(self):
+        self.assertEqual(self.detail().sync_runs, [])
+
+    def test_the_run_that_creates_the_centres_datasets_is_on_the_page(self):
+        """A catalogue sync is recorded against the catalogue, not the node.
+
+        It is the run that populates every centre's datasets, topics and
+        broker address, so leaving it out would answer "why are this centre's
+        datasets missing" with a table that structurally cannot contain the
+        answer.
+        """
+        run = SyncLog.objects.create(
+            catalogue=self.catalogue(is_writer=True),
+            sync_type=SyncLog.CATALOGUE,
+            status=SyncLog.FAILED,
+            started_at=NOW - timedelta(hours=2),
+            error_message="The catalogue could not be read",
+        )
+
+        runs = {row.run_id: row for row in self.detail().sync_runs}
+
+        self.assertIn(run.pk, runs)
+        self.assertEqual(runs[run.pk].scope, SyncScope.REGISTRY)
+
+    def test_a_catalogue_that_writes_nothing_is_not_read_as_the_registrys(self):
+        """A read-only catalogue's runs say nothing about what was registered."""
+        SyncLog.objects.create(
+            catalogue=self.catalogue(centre_id="fr-meteofrance-global-discovery"),
+            sync_type=SyncLog.CATALOGUE,
+            status=SyncLog.SUCCESS,
+            started_at=NOW - timedelta(hours=2),
+        )
+
         self.assertEqual(self.detail().sync_runs, [])
 
 

--- a/wis2watch/src/wis2watch/core/tests/test_node_detail.py
+++ b/wis2watch/src/wis2watch/core/tests/test_node_detail.py
@@ -1,0 +1,388 @@
+"""One centre's page, against a seeded database.
+
+The overview says which centre to look at; this says what about it stopped. So
+what is being guarded here is that the page separates things the overview
+deliberately runs together -- which dataset went quiet rather than the centre,
+which station stopped rather than the node, whether the missing data is a
+failing sync or a broker nothing can reach.
+
+The quiet failures are the ones worth the seeding: a station counted twice
+because two sources declared it, another centre's transmission read as this
+one's, a station transmitting that no registry declares dropped from the list
+because the query started from the declarations.
+"""
+
+from datetime import timedelta
+
+from django.test import TestCase
+
+from wis2watch.core.analysis import (
+    Expectation,
+    OriginReachability,
+    Silence,
+    StationStanding,
+    node_detail,
+)
+from wis2watch.core.models import (
+    CadenceBaseline,
+    Dataset,
+    HourlyRollup,
+    MessageSource,
+    NodeLastSeen,
+    Station,
+    StationSource,
+    SyncLog,
+    WIS2Node,
+)
+from wis2watch.core.tests.support import at, origin_broker
+
+
+NOW = at("2026-08-11T12:00:00")
+
+
+class NodeDetailTestCase(TestCase):
+    def setUp(self):
+        self.global_broker = MessageSource.objects.create(
+            name="Global Broker",
+            source_type=MessageSource.GLOBAL_BROKER,
+            host="globalbroker.example.int",
+        )
+        self.kenya = self.node("ke-meteo")
+
+    def node(self, centre_id, last_seen=None):
+        node = WIS2Node.objects.create(centre_id=centre_id, name=centre_id.upper())
+
+        if last_seen is not None:
+            NodeLastSeen.objects.create(node=node, last_message_at=last_seen)
+
+        return node
+
+    def dataset(self, name="synop", *, node=None, expects=None, status=Dataset.ACTIVE):
+        node = node or self.kenya
+
+        return Dataset.objects.create(
+            node=node,
+            identifier=f"urn:wmo:md:{node.centre_id}:{name}",
+            title=name,
+            wmo_data_policy=Dataset.CORE,
+            wmo_topic_hierarchy=f"origin/a/wis2/{node.centre_id}/data/core/{name}",
+            raw_json={},
+            status=status,
+            expected_interval_override_hours=expects,
+        )
+
+    def learned(self, dataset, interval_hours):
+        return CadenceBaseline.objects.create(
+            dataset=dataset,
+            interval_hours=interval_hours,
+            observations=20,
+            learned_at=NOW - timedelta(days=1),
+        )
+
+    def last_published(self, dataset, hours_ago):
+        return HourlyRollup.objects.create(
+            hour=NOW - timedelta(hours=hours_ago),
+            source=self.global_broker,
+            node=dataset.node,
+            dataset=dataset,
+            message_count=1,
+        )
+
+    def declare(self, wigos_id, *, node=None, local_name="", local_id=""):
+        """The node's own registry saying it operates a station."""
+        station, _ = Station.objects.get_or_create(wigos_id=wigos_id)
+
+        StationSource.objects.create(
+            station=station,
+            source_type=StationSource.NODE_REGISTRY,
+            node=self.kenya if node is None else node,
+            local_name=local_name,
+            local_id=local_id,
+        )
+
+        return station
+
+    def transmitted(self, wigos_id, *, hours_ago=1, node=None):
+        """A station heard transmitting under a centre's topics."""
+        station, _ = Station.objects.get_or_create(wigos_id=wigos_id)
+
+        StationSource.objects.create(
+            station=station,
+            source_type=StationSource.OBSERVED,
+            node=self.kenya if node is None else node,
+            last_seen=NOW - timedelta(hours=hours_ago),
+        )
+
+        return station
+
+    def detail(self, node=None, **kwargs):
+        kwargs.setdefault("now", NOW)
+
+        return node_detail(node or self.kenya, **kwargs)
+
+
+class HeadlineTests(NodeDetailTestCase):
+    """What the page says about the centre as a whole."""
+
+    def test_the_centre_carries_when_it_was_last_heard_from(self):
+        node = self.node("dj-anm", last_seen=at("2026-08-11T09:30:00"))
+
+        detail = self.detail(node)
+
+        self.assertEqual(detail.last_seen_at, at("2026-08-11T09:30:00"))
+        self.assertEqual(detail.hours_since_last_seen, 2.5)
+
+    def test_a_centre_never_heard_from_says_so_rather_than_nothing(self):
+        detail = self.detail()
+
+        self.assertIsNone(detail.last_seen_at)
+        self.assertIsNone(detail.hours_since_last_seen)
+
+
+class DatasetTests(NodeDetailTestCase):
+    """Which part of a centre's output stopped, rather than that something did."""
+
+    def by_title(self, **kwargs):
+        return {row.title: row for row in self.detail(**kwargs).datasets}
+
+    def test_a_dataset_carries_when_it_last_published_and_what_is_expected(self):
+        synop = self.dataset("synop")
+        self.learned(synop, 6)
+        self.last_published(synop, 30)
+
+        row = self.by_title()["synop"]
+
+        self.assertEqual(row.last_active_hour, NOW - timedelta(hours=30))
+        self.assertEqual(row.expected_interval_hours, 6)
+        self.assertEqual(row.expectation, Expectation.LEARNED)
+        self.assertEqual(row.silence, Silence.SILENT)
+
+    def test_a_stated_expectation_is_the_one_the_page_judges_against(self):
+        climate = self.dataset("climate", expects=24 * 30)
+        self.learned(climate, 6)
+        self.last_published(climate, 24)
+
+        row = self.by_title()["climate"]
+
+        self.assertEqual(row.expected_interval_hours, 24 * 30)
+        self.assertEqual(row.expectation, Expectation.OVERRIDDEN)
+        self.assertEqual(row.silence, Silence.ON_SCHEDULE)
+
+    def test_a_dataset_with_nothing_to_expect_of_it_is_not_called_silent(self):
+        self.last_published(self.dataset("synop"), 500)
+
+        row = self.by_title()["synop"]
+
+        self.assertIsNone(row.expected_interval_hours)
+        self.assertEqual(row.silence, Silence.UNKNOWN)
+
+    def test_another_centres_datasets_are_not_this_centres(self):
+        djibouti = self.node("dj-anm")
+        self.dataset("synop")
+        self.dataset("temp", node=djibouti)
+
+        self.assertEqual(sorted(self.by_title()), ["synop"])
+
+    def test_a_dataset_the_catalogue_no_longer_lists_is_shown_apart_from_the_rest(self):
+        """Retired datasets stay on the page, and no silence is claimed of them."""
+        self.dataset("synop")
+        self.dataset("withdrawn", status=Dataset.DELETED)
+
+        detail = self.detail()
+
+        self.assertEqual([row.title for row in detail.datasets], ["synop"])
+        self.assertEqual([dataset.title for dataset in detail.retired_datasets], ["withdrawn"])
+
+
+class StationTests(NodeDetailTestCase):
+    """The centre's stations, and which of them have stopped."""
+
+    def by_wigos_id(self, **kwargs):
+        return {row.wigos_id: row for row in self.detail(**kwargs).stations}
+
+    def test_a_declared_station_carries_when_it_last_transmitted(self):
+        self.declare("0-20000-0-63708")
+        self.transmitted("0-20000-0-63708", hours_ago=3)
+
+        row = self.by_wigos_id()["0-20000-0-63708"]
+
+        self.assertEqual(row.last_transmitted, NOW - timedelta(hours=3))
+        self.assertEqual(row.standing, StationStanding.TRANSMITTING)
+
+    def test_a_declared_station_nothing_has_heard_from_is_named(self):
+        self.declare("0-20000-0-63708")
+
+        row = self.by_wigos_id()["0-20000-0-63708"]
+
+        self.assertIsNone(row.last_transmitted)
+        self.assertEqual(row.standing, StationStanding.NEVER_TRANSMITTED)
+
+    def test_a_station_transmitting_that_the_registry_declares_nowhere_is_named(self):
+        """A transmitting station is never invisible, declared or not."""
+        self.transmitted("0-20000-0-63999")
+
+        row = self.by_wigos_id()["0-20000-0-63999"]
+
+        self.assertEqual(row.standing, StationStanding.UNDECLARED)
+        self.assertFalse(row.declared_by_registry)
+
+    def test_a_station_declared_and_observed_is_one_row(self):
+        self.declare("0-20000-0-63708")
+        self.transmitted("0-20000-0-63708")
+
+        self.assertEqual(len(self.detail().stations), 1)
+
+    def test_the_names_the_node_assigns_are_kept_beside_the_canonical_record(self):
+        station = self.declare(
+            "0-20000-0-63708", local_name="Dagoretti Corner", local_id="63741"
+        )
+        Station.objects.filter(pk=station.pk).update(name="NAIROBI DAGORETTI")
+
+        row = self.by_wigos_id()["0-20000-0-63708"]
+
+        self.assertEqual(row.name, "NAIROBI DAGORETTI")
+        self.assertEqual(row.local_name, "Dagoretti Corner")
+        self.assertEqual(row.local_id, "63741")
+
+    def test_another_centres_transmission_is_not_read_as_this_centres(self):
+        djibouti = self.node("dj-anm")
+        self.declare("0-20000-0-63708")
+        self.transmitted("0-20000-0-63708", node=djibouti, hours_ago=1)
+
+        row = self.by_wigos_id()["0-20000-0-63708"]
+
+        self.assertIsNone(row.last_transmitted)
+        self.assertEqual(row.standing, StationStanding.NEVER_TRANSMITTED)
+
+    def test_another_centres_stations_are_not_this_centres(self):
+        djibouti = self.node("dj-anm")
+        self.declare("0-20000-0-63708")
+        self.declare("0-20000-0-60001", node=djibouti)
+
+        self.assertEqual(sorted(self.by_wigos_id()), ["0-20000-0-63708"])
+
+    def test_a_station_only_oscar_declares_is_not_the_nodes(self):
+        """OSCAR declares against a territory, and says nothing of this node."""
+        station, _ = Station.objects.get_or_create(wigos_id="0-20000-0-63888")
+        StationSource.objects.create(
+            station=station, source_type=StationSource.OSCAR, node=None
+        )
+
+        self.assertEqual(self.detail().stations, [])
+
+    def test_the_silent_come_first_and_among_them_the_longest_quiet(self):
+        self.declare("0-20000-0-00001")
+        self.transmitted("0-20000-0-00001", hours_ago=1)
+        self.declare("0-20000-0-00002")
+        self.transmitted("0-20000-0-00002", hours_ago=40)
+        self.declare("0-20000-0-00003")
+
+        self.assertEqual(
+            [row.wigos_id for row in self.detail().stations],
+            ["0-20000-0-00003", "0-20000-0-00002", "0-20000-0-00001"],
+        )
+
+
+class SyncRunTests(NodeDetailTestCase):
+    """Whether a missing dataset is a failing sync."""
+
+    def sync_run(
+        self,
+        *,
+        node=None,
+        status=SyncLog.SUCCESS,
+        hours_ago=1,
+        error="",
+        sync_type=SyncLog.NODE_STATIONS,
+    ):
+        return SyncLog.objects.create(
+            node=self.kenya if node is None else node,
+            sync_type=sync_type,
+            status=status,
+            started_at=NOW - timedelta(hours=hours_ago),
+            error_message=error,
+        )
+
+    def test_the_most_recent_runs_come_first_with_what_they_said(self):
+        self.sync_run(hours_ago=5)
+        failed = self.sync_run(
+            hours_ago=1, status=SyncLog.FAILED, error="Connection refused"
+        )
+
+        runs = self.detail().sync_runs
+
+        self.assertEqual(runs[0].pk, failed.pk)
+        self.assertEqual(runs[0].error_message, "Connection refused")
+
+    def test_only_a_bounded_number_of_runs_is_read(self):
+        for hours_ago in range(1, 8):
+            self.sync_run(hours_ago=hours_ago)
+
+        self.assertEqual(len(self.detail(runs_per_type=3).sync_runs), 3)
+
+    def test_a_frequent_kind_of_run_cannot_bury_a_rare_one(self):
+        """Probes are sampled hourly; the station registry is read daily."""
+        for hours_ago in range(1, 8):
+            self.sync_run(hours_ago=hours_ago, sync_type=SyncLog.LINK_PROBES)
+
+        stations = self.sync_run(hours_ago=20, status=SyncLog.FAILED)
+
+        runs = self.detail(runs_per_type=3).sync_runs
+
+        self.assertIn(stations.pk, [run.pk for run in runs])
+        self.assertEqual(runs[-1].pk, stations.pk)
+
+    def test_another_centres_runs_are_not_this_centres(self):
+        djibouti = self.node("dj-anm")
+        self.sync_run()
+        self.sync_run(node=djibouti)
+
+        self.assertEqual(len(self.detail().sync_runs), 1)
+
+    def test_a_centre_nothing_has_synced_reports_no_runs(self):
+        self.assertEqual(self.detail().sync_runs, [])
+
+
+class OriginBrokerTests(NodeDetailTestCase):
+    """Whether the missing data is a broker nothing outside can reach."""
+
+    def test_a_broker_that_answers_is_reachable_and_says_where_it_is(self):
+        broker = origin_broker(
+            self.kenya, is_reachable=True, last_connected_at=NOW - timedelta(minutes=5)
+        )
+
+        origin = self.detail().origin
+
+        self.assertEqual(origin.reachability, OriginReachability.REACHABLE)
+        self.assertEqual(origin.address, f"{broker.host}:{broker.port}")
+        self.assertEqual(origin.last_connected_at, NOW - timedelta(minutes=5))
+
+    def test_a_broker_that_does_not_answer_says_what_went_wrong(self):
+        origin_broker(self.kenya, is_reachable=False, last_error="Connection timed out")
+
+        origin = self.detail().origin
+
+        self.assertEqual(origin.reachability, OriginReachability.UNREACHABLE)
+        self.assertEqual(origin.last_error, "Connection timed out")
+
+    def test_a_broker_nothing_has_tried_yet_is_not_called_unreachable(self):
+        origin_broker(self.kenya)
+
+        self.assertEqual(
+            self.detail().origin.reachability, OriginReachability.NOT_ATTEMPTED
+        )
+
+    def test_a_centre_advertising_no_broker_of_its_own_says_so(self):
+        origin = self.detail().origin
+
+        self.assertEqual(origin.reachability, OriginReachability.NOT_ADVERTISED)
+        self.assertEqual(origin.address, "")
+
+    def test_the_global_broker_is_not_mistaken_for_the_centres_own(self):
+        self.global_broker.node = self.kenya
+        self.global_broker.is_reachable = True
+        self.global_broker.save()
+
+        self.assertEqual(
+            self.detail().origin.reachability, OriginReachability.NOT_ADVERTISED
+        )

--- a/wis2watch/src/wis2watch/core/views.py
+++ b/wis2watch/src/wis2watch/core/views.py
@@ -7,9 +7,9 @@ from django.urls import reverse_lazy
 from django.utils.translation import gettext as _
 from wagtail.admin import messages
 
-from .analysis import Staleness, default_volume_hours, node_overview
+from .analysis import Staleness, default_volume_hours, node_detail, node_overview
 from .forms import SyncNodeForm
-from .models import StationSource, SyncLog, WIS2Node
+from .models import SyncLog, WIS2Node
 from .node_stations import sync_node_stations
 from .stations import node_stations_as_csv
 from .viewsets import WIS2NodeViewSet
@@ -109,8 +109,12 @@ def get_node_stations_as_csv(request, node_id):
 
 
 def node_details(request, node_id):
-    """
-    View to display details of a WIS2 Node.
+    """Everything known about one centre, on one page.
+
+    Where the overview flags a centre, this is where the flag is followed to.
+    The findings are computed whole and then rendered; syncing the node by hand
+    happens before they are read, so a page returned after a sync shows what
+    that sync left behind rather than the state it was asked to correct.
 
     Args:
         request: HTTP request object.
@@ -154,16 +158,15 @@ def node_details(request, node_id):
         {"url": "", "label": node.name},
     ]
 
-    station_declarations = StationSource.objects.declared_by_node_registry(
-        node
-    ).with_last_transmitted()
+    detail = node_detail(node)
 
     context = {
         "breadcrumbs_items": breadcrumbs_items,
         "node": node,
         "nodes_index_url": nodes_index_url,
-        "station_declarations": station_declarations,
-        "station_count": station_declarations.count(),
+        "overview_url": reverse_lazy("node_overview"),
+        "detail": detail,
+        "station_count": len(detail.stations),
     }
 
     return render(request, 'wis2watchcore/node_details.html', context)

--- a/wis2watch/src/wis2watch/core/views.py
+++ b/wis2watch/src/wis2watch/core/views.py
@@ -158,15 +158,12 @@ def node_details(request, node_id):
         {"url": "", "label": node.name},
     ]
 
-    detail = node_detail(node)
-
     context = {
         "breadcrumbs_items": breadcrumbs_items,
         "node": node,
         "nodes_index_url": nodes_index_url,
         "overview_url": reverse_lazy("node_overview"),
-        "detail": detail,
-        "station_count": len(detail.stations),
+        "detail": node_detail(node),
     }
 
     return render(request, 'wis2watchcore/node_details.html', context)


### PR DESCRIPTION
Closes #15.

When the overview flags a centre, this is where the flag is followed to. The overview reduces a centre to one line, and each of those reductions hides what the next question needs: which dataset stopped rather than the centre, which station went quiet rather than the node, and whether missing data is the centre publishing nothing or this tool failing to read it.

## What the page shows

- **Datasets** — each live dataset's last published hour beside the cadence learned or stated for it, judged by the same function the overview reduces to one badge, so page and table can never disagree. Datasets the catalogue has withdrawn are kept apart, with no silence claimed of them.
- **Stations** — every station the centre declares or has been heard transmitting for, longest quiet first, with per-station last-transmitted. A station transmitting that the registry declares nowhere is listed too: a registration gap, not an absence.
- **Sync runs** — the centre's own runs and the writing catalogue's, read a kind at a time so the hourly link probes cannot bury the daily station sync that explains the missing stations.
- **The centre's own broker** — reachability, the address dialled, last connection and last error.

## Acceptance criteria

- [x] Each of the node's datasets shows last-seen and its applicable expected cadence
- [x] The node's stations are listed with per-station last-seen
- [x] Recent sync runs and their outcomes are shown
- [x] Connection errors and origin reachability state are shown
- [x] The page is reachable from the node overview (already linked; now has a regression test)

## Notes

- New `core/analysis/node_detail.py` at the analysis seam, tested against a seeded database. `OriginReachability` and the flat staleness threshold moved to their own modules so a centre's page no longer imports the page beside it.
- A station last heard from months ago is `Gone quiet` rather than green `Transmitting`, judged against the same flat threshold the overview calls a centre stale by.
- `StationSourceQuerySet.with_last_transmitted()` removed: unused after this change, and it read the latest observation from any node rather than this one's.
- 734 tests pass.