### PR TITLE
Gap reports: the problems nobody was looking for

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -46,6 +46,10 @@ WIS2WATCH_ROLLUP_WINDOW_HOURS=48
 WIS2WATCH_STALE_AFTER_HOURS=24
 # How many hourly buckets of traffic the node overview reports as recent volume.
 WIS2WATCH_VOLUME_WINDOW_HOURS=24
+# Over how many hours the gap reports work out each centre's share of messages
+# carrying no station identifier. Wider than the volume window, because a share
+# is only worth reading over enough messages to have one.
+WIS2WATCH_ATTRIBUTION_WINDOW_HOURS=168
 
 ## Silence baselines
 # How much history each dataset's publishing rhythm is learned from, in days.

--- a/wis2watch/src/wis2watch/config/settings/base.py
+++ b/wis2watch/src/wis2watch/config/settings/base.py
@@ -380,6 +380,13 @@ WIS2WATCH_CADENCE_MIN_OBSERVATIONS = env.int("WIS2WATCH_CADENCE_MIN_OBSERVATIONS
 # volume, ending with the hour in progress.
 WIS2WATCH_VOLUME_WINDOW_HOURS = env.int("WIS2WATCH_VOLUME_WINDOW_HOURS", 24)
 
+# Over how many hours the gap reports work out each centre's share of messages
+# carrying no station identifier. Wider than the overview's volume window,
+# because a share is only worth reading over enough messages to have one: a
+# centre publishing twice a day would otherwise be reported at nought or a
+# hundred per cent depending on the day it was asked about.
+WIS2WATCH_ATTRIBUTION_WINDOW_HOURS = env.int("WIS2WATCH_ATTRIBUTION_WINDOW_HOURS", 168)
+
 WIS2WATCH_LOG_LEVEL = env.str("WIS2WATCH_LOG_LEVEL", "INFO")
 WIS2WATCH_DATABASE_LOG_LEVEL = env.str("WIS2WATCH_DATABASE_LOG_LEVEL", "ERROR")
 

--- a/wis2watch/src/wis2watch/core/analysis/__init__.py
+++ b/wis2watch/src/wis2watch/core/analysis/__init__.py
@@ -12,6 +12,24 @@ confident wrong answer rather than an exception, and only real rows expose
 them.
 """
 
+from .gaps import (
+    GAP_REPORTS,
+    GapReport,
+    GapReportSummary,
+    PropagationGapRow,
+    SilentStationRow,
+    UnattributedRateRow,
+    UndeclaredStationRow,
+    UnregisteredCentreRow,
+    default_attribution_window_hours,
+    gap_report,
+    gap_report_summaries,
+    propagation_gaps,
+    stations_declared_but_silent,
+    stations_transmitting_undeclared,
+    unattributed_rates,
+    unregistered_centres,
+)
 from .node_detail import (
     NodeDatasetRow,
     NodeDetail,
@@ -40,9 +58,12 @@ from .silence import (
 from .staleness import Staleness
 
 __all__ = [
+    "GAP_REPORTS",
     "CachePickup",
     "DatasetSilenceRow",
     "Expectation",
+    "GapReport",
+    "GapReportSummary",
     "NodeDatasetRow",
     "NodeDetail",
     "NodeOverviewRow",
@@ -50,14 +71,27 @@ __all__ = [
     "NodeStationRow",
     "OriginBrokerState",
     "OriginReachability",
+    "PropagationGapRow",
     "Silence",
+    "SilentStationRow",
     "Staleness",
     "StationStanding",
     "SyncRunRow",
     "SyncScope",
+    "UnattributedRateRow",
+    "UndeclaredStationRow",
+    "UnregisteredCentreRow",
     "dataset_silence",
+    "default_attribution_window_hours",
     "default_volume_hours",
+    "gap_report",
+    "gap_report_summaries",
     "node_detail",
     "node_overview",
+    "propagation_gaps",
     "silence_by_node",
+    "stations_declared_but_silent",
+    "stations_transmitting_undeclared",
+    "unattributed_rates",
+    "unregistered_centres",
 ]

--- a/wis2watch/src/wis2watch/core/analysis/gaps.py
+++ b/wis2watch/src/wis2watch/core/analysis/gaps.py
@@ -1,0 +1,614 @@
+"""The gap reports: the problems nobody was looking for.
+
+Everything else this tool shows answers a question somebody already thought to
+ask. The overview answers "is my region publishing", the node page answers
+"what about this centre stopped". These answer questions nobody asked, which is
+what makes the tool diagnostic rather than merely informative: a country whose
+stations are declared to the world and have never once transmitted, a centre
+publishing that no catalogue has indexed, data announced to a broker the rest
+of the world never hears.
+
+Five reports, because there are five ways the picture can be wrong that no
+single view of one centre can show:
+
+* what a country declares in OSCAR and has never been heard from;
+* what is transmitting that no registry -- OSCAR's or a centre's own --
+  declares;
+* what a centre published that the Global Broker never carried;
+* which centres publish with no catalogue record at all;
+* how much of each centre's traffic says nothing about which station it came
+  from.
+
+Every one of them is a list of named entities rather than a count. "Seventeen
+stations are silent" is not a finding anybody can act on; a WIGOS identifier, a
+territory and the centre that ought to know about it is a conversation someone
+can have. So each row carries what it would take to open that conversation, and
+the reports are bounded by filters rather than by truncation -- because a
+report that quietly drops findings is worse than one that is long.
+
+Two of those filters do most of the work, and both exist to keep the reports
+readable rather than complete. OSCAR is notoriously stale, so only stations it
+still reports as fully operational count as declared. And a centre whose own
+broker this tool cannot currently reach has its propagation gaps withheld,
+because they are indistinguishable from this tool having stopped listening.
+"""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import datetime
+
+from django.conf import settings
+from django.db.models import Exists, F, OuterRef, Q, Subquery, Sum
+from django.db.models.functions import Coalesce
+from django.utils import timezone as dj_timezone
+from django.utils.translation import gettext_lazy as _
+from django_countries.fields import Country
+
+from ..models import (
+    HourlyRollup,
+    MessageSource,
+    PropagationGap,
+    StationSource,
+    UnregisteredCentre,
+)
+from ..rollups import window_start
+from .silence import hours_between
+
+#: Over how many hours a centre's unattributed share is worked out. Longer than
+#: the overview's volume window on purpose: a share needs enough messages
+#: behind it to mean anything, and a centre publishing twice a day has none
+#: over a day.
+DEFAULT_ATTRIBUTION_WINDOW_HOURS = 168
+
+
+def default_attribution_window_hours():
+    """Over how many hours the unattributed share is worked out."""
+    return getattr(
+        settings,
+        "WIS2WATCH_ATTRIBUTION_WINDOW_HOURS",
+        DEFAULT_ATTRIBUTION_WINDOW_HOURS,
+    )
+
+
+@dataclass(frozen=True)
+class SilentStationRow:
+    """A station a country declares to the world and nothing has ever heard.
+
+    The territory is what makes the row actionable: OSCAR files a station under
+    a territory rather than a centre, so that is who the declaration belongs
+    to. Beside it, whether any centre's own registry declares the same station,
+    because the two are different conversations -- a station its centre knows
+    about and never transmits for is an ingestion to fix, and one only OSCAR
+    has ever heard of is a registration to correct.
+    """
+
+    station_id: int
+    wigos_id: str
+    name: str
+    territory: str
+    wmo_region: str
+    facility_type: str
+    registry_centre_id: str
+
+    @property
+    def display_name(self):
+        """What to call the station, falling back to what identifies it."""
+        return self.name or self.wigos_id
+
+
+@dataclass(frozen=True)
+class UndeclaredStationRow:
+    """A station transmitting under a centre's topics that no registry declares.
+
+    One row per centre that transmits for it rather than one per station: a
+    station carried by two centres is two registration gaps, each of which is
+    somebody's to close.
+    """
+
+    station_id: int
+    wigos_id: str
+    name: str
+    node_id: int | None
+    centre_id: str
+    last_transmitted: datetime | None
+    hours_quiet: float | None
+
+    @property
+    def display_name(self):
+        """What to call the station, falling back to what identifies it."""
+        return self.name or self.wigos_id
+
+
+@dataclass(frozen=True)
+class PropagationGapRow:
+    """One notification a centre published that the world never received."""
+
+    gap_id: int
+    node_id: int
+    centre_id: str
+    node_name: str
+    dataset_title: str
+    notification_id: str
+    topic: str
+    published_at: datetime
+    observed_at_origin: datetime
+    detected_at: datetime
+    hours_missing: float | None
+
+
+@dataclass(frozen=True)
+class UnregisteredCentreRow:
+    """A centre of the region publishing that no catalogue has indexed."""
+
+    centre_id: str
+    country_code: str
+    country_name: str
+    sample_topic: str
+    first_seen_at: datetime
+    last_seen_at: datetime
+    hours_unregistered: float | None
+
+
+@dataclass(frozen=True)
+class UnattributedRateRow:
+    """How much of one centre's traffic names no station.
+
+    A share rather than a count, because centres publish at wildly different
+    volumes and the finding is about the habit rather than the amount. What it
+    is not is a fault on its own: whole data categories -- gridded products,
+    satellite imagery, warnings -- have no station to name, so a high share is
+    a question to ask the centre, not an answer.
+    """
+
+    node_id: int
+    centre_id: str
+    name: str
+    country_code: str
+    country_name: str
+    message_count: int
+    unattributed_count: int
+
+    @property
+    def attributed_count(self):
+        """How many of the centre's messages named the station they came from."""
+        return self.message_count - self.unattributed_count
+
+    @property
+    def rate(self):
+        """The share of the centre's messages naming no station, from 0 to 1."""
+        if not self.message_count:
+            return 0
+
+        return self.unattributed_count / self.message_count
+
+    @property
+    def percent(self):
+        """The same share as a percentage, for a table cell."""
+        return self.rate * 100
+
+
+def stations_declared_but_silent(*, now=None):
+    """Stations OSCAR calls operational that have never once transmitted.
+
+    Args:
+        now: unused; taken so that every report is asked for the same way.
+
+    Returns:
+        list[SilentStationRow]: by territory, then by station name.
+
+    Never transmitted, rather than not lately: a station that stopped in March
+    is the centre page's finding, and naming it here as well would report one
+    fault twice under two names. What this is for is the country whose declared
+    network is not connected to WIS2 at all.
+    """
+    return [_silent_station_row(declaration) for declaration in _silent_declarations()]
+
+
+def stations_transmitting_undeclared(*, now=None):
+    """Stations being heard from that no registry admits to.
+
+    Args:
+        now: the instant the quiet beside each station is measured up to.
+
+    Returns:
+        list[UndeclaredStationRow]: by centre, then by identifier.
+
+    Declared anywhere is declared: a station another centre's registry names is
+    not a registration gap, whoever is transmitting for it. What is left is
+    traffic attributed to stations no official or local declaration has ever
+    mentioned, which is the registration nobody has noticed is missing.
+    """
+    now = now or dj_timezone.now()
+
+    return [
+        _undeclared_station_row(observation, now=now)
+        for observation in _undeclared_observations()
+    ]
+
+
+def propagation_gaps(*, now=None):
+    """Notifications published at origin that the Global Broker never carried.
+
+    Args:
+        now: the instant each gap's age is measured up to.
+
+    Returns:
+        list[PropagationGapRow]: newest publication first.
+
+    Only centres whose own broker answers right now are reported on. A gap
+    recorded while a broker was up and read after it went dark cannot be told
+    from this tool having stopped listening, and sending somebody to a centre
+    to ask about messages that may never have gone missing is how a diagnostic
+    stops being believed.
+    """
+    now = now or dj_timezone.now()
+
+    return [_propagation_gap_row(gap, now=now) for gap in _reportable_gaps()]
+
+
+def unregistered_centres(*, now=None):
+    """Centres of the region publishing with no discovery catalogue record.
+
+    Args:
+        now: the instant each centre's time unregistered is measured up to.
+
+    Returns:
+        list[UnregisteredCentreRow]: longest unregistered first.
+
+    What the wildcard sweep found by listening past the registry. A centre here
+    is publishing to WIS2 while being invisible to everything that reads a
+    catalogue -- including, but for the sweep, this tool.
+    """
+    now = now or dj_timezone.now()
+
+    return [
+        _unregistered_centre_row(centre, now=now)
+        for centre in _open_unregistered_centres()
+    ]
+
+
+def unattributed_rates(*, now=None, window_hours=None):
+    """Each publishing centre's share of messages naming no station.
+
+    Args:
+        now: the instant the window ends with the hour of.
+        window_hours: how many hourly buckets of traffic the share is worked
+            out over.
+
+    Returns:
+        list[UnattributedRateRow]: worst share first, and among equals the
+        centre publishing most.
+
+    Every centre heard publishing in the window, not only the ones with a share
+    to answer for: this is a rate report, and a rate is only readable against
+    the centres that are doing it right. A centre that published nothing is
+    absent rather than reported at nought per cent, which would read as exactly
+    that -- doing it right -- when what it has actually done is go quiet.
+
+    Counted from the Global Broker alone. The same publication is observed at
+    the centre's own broker and again on every cache that carried it, so
+    counting every vantage point would report one message as several and shrink
+    every share by however many caches happened to pick the centre up.
+    """
+    now = now or dj_timezone.now()
+    hours = (
+        default_attribution_window_hours() if window_hours is None else window_hours
+    )
+
+    rows = [
+        _unattributed_rate_row(counted)
+        for counted in _traffic_by_centre(since=window_start(now, hours))
+    ]
+
+    return sorted(rows, key=lambda row: (-row.rate, -row.message_count, row.centre_id))
+
+
+def _silent_declarations():
+    """OSCAR's operational declarations that no observation answers.
+
+    The observed declaration is what says a station has ever transmitted, and
+    it is asked for by station rather than by node: a station heard under any
+    centre's topics has been heard.
+    """
+    observed = StationSource.objects.filter(
+        station=OuterRef("station_id"), source_type=StationSource.OBSERVED
+    )
+
+    # Ordered so that a station two centres declare names the same one of them
+    # every time the report is read. Which centre it names decides whether the
+    # row is somebody's ingestion to fix or somebody's registration to correct,
+    # and an answer that changes between two readings of the same page is not
+    # one anybody can act on.
+    by_a_centre = StationSource.objects.filter(
+        station=OuterRef("station_id"),
+        source_type=StationSource.NODE_REGISTRY,
+        node__isnull=False,
+    ).order_by("node__centre_id")
+
+    return (
+        StationSource.objects.declared_in_oscar()
+        .filter(~Exists(observed))
+        .annotate(registry_centre_id=Subquery(by_a_centre.values("node__centre_id")[:1]))
+        .order_by("station__territory", "station__name", "station__wigos_id")
+    )
+
+
+def _silent_station_row(declaration):
+    """One OSCAR declaration nothing has answered, as a finding."""
+    station = declaration.station
+
+    return SilentStationRow(
+        station_id=station.pk,
+        wigos_id=station.wigos_id,
+        name=station.name,
+        territory=station.territory,
+        wmo_region=station.wmo_region,
+        facility_type=station.get_facility_type_display(),
+        registry_centre_id=declaration.registry_centre_id or "",
+    )
+
+
+def _undeclared_observations():
+    """Observations of stations that neither OSCAR nor any centre declares.
+
+    Centres with no catalogue record sort first, since their observations carry
+    no centre at all: a station transmitting under a centre nothing has heard
+    of is the least accounted-for traffic there is, and letting it settle to
+    the bottom of the report is how it stays that way.
+    """
+    declared = StationSource.objects.filter(
+        station=OuterRef("station_id"),
+        source_type__in=(StationSource.OSCAR, StationSource.NODE_REGISTRY),
+    )
+
+    return (
+        StationSource.objects.filter(source_type=StationSource.OBSERVED)
+        .filter(~Exists(declared))
+        .select_related("station", "node")
+        .order_by(F("node__centre_id").asc(nulls_first=True), "station__wigos_id")
+    )
+
+
+def _undeclared_station_row(observation, *, now):
+    """One observation of an undeclared station, as a finding."""
+    station = observation.station
+
+    return UndeclaredStationRow(
+        station_id=station.pk,
+        wigos_id=station.wigos_id,
+        name=station.name,
+        node_id=observation.node_id,
+        centre_id=observation.node.centre_id if observation.node_id else "",
+        last_transmitted=observation.last_seen,
+        hours_quiet=hours_between(observation.last_seen, now),
+    )
+
+
+def _reportable_gaps():
+    """The open gaps of centres whose own broker still answers."""
+    return (
+        PropagationGap.objects.open()
+        .filter(node__in=MessageSource.objects.watched_origins().values("node_id"))
+        .select_related("node", "dataset")
+    )
+
+
+def _propagation_gap_row(gap, *, now):
+    """One open gap as a finding."""
+    return PropagationGapRow(
+        gap_id=gap.pk,
+        node_id=gap.node_id,
+        centre_id=gap.node.centre_id,
+        node_name=gap.node.name,
+        dataset_title=gap.dataset.title if gap.dataset_id else "",
+        notification_id=gap.notification_id,
+        topic=gap.topic,
+        published_at=gap.published_at,
+        observed_at_origin=gap.observed_at_origin,
+        detected_at=gap.detected_at,
+        hours_missing=hours_between(gap.published_at, now),
+    )
+
+
+def _open_unregistered_centres():
+    """The centres the registry has still not caught up with."""
+    return UnregisteredCentre.objects.unregistered().order_by(
+        "first_seen_at", "centre_id"
+    )
+
+
+def _unregistered_centre_row(centre, *, now):
+    """One unregistered centre as a finding."""
+    return UnregisteredCentreRow(
+        centre_id=centre.centre_id,
+        country_code=centre.country.code if centre.country else "",
+        country_name=centre.country.name if centre.country else "",
+        sample_topic=centre.sample_topic,
+        first_seen_at=centre.first_seen_at,
+        last_seen_at=centre.last_seen_at,
+        hours_unregistered=hours_between(centre.first_seen_at, now),
+    )
+
+
+def _traffic_by_centre(*, since):
+    """What each centre published in the window, and how much of it named nothing.
+
+    Both counts come off the same grouped pass over the rollups, because they
+    are a share of one another: derived separately they could be drawn over
+    slightly different sets of buckets, and a share of two numbers that do not
+    belong together is worse than no share at all.
+
+    A centre whose messages all name a station has no unattributed buckets to
+    sum, which is a null rather than a nought -- so it is coalesced, not left
+    to make the arithmetic below disappear.
+
+    The sums are named apart from the column they are drawn from, because a
+    bucket's own count and a centre's total are different numbers and the ORM
+    will not let one alias stand for both.
+    """
+    return (
+        HourlyRollup.objects.filter(
+            hour__gte=since, source__source_type=MessageSource.GLOBAL_BROKER
+        )
+        .values("node_id", "node__centre_id", "node__name", "node__country")
+        .annotate(
+            messages=Sum("message_count"),
+            unattributed=Coalesce(
+                Sum("message_count", filter=Q(station__isnull=True)), 0
+            ),
+        )
+    )
+
+
+def _unattributed_rate_row(counted):
+    """One centre's counted traffic as a finding."""
+    country = Country(counted["node__country"] or "")
+
+    return UnattributedRateRow(
+        node_id=counted["node_id"],
+        centre_id=counted["node__centre_id"],
+        name=counted["node__name"],
+        country_code=country.code,
+        country_name=country.name,
+        message_count=counted["messages"],
+        unattributed_count=counted["unattributed"],
+    )
+
+
+def _centres_naming_no_station(*, now):
+    """How many centres left at least one message unattributed in the window.
+
+    The rate report's headline, and deliberately not the number of rows it
+    lists: it lists every publishing centre, including the ones with nothing to
+    answer for, and an index promising a hundred findings that turn out to be a
+    hundred centres doing it right is how the index stops being read.
+    """
+    return (
+        HourlyRollup.objects.filter(
+            hour__gte=window_start(now, default_attribution_window_hours()),
+            source__source_type=MessageSource.GLOBAL_BROKER,
+            station__isnull=True,
+            message_count__gt=0,
+        )
+        .values("node_id")
+        .distinct()
+        .count()
+    )
+
+
+@dataclass(frozen=True)
+class GapReport:
+    """One report: what it finds, and how to ask for it.
+
+    The five are held as a list rather than as five hard-wired pages so that
+    the index, the routing and the report itself all read from one place. A
+    report that exists but is not on the index is a finding nobody sees, which
+    is the failure this whole module exists to prevent.
+
+    The two callables are named as the verbs they are. A template renders any
+    attribute it is given and calls it if it can, so a field called ``count``
+    would run a query from the middle of a page that only meant to print a
+    number.
+    """
+
+    slug: str
+    title: str
+    description: str
+    find_rows: Callable[..., list]
+    count_rows: Callable[..., int]
+
+
+@dataclass(frozen=True)
+class GapReportSummary:
+    """One line of the index: a report and how much it has found."""
+
+    slug: str
+    title: str
+    description: str
+    count: int
+
+
+#: The five reports, in the order the index shows them: what is declared and
+#: missing, what is arriving and unaccounted for, then the three about the
+#: centres themselves.
+GAP_REPORTS = (
+    GapReport(
+        slug="declared-but-silent",
+        title=_("Declared but silent stations"),
+        description=_(
+            "Stations OSCAR/Surface reports as operational that have never "
+            "been heard transmitting."
+        ),
+        find_rows=stations_declared_but_silent,
+        count_rows=lambda *, now=None: _silent_declarations().count(),
+    ),
+    GapReport(
+        slug="transmitting-undeclared",
+        title=_("Transmitting but undeclared stations"),
+        description=_(
+            "Stations heard transmitting that neither OSCAR/Surface nor any "
+            "centre's own registry declares."
+        ),
+        find_rows=stations_transmitting_undeclared,
+        count_rows=lambda *, now=None: _undeclared_observations().count(),
+    ),
+    GapReport(
+        slug="propagation-gaps",
+        title=_("Propagation gaps"),
+        description=_(
+            "Notifications seen at a centre's own broker that the Global "
+            "Broker has never carried. Centres whose own broker cannot "
+            "currently be reached are left out."
+        ),
+        find_rows=propagation_gaps,
+        count_rows=lambda *, now=None: _reportable_gaps().count(),
+    ),
+    GapReport(
+        slug="unregistered-centres",
+        title=_("Unregistered centres"),
+        description=_(
+            "Centres of the monitored region publishing with no discovery "
+            "catalogue record."
+        ),
+        find_rows=unregistered_centres,
+        count_rows=lambda *, now=None: _open_unregistered_centres().count(),
+    ),
+    GapReport(
+        slug="unattributed-messages",
+        title=_("Unattributed messages"),
+        description=_(
+            "How much of each centre's traffic carries no WIGOS station "
+            "identifier. The count is the centres leaving any message "
+            "unattributed; the report lists every centre publishing."
+        ),
+        find_rows=unattributed_rates,
+        count_rows=lambda *, now=None: _centres_naming_no_station(
+            now=now or dj_timezone.now()
+        ),
+    ),
+)
+
+
+def gap_report(slug):
+    """The report of that name, or None if nothing is called that."""
+    return next((report for report in GAP_REPORTS if report.slug == slug), None)
+
+
+def gap_report_summaries(*, now=None):
+    """Every report with how much it has found, for the index.
+
+    Counted rather than listed: the index exists to say which report is worth
+    opening, and building five reports in full to show five numbers would make
+    the cheapest page in the tool the most expensive.
+    """
+    now = now or dj_timezone.now()
+
+    return [
+        GapReportSummary(
+            slug=report.slug,
+            title=report.title,
+            description=report.description,
+            count=report.count_rows(now=now),
+        )
+        for report in GAP_REPORTS
+    ]

--- a/wis2watch/src/wis2watch/core/analysis/overview.py
+++ b/wis2watch/src/wis2watch/core/analysis/overview.py
@@ -29,7 +29,7 @@ lookups rather than a scan that grows with the region's traffic.
 """
 
 from dataclasses import dataclass
-from datetime import datetime, timedelta, timezone
+from datetime import datetime
 
 from django.conf import settings
 from django.db.models import Count, Exists, OuterRef, Subquery, Sum
@@ -45,7 +45,7 @@ from ..models import (
     StationSource,
     WIS2Node,
 )
-from ..rollups import floor_to_hour
+from ..rollups import window_start
 from .reachability import OriginReachability
 from .silence import BEFORE_ANYTHING, NodeSilence, Silence, hours_between, silence_by_node
 from .staleness import Staleness, default_stale_after_hours
@@ -143,18 +143,6 @@ def default_volume_hours():
     return getattr(settings, "WIS2WATCH_VOLUME_WINDOW_HOURS", DEFAULT_VOLUME_HOURS)
 
 
-def volume_window_start(now, volume_hours):
-    """The first hourly bucket the volume column counts.
-
-    Counted in whole buckets ending with the hour in progress, so the window
-    is the same length whatever minute the page is opened at. Measuring back
-    from the current instant instead would either take in a slice of an
-    extra hour or drop part of one, and a column headed "24h" would mean
-    something slightly different each time it was read.
-    """
-    return floor_to_hour(now) - timedelta(hours=volume_hours - 1)
-
-
 def node_overview(
     *,
     now=None,
@@ -191,7 +179,7 @@ def node_overview(
 
     rows = [
         _row(node, now=now, stale_after=stale_after, silence=silence)
-        for node in _annotated_nodes(since=volume_window_start(now, hours))
+        for node in _annotated_nodes(since=window_start(now, hours))
     ]
 
     if staleness is not None:

--- a/wis2watch/src/wis2watch/core/models.py
+++ b/wis2watch/src/wis2watch/core/models.py
@@ -218,6 +218,34 @@ class MessageSourceQuerySet(models.QuerySet):
         """
         return self.filter(carried_by__isnull=True)
 
+    def origin_brokers(self):
+        """The nodes' own brokers this tool is currently meant to be watching.
+
+        A broker switched off in the admin is not one of them: reachability is
+        only ever what the last live connection recorded, so a source nothing
+        is dialling any more carries an answer that has since gone stale.
+        """
+        return self.filter(
+            source_type=MessageSource.ORIGIN_BROKER,
+            is_active=True,
+            node__isnull=False,
+        )
+
+    def watched_origins(self):
+        """The origin brokers whose view of their centre can be trusted now.
+
+        What decides whether a centre may be judged on the difference between
+        its own broker and the Global Broker -- and so is asked both by the
+        evaluation that records propagation gaps and by the report that lists
+        them. Written once, because a gap recorded while a broker answered and
+        then reported after it went dark is exactly the finding neither of them
+        should stand behind.
+
+        A null reachability is "not attempted yet", and is no more a licence to
+        judge a centre than a failure is.
+        """
+        return self.origin_brokers().filter(is_reachable=True)
+
 
 class MessageSource(TimeStampedModel):
     """

--- a/wis2watch/src/wis2watch/core/propagation.py
+++ b/wis2watch/src/wis2watch/core/propagation.py
@@ -122,13 +122,22 @@ def evaluate_propagation(*, now=None, grace_minutes=None, window_hours=None):
     )
     since = evaluation_window_start(now, window_hours)
 
-    sources = _watched_origin_sources() if _the_world_is_watched() else []
+    # Which brokers may be judged on is the model's answer rather than this
+    # module's, because the report that lists the gaps recorded here asks the
+    # same question of the same brokers: the two answering differently would
+    # put a centre's gaps on a page the evaluation had decided it could not
+    # judge.
+    sources = (
+        list(MessageSource.objects.watched_origins())
+        if _the_world_is_watched()
+        else []
+    )
     counts = PropagationCounts(
         nodes_evaluated=len(sources),
         # Whatever was not judged was suppressed, for whichever of the two
         # reasons. A node has at most one broker of its own, so counting the
         # sources not evaluated counts the centres not judged.
-        nodes_suppressed=_origin_sources_being_watched().count() - len(sources),
+        nodes_suppressed=MessageSource.objects.origin_brokers().count() - len(sources),
     )
 
     # Closing first costs nothing and keeps a run's own two halves consistent:
@@ -144,31 +153,6 @@ def evaluate_propagation(*, now=None, grace_minutes=None, window_hours=None):
     logger.info("Propagation evaluated back to %s: %s", since, counts.summary)
 
     return counts
-
-
-def _origin_sources_being_watched():
-    """The origin brokers this process is currently connected to at all.
-
-    Reachability is only ever what the supervisor last recorded of a live
-    connection, so a broker no longer being connected -- deactivated in the
-    admin -- would otherwise be judged on an answer that has since gone stale.
-    Both halves of the run start from here, so what counts as a centre this
-    tool can see is decided once.
-    """
-    return MessageSource.objects.filter(
-        source_type=MessageSource.ORIGIN_BROKER,
-        is_active=True,
-        node__isnull=False,
-    )
-
-
-def _watched_origin_sources():
-    """The origin brokers whose view can be trusted right now.
-
-    A null reachability is "not attempted yet", and is no more a licence to
-    judge a centre than a failure is.
-    """
-    return list(_origin_sources_being_watched().filter(is_reachable=True))
 
 
 def _the_world_is_watched():

--- a/wis2watch/src/wis2watch/core/rollups.py
+++ b/wis2watch/src/wis2watch/core/rollups.py
@@ -69,6 +69,23 @@ def floor_to_hour(moment):
     return moment.astimezone(timezone.utc).replace(minute=0, second=0, microsecond=0)
 
 
+def window_start(now, hours):
+    """The first hourly bucket a window of that many hours covers.
+
+    Counted in whole buckets ending with the hour in progress, so a window is
+    the same length whatever minute it is asked for at. Measuring back from the
+    instant itself would either take in a slice of an extra bucket or drop part
+    of one, and a column headed "24h" would mean something slightly different
+    each time it was read.
+
+    Here rather than beside any one of the surfaces that reads a window,
+    because the buckets are what the rule is about: this is the finest answer
+    the rollups can give, and two surfaces spelling it separately is how a
+    "last 24 hours" and a "last 24 hours" come to cover different hours.
+    """
+    return floor_to_hour(now) - timedelta(hours=hours - 1)
+
+
 def default_window_hours():
     """How far back a scheduled run recomputes, unless told otherwise."""
     return getattr(settings, "WIS2WATCH_ROLLUP_WINDOW_HOURS", DEFAULT_WINDOW_HOURS)

--- a/wis2watch/src/wis2watch/core/templates/wis2watchcore/gap_reports.html
+++ b/wis2watch/src/wis2watch/core/templates/wis2watchcore/gap_reports.html
@@ -1,0 +1,90 @@
+{% extends "wagtailadmin/generic/base.html" %}
+
+{% load i18n wagtailadmin_tags %}
+
+{% block extra_css %}
+    {{ block.super }}
+    <style>
+        .reports-lead {
+            margin: 20px 0 25px;
+            color: #555;
+            max-width: 70ch;
+        }
+
+        .report-list {
+            list-style: none;
+            margin: 0;
+            padding: 0;
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+            gap: 15px;
+        }
+
+        .report-card {
+            background: #fff;
+            border: 1px solid #ddd;
+            border-radius: 5px;
+            padding: 15px 20px;
+        }
+
+        .report-card-head {
+            display: flex;
+            justify-content: space-between;
+            align-items: baseline;
+            gap: 15px;
+        }
+
+        .report-title {
+            font-weight: 600;
+            font-size: 1.05em;
+        }
+
+        .report-count {
+            display: inline-block;
+            padding: 3px 12px;
+            border-radius: 3px;
+            font-weight: 600;
+            background: #eee;
+            color: #555;
+        }
+
+        .report-count-found {
+            background: #fff3cd;
+            color: #856404;
+        }
+
+        .report-description {
+            margin: 10px 0 0;
+            color: #555;
+            font-size: 0.9em;
+        }
+
+        .reports-back {
+            margin-top: 30px;
+        }
+    </style>
+{% endblock %}
+
+{% block main_content %}
+    <p class="reports-lead">
+        {% trans "What the overview cannot show: stations declared and never heard, traffic nobody declared, notifications the world never received, and centres publishing that no catalogue has indexed." %}
+    </p>
+
+    <ul class="report-list">
+        {% for summary in summaries %}
+            <li class="report-card">
+                <div class="report-card-head">
+                    <a class="report-title" href="{% url 'gap_report' summary.slug %}">{{ summary.title }}</a>
+                    <span class="report-count {% if summary.count %}report-count-found{% endif %}">
+                        {{ summary.count }}
+                    </span>
+                </div>
+                <p class="report-description">{{ summary.description }}</p>
+            </li>
+        {% endfor %}
+    </ul>
+
+    <p class="reports-back">
+        <a href="{{ overview_url }}">{% trans "Back to the node overview" %}</a>
+    </p>
+{% endblock %}

--- a/wis2watch/src/wis2watch/core/templates/wis2watchcore/gap_reports/base.html
+++ b/wis2watch/src/wis2watch/core/templates/wis2watchcore/gap_reports/base.html
@@ -1,0 +1,127 @@
+{% extends "wagtailadmin/generic/base.html" %}
+
+{% load i18n wagtailadmin_tags %}
+
+{% comment %}
+    The frame every gap report shares: what the report is for, its findings a
+    page at a time, and what it says when it has found nothing. Only the
+    columns differ between the five, so only the columns are overridden --
+    otherwise a report added later would arrive looking like a different tool.
+{% endcomment %}
+
+{% block extra_css %}
+    {{ block.super }}
+    <style>
+        .report-description {
+            margin: 20px 0;
+            color: #555;
+            max-width: 80ch;
+        }
+
+        .report-note {
+            margin: 0 0 20px;
+            color: #666;
+            font-size: 0.9em;
+            max-width: 80ch;
+        }
+
+        .report-table {
+            width: 100%;
+            border-collapse: collapse;
+            background: #fff;
+        }
+
+        .report-table th {
+            background: #f5f5f5;
+            padding: 10px;
+            text-align: left;
+            font-weight: 600;
+            color: #555;
+            border-bottom: 2px solid #ddd;
+            font-size: 0.9em;
+        }
+
+        .report-table td {
+            padding: 10px;
+            border-bottom: 1px solid #eee;
+            font-size: 0.9em;
+        }
+
+        .report-table td.numeric,
+        .report-table th.numeric {
+            text-align: right;
+        }
+
+        .report-table td.wrapping {
+            max-width: 40ch;
+            word-break: break-all;
+        }
+
+        .row-detail {
+            margin-top: 4px;
+            color: #555;
+            font-size: 0.8em;
+        }
+
+        .badge {
+            display: inline-block;
+            padding: 3px 10px;
+            border-radius: 3px;
+            font-size: 0.85em;
+            font-weight: 500;
+        }
+
+        .badge-warning {
+            background: #fff3cd;
+            color: #856404;
+        }
+
+        .badge-quiet {
+            background: #eee;
+            color: #555;
+        }
+
+        .empty-state {
+            text-align: center;
+            padding: 50px;
+            color: #999;
+        }
+
+        .report-back {
+            margin-top: 30px;
+        }
+    </style>
+{% endblock %}
+
+{% block main_content %}
+    <p class="report-description">{{ report.description }}</p>
+
+    {% block report_note %}{% endblock %}
+
+    {% if rows %}
+        <table class="listing report-table">
+            <thead>
+            <tr>
+                {% block table_head %}{% endblock %}
+            </tr>
+            </thead>
+            <tbody>
+            {% for row in rows %}
+                <tr>
+                    {% block table_row %}{% endblock %}
+                </tr>
+            {% endfor %}
+            </tbody>
+        </table>
+
+        {% include "wagtailadmin/shared/pagination_nav.html" with items=page_obj %}
+    {% else %}
+        <div class="empty-state">
+            <p>{% block empty_message %}{% trans "Nothing to report" %}{% endblock %}</p>
+        </div>
+    {% endif %}
+
+    <p class="report-back">
+        <a href="{% url 'gap_reports' %}">{% trans "Back to the gap reports" %}</a>
+    </p>
+{% endblock %}

--- a/wis2watch/src/wis2watch/core/templates/wis2watchcore/gap_reports/declared_but_silent.html
+++ b/wis2watch/src/wis2watch/core/templates/wis2watchcore/gap_reports/declared_but_silent.html
@@ -1,0 +1,39 @@
+{% extends "wis2watchcore/gap_reports/base.html" %}
+
+{% load i18n %}
+
+{% block report_note %}
+    <p class="report-note">
+        {% trans "Never heard from at all, rather than not lately: a station that has stopped since is named on its centre's own page." %}
+    </p>
+{% endblock %}
+
+{% block table_head %}
+    <th>{% trans "Station" %}</th>
+    <th>{% trans "WIGOS ID" %}</th>
+    <th>{% trans "Territory" %}</th>
+    <th>{% trans "WMO region" %}</th>
+    <th>{% trans "Facility" %}</th>
+    <th title="{% trans 'The centre whose own registry also declares this station, where one does' %}">
+        {% trans "Declared by centre" %}
+    </th>
+{% endblock %}
+
+{% block table_row %}
+    <td>{{ row.display_name }}</td>
+    <td><code>{{ row.wigos_id }}</code></td>
+    <td>{{ row.territory|default:"—" }}</td>
+    <td>{{ row.wmo_region|default:"—" }}</td>
+    <td>{{ row.facility_type|default:"—" }}</td>
+    <td>
+        {% if row.registry_centre_id %}
+            <code>{{ row.registry_centre_id }}</code>
+        {% else %}
+            <span class="badge badge-warning">{% trans "No centre declares it" %}</span>
+        {% endif %}
+    </td>
+{% endblock %}
+
+{% block empty_message %}
+    {% trans "Every station OSCAR/Surface calls operational has been heard transmitting" %}
+{% endblock %}

--- a/wis2watch/src/wis2watch/core/templates/wis2watchcore/gap_reports/propagation_gaps.html
+++ b/wis2watch/src/wis2watch/core/templates/wis2watchcore/gap_reports/propagation_gaps.html
@@ -1,0 +1,44 @@
+{% extends "wis2watchcore/gap_reports/base.html" %}
+
+{% load i18n %}
+
+{% block report_note %}
+    <p class="report-note">
+        {% trans "Each row is one notification, named by the UUID both vantage points carry, so it can be taken to the centre as it stands." %}
+    </p>
+{% endblock %}
+
+{% block table_head %}
+    <th>{% trans "Centre" %}</th>
+    <th>{% trans "Dataset" %}</th>
+    <th>{% trans "Topic" %}</th>
+    <th>{% trans "Notification" %}</th>
+    <th>{% trans "Published" %}</th>
+    <th>{% trans "Missing for" %}</th>
+{% endblock %}
+
+{% block table_row %}
+    <td>
+        <a href="{% url 'node_details' row.node_id %}"><code>{{ row.centre_id }}</code></a>
+    </td>
+    <td>{{ row.dataset_title|default:"—" }}</td>
+    <td class="wrapping"><code>{{ row.topic }}</code></td>
+    <td class="wrapping"><code>{{ row.notification_id }}</code></td>
+    <td>
+        {{ row.published_at|date:"Y-m-d H:i" }}
+        <div class="row-detail">
+            {% blocktrans with seen=row.observed_at_origin|date:"Y-m-d H:i" %}seen at origin {{ seen }}{% endblocktrans %}
+        </div>
+    </td>
+    <td>
+        {% if row.hours_missing is not None %}
+            {% blocktrans with hours=row.hours_missing|floatformat:1 %}{{ hours }}h{% endblocktrans %}
+        {% else %}
+            —
+        {% endif %}
+    </td>
+{% endblock %}
+
+{% block empty_message %}
+    {% trans "Everything published at a reachable centre's own broker has reached the Global Broker" %}
+{% endblock %}

--- a/wis2watch/src/wis2watch/core/templates/wis2watchcore/gap_reports/transmitting_undeclared.html
+++ b/wis2watch/src/wis2watch/core/templates/wis2watchcore/gap_reports/transmitting_undeclared.html
@@ -1,0 +1,41 @@
+{% extends "wis2watchcore/gap_reports/base.html" %}
+
+{% load i18n %}
+
+{% block report_note %}
+    <p class="report-note">
+        {% trans "One row per centre transmitting for the station: a station carried by two centres is two registrations to correct." %}
+    </p>
+{% endblock %}
+
+{% block table_head %}
+    <th>{% trans "Centre" %}</th>
+    <th>{% trans "Station" %}</th>
+    <th>{% trans "WIGOS ID" %}</th>
+    <th>{% trans "Last transmitted" %}</th>
+    <th>{% trans "Quiet for" %}</th>
+{% endblock %}
+
+{% block table_row %}
+    <td>
+        {% if row.node_id %}
+            <a href="{% url 'node_details' row.node_id %}"><code>{{ row.centre_id }}</code></a>
+        {% else %}
+            <span class="badge badge-warning">{% trans "Unregistered centre" %}</span>
+        {% endif %}
+    </td>
+    <td>{{ row.display_name }}</td>
+    <td><code>{{ row.wigos_id }}</code></td>
+    <td>{{ row.last_transmitted|date:"Y-m-d H:i"|default:"—" }}</td>
+    <td>
+        {% if row.hours_quiet is not None %}
+            {% blocktrans with hours=row.hours_quiet|floatformat:1 %}{{ hours }}h{% endblocktrans %}
+        {% else %}
+            —
+        {% endif %}
+    </td>
+{% endblock %}
+
+{% block empty_message %}
+    {% trans "Every station being heard from is declared somewhere" %}
+{% endblock %}

--- a/wis2watch/src/wis2watch/core/templates/wis2watchcore/gap_reports/unattributed_messages.html
+++ b/wis2watch/src/wis2watch/core/templates/wis2watchcore/gap_reports/unattributed_messages.html
@@ -1,0 +1,40 @@
+{% extends "wis2watchcore/gap_reports/base.html" %}
+
+{% load i18n %}
+
+{% block report_note %}
+    <p class="report-note">
+        {% blocktrans with hours=attribution_hours %}Counted over the last {{ hours }} hours, from what the Global Broker carried. Every centre heard publishing is listed, because a share is only readable beside the centres that carry the identifier throughout.{% endblocktrans %}
+    </p>
+    <p class="report-note">
+        {% trans "A high share is a question rather than a fault: whole data categories — gridded products, satellite imagery, warnings — have no station to name." %}
+    </p>
+{% endblock %}
+
+{% block table_head %}
+    <th>{% trans "Centre" %}</th>
+    <th>{% trans "Country" %}</th>
+    <th class="numeric">{% trans "Messages" %}</th>
+    <th class="numeric">{% trans "Naming a station" %}</th>
+    <th class="numeric">{% trans "Naming none" %}</th>
+    <th class="numeric">{% trans "Unattributed" %}</th>
+{% endblock %}
+
+{% block table_row %}
+    <td>
+        <a href="{% url 'node_details' row.node_id %}"><code>{{ row.centre_id }}</code></a>
+    </td>
+    <td>{{ row.country_name|default:"—" }}</td>
+    <td class="numeric">{{ row.message_count }}</td>
+    <td class="numeric">{{ row.attributed_count }}</td>
+    <td class="numeric">{{ row.unattributed_count }}</td>
+    <td class="numeric">
+        <span class="badge {% if row.unattributed_count %}badge-warning{% else %}badge-quiet{% endif %}">
+            {% blocktrans with percent=row.percent|floatformat:1 %}{{ percent }}%{% endblocktrans %}
+        </span>
+    </td>
+{% endblock %}
+
+{% block empty_message %}
+    {% trans "No centre has been heard publishing in the window" %}
+{% endblock %}

--- a/wis2watch/src/wis2watch/core/templates/wis2watchcore/gap_reports/unregistered_centres.html
+++ b/wis2watch/src/wis2watch/core/templates/wis2watchcore/gap_reports/unregistered_centres.html
@@ -1,0 +1,37 @@
+{% extends "wis2watchcore/gap_reports/base.html" %}
+
+{% load i18n %}
+
+{% block report_note %}
+    <p class="report-note">
+        {% trans "Found by the wildcard sweep, which listens past the registry: a centre here is publishing to WIS2 while being invisible to anything that reads a catalogue." %}
+    </p>
+{% endblock %}
+
+{% block table_head %}
+    <th>{% trans "Centre" %}</th>
+    <th>{% trans "Country" %}</th>
+    <th>{% trans "Seen publishing on" %}</th>
+    <th>{% trans "First seen" %}</th>
+    <th>{% trans "Last seen" %}</th>
+    <th>{% trans "Unregistered for" %}</th>
+{% endblock %}
+
+{% block table_row %}
+    <td><code>{{ row.centre_id }}</code></td>
+    <td>{{ row.country_name|default:"—" }}</td>
+    <td class="wrapping"><code>{{ row.sample_topic|default:"—" }}</code></td>
+    <td>{{ row.first_seen_at|date:"Y-m-d H:i" }}</td>
+    <td>{{ row.last_seen_at|date:"Y-m-d H:i" }}</td>
+    <td>
+        {% if row.hours_unregistered is not None %}
+            {% blocktrans with hours=row.hours_unregistered|floatformat:1 %}{{ hours }}h{% endblocktrans %}
+        {% else %}
+            —
+        {% endif %}
+    </td>
+{% endblock %}
+
+{% block empty_message %}
+    {% trans "Every centre heard publishing has a discovery catalogue record" %}
+{% endblock %}

--- a/wis2watch/src/wis2watch/core/templates/wis2watchcore/node_overview.html
+++ b/wis2watch/src/wis2watch/core/templates/wis2watchcore/node_overview.html
@@ -133,10 +133,39 @@
             padding: 50px;
             color: #999;
         }
+
+        .overview-reports {
+            display: flex;
+            gap: 10px;
+            align-items: baseline;
+            flex-wrap: wrap;
+            margin: 20px 0 0;
+            padding-bottom: 15px;
+            border-bottom: 1px solid #ddd;
+        }
+
+        .overview-reports-label {
+            font-weight: 600;
+            color: #555;
+        }
     </style>
 {% endblock %}
 
 {% block main_content %}
+    {% comment %}
+        The gap reports named here as well as on their own index, because this
+        table is what somebody has open when they start wondering what else is
+        wrong -- and a report nobody arrives at reports nothing.
+    {% endcomment %}
+    <div class="overview-reports">
+        <span class="overview-reports-label">
+            <a href="{% url 'gap_reports' %}">{% trans "Gap reports" %}</a>:
+        </span>
+        {% for report in gap_reports %}
+            <a href="{% url 'gap_report' report.slug %}">{{ report.title }}</a>
+        {% endfor %}
+    </div>
+
     <div class="overview-filters">
         <span>{% trans "Staleness" %}:</span>
         <a class="overview-filter {% if not staleness %}selected{% endif %}"

--- a/wis2watch/src/wis2watch/core/tests/test_admin.py
+++ b/wis2watch/src/wis2watch/core/tests/test_admin.py
@@ -5,6 +5,7 @@ from django.test import TestCase
 from django.urls import reverse
 from django.utils import timezone as dj_timezone
 
+from wis2watch.core.analysis import GAP_REPORTS
 from wis2watch.core.models import (
     CadenceBaseline,
     Dataset,
@@ -12,9 +13,11 @@ from wis2watch.core.models import (
     HourlyRollup,
     MessageSource,
     NodeLastSeen,
+    PropagationGap,
     Station,
     StationSource,
     SyncLog,
+    UnregisteredCentre,
     WIS2Node,
 )
 from wis2watch.core.viewsets import (
@@ -286,6 +289,146 @@ class NodeOverviewViewTests(TestCase):
 
         self.assertContains(response, "Nothing to cache")
         self.assertNotContains(response, "Not cached")
+
+
+class GapReportViewTests(TestCase):
+    """The five reports, and the ways somebody arrives at one.
+
+    What the reports find is the analysis seam's business; what is guarded here
+    is that each of them can actually be reached and rendered, since a finding
+    on a page nobody can open is a finding that stayed in the database.
+    """
+
+    def setUp(self):
+        self.client.force_login(
+            get_user_model().objects.create_superuser("diagnostician", password="s3cret")
+        )
+        self.node = WIS2Node.objects.create(centre_id="ke-kmd", name="Kenya Met")
+
+    def declared_in_oscar(self):
+        """A station the country declares and nothing has ever heard."""
+        station = Station.objects.create(
+            wigos_id="0-20000-0-63741",
+            name="Dagoretti",
+            operating_status="operational",
+        )
+        StationSource.objects.create(station=station, source_type=StationSource.OSCAR)
+
+        return station
+
+    def a_finding_for_every_report(self):
+        """One of each, so that every report has a row to lay out.
+
+        A column that only ever renders against an empty table is a column
+        nobody has seen: the row is where a template's mistakes are.
+        """
+        self.declared_in_oscar()
+
+        StationSource.objects.create(
+            station=Station.objects.create(wigos_id="0-20000-0-63999"),
+            source_type=StationSource.OBSERVED,
+            node=self.node,
+            last_seen=dj_timezone.now(),
+        )
+        origin = MessageSource.objects.create(
+            name="ke-kmd origin broker",
+            source_type=MessageSource.ORIGIN_BROKER,
+            node=self.node,
+            centre_id="ke-kmd",
+            host="wis.kmd.test",
+            is_reachable=True,
+        )
+        PropagationGap.objects.create(
+            node=self.node,
+            origin_source=origin,
+            notification_id="4b1d",
+            topic="origin/a/wis2/ke-kmd/data/core/weather/synop",
+            published_at=dj_timezone.now(),
+            observed_at_origin=dj_timezone.now(),
+            detected_at=dj_timezone.now(),
+        )
+        UnregisteredCentre.objects.create(
+            centre_id="ml-meteo",
+            country="ML",
+            sample_topic="origin/a/wis2/ml-meteo/data/core/weather/synop",
+            first_seen_at=dj_timezone.now(),
+            last_seen_at=dj_timezone.now(),
+        )
+        HourlyRollup.objects.create(
+            hour=dj_timezone.now().replace(minute=0, second=0, microsecond=0),
+            source=MessageSource.objects.create(
+                name="Global Broker",
+                source_type=MessageSource.GLOBAL_BROKER,
+                host="globalbroker.example.int",
+            ),
+            node=self.node,
+            message_count=4,
+        )
+
+    def test_the_index_lists_every_report(self):
+        response = self.client.get(reverse("gap_reports"))
+
+        self.assertEqual(response.status_code, 200)
+
+        for report in GAP_REPORTS:
+            with self.subTest(slug=report.slug):
+                self.assertContains(response, reverse("gap_report", args=[report.slug]))
+
+    def test_the_index_counts_what_each_report_holds(self):
+        self.declared_in_oscar()
+
+        response = self.client.get(reverse("gap_reports"))
+
+        counted = {
+            summary.slug: summary.count for summary in response.context["summaries"]
+        }
+        self.assertEqual(counted["declared-but-silent"], 1)
+
+    def test_every_report_renders_what_it_found(self):
+        self.a_finding_for_every_report()
+
+        for report in GAP_REPORTS:
+            with self.subTest(slug=report.slug):
+                response = self.client.get(reverse("gap_report", args=[report.slug]))
+
+                self.assertEqual(response.status_code, 200)
+                self.assertEqual(response.context["page_obj"].paginator.count, 1)
+
+    def test_every_report_renders_with_nothing_to_show(self):
+        for report in GAP_REPORTS:
+            with self.subTest(slug=report.slug):
+                response = self.client.get(reverse("gap_report", args=[report.slug]))
+
+                self.assertEqual(response.status_code, 200)
+
+    def test_a_report_names_the_entities_it_found(self):
+        """A count would not be a finding anybody could act on."""
+        self.declared_in_oscar()
+
+        response = self.client.get(
+            reverse("gap_report", args=["declared-but-silent"])
+        )
+
+        self.assertContains(response, "0-20000-0-63741")
+        self.assertContains(response, "Dagoretti")
+
+    def test_a_report_that_found_nothing_says_so(self):
+        response = self.client.get(reverse("gap_report", args=["declared-but-silent"]))
+
+        self.assertContains(response, "has been heard transmitting")
+
+    def test_a_report_nothing_is_called_is_not_found(self):
+        response = self.client.get(reverse("gap_report", args=["stations-i-invented"]))
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_the_overview_reaches_every_report(self):
+        """The table is what somebody has open when they start wondering."""
+        response = self.client.get(reverse("node_overview"))
+
+        for report in GAP_REPORTS:
+            with self.subTest(slug=report.slug):
+                self.assertContains(response, reverse("gap_report", args=[report.slug]))
 
 
 class DatasetAdminTests(TestCase):

--- a/wis2watch/src/wis2watch/core/tests/test_gaps.py
+++ b/wis2watch/src/wis2watch/core/tests/test_gaps.py
@@ -1,0 +1,584 @@
+"""The gap reports, against a seeded database.
+
+These are the findings nobody asked for, so the way they fail is by being
+unreadable rather than by raising: a declared-but-silent report full of
+stations closed a decade ago, a propagation report full of gaps that exist
+only because this tool stopped listening, an unattributed rate that counts the
+same publication once per vantage point that saw it.
+
+What is seeded here is therefore the provenance combinations themselves --
+each of the three sources that can declare a station, present and absent in
+every combination that changes the answer -- and the two filters the reports
+would be useless without: OSCAR's operational status, and whether a centre's
+own broker was reachable at all when the gap was recorded.
+"""
+
+from datetime import timedelta
+
+from django.test import TestCase
+
+from wis2watch.core.analysis import (
+    GAP_REPORTS,
+    gap_report_summaries,
+    propagation_gaps,
+    stations_declared_but_silent,
+    stations_transmitting_undeclared,
+    unattributed_rates,
+    unregistered_centres,
+)
+from wis2watch.core.interpretation import OPERATIONAL
+from wis2watch.core.models import (
+    Dataset,
+    HourlyRollup,
+    MessageSource,
+    PropagationGap,
+    Station,
+    StationSource,
+    UnregisteredCentre,
+    WIS2Node,
+)
+from wis2watch.core.tests.support import at, origin_broker
+
+
+NOW = at("2026-08-11T12:00:00")
+
+
+class GapReportTestCase(TestCase):
+    def setUp(self):
+        self.global_broker = MessageSource.objects.create(
+            name="Global Broker",
+            source_type=MessageSource.GLOBAL_BROKER,
+            host="globalbroker.example.int",
+        )
+        self.kenya = self.node("ke-meteo")
+
+    def node(self, centre_id):
+        return WIS2Node.objects.create(centre_id=centre_id, name=centre_id.upper())
+
+    def station(self, wigos_id, **kwargs):
+        station, _ = Station.objects.get_or_create(wigos_id=wigos_id, defaults=kwargs)
+
+        return station
+
+    def in_oscar(self, wigos_id, *, status=OPERATIONAL, **kwargs):
+        """A station the country officially declares, as OSCAR reports it."""
+        station = self.station(wigos_id, operating_status=status, **kwargs)
+
+        StationSource.objects.create(
+            station=station,
+            source_type=StationSource.OSCAR,
+        )
+
+        return station
+
+    def in_registry(self, wigos_id, *, node=None, local_name=""):
+        """A station the node's own registry declares."""
+        station = self.station(wigos_id)
+
+        StationSource.objects.create(
+            station=station,
+            source_type=StationSource.NODE_REGISTRY,
+            node=self.kenya if node is None else node,
+            local_name=local_name,
+        )
+
+        return station
+
+    def transmitted(self, wigos_id, *, node=None, hours_ago=1):
+        """A station heard transmitting under a centre's topics."""
+        station = self.station(wigos_id)
+
+        StationSource.objects.create(
+            station=station,
+            source_type=StationSource.OBSERVED,
+            node=self.kenya if node is None else node,
+            last_seen=NOW - timedelta(hours=hours_ago),
+        )
+
+        return station
+
+
+class DeclaredButSilentTests(GapReportTestCase):
+    """Stations a country declares to the world that have never been heard."""
+
+    def report(self):
+        return stations_declared_but_silent(now=NOW)
+
+    def wigos_ids(self):
+        return [row.wigos_id for row in self.report()]
+
+    def test_an_operational_station_never_heard_from_is_reported(self):
+        self.in_oscar("0-20000-0-63741", name="Dagoretti", territory="KEN")
+
+        (row,) = self.report()
+
+        self.assertEqual(row.wigos_id, "0-20000-0-63741")
+        self.assertEqual(row.name, "Dagoretti")
+        self.assertEqual(row.territory, "KEN")
+
+    def test_a_station_that_has_transmitted_is_not_reported(self):
+        self.in_oscar("0-20000-0-63741")
+        self.transmitted("0-20000-0-63741")
+
+        self.assertEqual(self.wigos_ids(), [])
+
+    def test_a_station_that_transmitted_long_ago_is_not_reported(self):
+        """This report is about never, not about lately.
+
+        A station that stopped in March is the node detail page's finding, and
+        naming it here as well would report one fault twice under two names.
+        """
+        self.in_oscar("0-20000-0-63741")
+        self.transmitted("0-20000-0-63741", hours_ago=24 * 200)
+
+        self.assertEqual(self.wigos_ids(), [])
+
+    def test_a_station_oscar_does_not_call_operational_is_not_reported(self):
+        for status in ("partlyOperational", "closed", "unknown", ""):
+            with self.subTest(status=status):
+                Station.objects.all().delete()
+                self.in_oscar("0-20000-0-63741", status=status)
+
+                self.assertEqual(self.wigos_ids(), [])
+
+    def test_a_station_only_the_node_registry_declares_is_not_reported(self):
+        """OSCAR is what this report is about: it is the official declaration."""
+        self.in_registry("0-20000-0-63741")
+
+        self.assertEqual(self.wigos_ids(), [])
+
+    def test_the_centre_whose_registry_also_declares_it_is_named(self):
+        """Two different conversations, so the row says which one to have.
+
+        A station its own centre knows about and never transmits is a centre to
+        ask; a station nobody but OSCAR has heard of is a registration to
+        correct.
+        """
+        self.in_oscar("0-20000-0-63741")
+        self.in_registry("0-20000-0-63741")
+
+        (row,) = self.report()
+
+        self.assertEqual(row.registry_centre_id, "ke-meteo")
+
+    def test_a_station_two_centres_declare_names_the_same_one_every_time(self):
+        """An answer that changes between readings is not one anybody can act on."""
+        self.in_oscar("0-20000-0-63741")
+        self.in_registry("0-20000-0-63741", node=self.node("ug-unma"))
+        self.in_registry("0-20000-0-63741")
+
+        for _reading in range(2):
+            (row,) = self.report()
+
+            self.assertEqual(row.registry_centre_id, "ke-meteo")
+
+    def test_a_station_no_centre_declares_carries_no_centre(self):
+        self.in_oscar("0-20000-0-63741")
+
+        (row,) = self.report()
+
+        self.assertEqual(row.registry_centre_id, "")
+
+    def test_the_report_reads_by_territory_and_then_by_name(self):
+        self.in_oscar("0-20000-0-63741", name="Wilson", territory="KEN")
+        self.in_oscar("0-20000-0-63737", name="Dagoretti", territory="KEN")
+        self.in_oscar("0-20000-0-63125", name="Entebbe", territory="UGA")
+
+        self.assertEqual(
+            [row.name for row in self.report()], ["Dagoretti", "Wilson", "Entebbe"]
+        )
+
+
+class TransmittingUndeclaredTests(GapReportTestCase):
+    """Stations the world is hearing from that no registry admits to."""
+
+    def report(self):
+        return stations_transmitting_undeclared(now=NOW)
+
+    def wigos_ids(self):
+        return [row.wigos_id for row in self.report()]
+
+    def test_a_station_declared_nowhere_is_reported_with_its_centre(self):
+        self.transmitted("0-20000-0-63741", hours_ago=3)
+
+        (row,) = self.report()
+
+        self.assertEqual(row.wigos_id, "0-20000-0-63741")
+        self.assertEqual(row.centre_id, "ke-meteo")
+        self.assertEqual(row.last_transmitted, NOW - timedelta(hours=3))
+        self.assertEqual(row.hours_quiet, 3)
+
+    def test_a_station_oscar_declares_is_not_reported(self):
+        self.in_oscar("0-20000-0-63741")
+        self.transmitted("0-20000-0-63741")
+
+        self.assertEqual(self.wigos_ids(), [])
+
+    def test_a_station_its_own_centre_declares_is_not_reported(self):
+        self.in_registry("0-20000-0-63741")
+        self.transmitted("0-20000-0-63741")
+
+        self.assertEqual(self.wigos_ids(), [])
+
+    def test_a_station_another_centre_declares_is_not_reported(self):
+        """Declared anywhere is declared: the registration gap is closed."""
+        uganda = self.node("ug-unma")
+        self.in_registry("0-20000-0-63741", node=uganda)
+        self.transmitted("0-20000-0-63741")
+
+        self.assertEqual(self.wigos_ids(), [])
+
+    def test_a_station_transmitting_under_two_centres_is_reported_for_each(self):
+        """One station, two findings: each centre has its own registration to fix."""
+        uganda = self.node("ug-unma")
+        self.transmitted("0-20000-0-63741")
+        self.transmitted("0-20000-0-63741", node=uganda)
+
+        self.assertEqual(
+            sorted(row.centre_id for row in self.report()), ["ke-meteo", "ug-unma"]
+        )
+
+    def test_a_station_transmitting_under_no_registered_centre_is_still_reported(self):
+        """A centre with no catalogue record still has stations.
+
+        Dropping them would hide the traffic most worth asking about: a centre
+        nobody registered, transmitting for stations nobody declared.
+        """
+        station = self.station("0-20000-0-63741")
+        StationSource.objects.create(
+            station=station,
+            source_type=StationSource.OBSERVED,
+            node=None,
+            last_seen=NOW,
+        )
+
+        (row,) = self.report()
+
+        self.assertEqual(row.wigos_id, "0-20000-0-63741")
+        self.assertEqual(row.centre_id, "")
+
+    def test_the_report_reads_by_centre_and_then_by_identifier(self):
+        uganda = self.node("ug-unma")
+        self.transmitted("0-20000-0-63741")
+        self.transmitted("0-20000-0-63737")
+        self.transmitted("0-20000-0-63125", node=uganda)
+
+        self.assertEqual(
+            [(row.centre_id, row.wigos_id) for row in self.report()],
+            [
+                ("ke-meteo", "0-20000-0-63737"),
+                ("ke-meteo", "0-20000-0-63741"),
+                ("ug-unma", "0-20000-0-63125"),
+            ],
+        )
+
+
+class PropagationGapTests(GapReportTestCase):
+    """Notifications a centre published that the world never received."""
+
+    def report(self):
+        return propagation_gaps(now=NOW)
+
+    def gap(
+        self,
+        node=None,
+        *,
+        notification_id="d9a1",
+        hours_ago=2,
+        resolved=False,
+        dataset=None,
+    ):
+        node = node or self.kenya
+
+        return PropagationGap.objects.create(
+            node=node,
+            origin_source=node.origin_source,
+            dataset=dataset,
+            notification_id=notification_id,
+            topic=f"origin/a/wis2/{node.centre_id}/data/core/weather/surface-based-observations/synop",
+            published_at=NOW - timedelta(hours=hours_ago),
+            observed_at_origin=NOW - timedelta(hours=hours_ago),
+            detected_at=NOW - timedelta(hours=hours_ago) + timedelta(minutes=20),
+            resolved_at=NOW if resolved else None,
+        )
+
+    def test_an_open_gap_at_a_reachable_centre_names_the_notification(self):
+        origin_broker(self.kenya, is_reachable=True)
+        self.gap(notification_id="d9a1", hours_ago=2)
+
+        (row,) = self.report()
+
+        self.assertEqual(row.centre_id, "ke-meteo")
+        self.assertEqual(row.notification_id, "d9a1")
+        self.assertIn("synop", row.topic)
+        self.assertEqual(row.published_at, NOW - timedelta(hours=2))
+        self.assertEqual(row.hours_missing, 2)
+
+    def test_a_gap_the_world_has_since_carried_is_not_reported(self):
+        origin_broker(self.kenya, is_reachable=True)
+        self.gap(resolved=True)
+
+        self.assertEqual(self.report(), [])
+
+    def test_gaps_at_a_centre_whose_own_broker_is_unreachable_are_not_reported(self):
+        """The tool's blind spot is not the centre's loss.
+
+        A broker that has gone dark since the gaps were recorded makes every
+        one of them unverifiable, and reporting them anyway sends somebody to a
+        centre to ask about messages this tool may simply have stopped seeing.
+        """
+        origin_broker(self.kenya, is_reachable=False)
+        self.gap()
+
+        self.assertEqual(self.report(), [])
+
+    def test_gaps_at_a_centre_whose_broker_has_not_been_dialled_are_not_reported(self):
+        origin_broker(self.kenya)
+        self.gap()
+
+        self.assertEqual(self.report(), [])
+
+    def test_gaps_at_a_centre_whose_broker_is_switched_off_are_not_reported(self):
+        origin_broker(self.kenya, is_reachable=True, is_active=False)
+        self.gap()
+
+        self.assertEqual(self.report(), [])
+
+    def test_gaps_at_a_centre_with_no_broker_of_its_own_are_not_reported(self):
+        self.gap()
+
+        self.assertEqual(self.report(), [])
+
+    def test_the_report_reads_newest_first(self):
+        origin_broker(self.kenya, is_reachable=True)
+        self.gap(notification_id="older", hours_ago=6)
+        self.gap(notification_id="newer", hours_ago=1)
+
+        self.assertEqual(
+            [row.notification_id for row in self.report()], ["newer", "older"]
+        )
+
+    def test_a_gap_names_the_dataset_where_the_registry_knows_one(self):
+        origin_broker(self.kenya, is_reachable=True)
+        dataset = Dataset.objects.create(
+            node=self.kenya,
+            identifier="urn:wmo:md:ke-meteo:synop",
+            title="Kenya SYNOP",
+            wmo_data_policy=Dataset.CORE,
+            wmo_topic_hierarchy="origin/a/wis2/ke-meteo/data/core/synop",
+            raw_json={},
+        )
+        self.gap(dataset=dataset)
+
+        (row,) = self.report()
+
+        self.assertEqual(row.dataset_title, "Kenya SYNOP")
+
+
+class UnregisteredCentreTests(GapReportTestCase):
+    """Centres of the region publishing that no catalogue has indexed."""
+
+    def report(self):
+        return unregistered_centres(now=NOW)
+
+    def seen(self, centre_id, *, first_seen_hours_ago=48, registered=False):
+        return UnregisteredCentre.objects.create(
+            centre_id=centre_id,
+            country=centre_id[:2].upper(),
+            sample_topic=f"origin/a/wis2/{centre_id}/data/core/synop",
+            first_seen_at=NOW - timedelta(hours=first_seen_hours_ago),
+            last_seen_at=NOW - timedelta(hours=1),
+            registered_at=NOW if registered else None,
+        )
+
+    def test_a_centre_the_registry_does_not_know_is_reported(self):
+        self.seen("ml-meteo", first_seen_hours_ago=48)
+
+        (row,) = self.report()
+
+        self.assertEqual(row.centre_id, "ml-meteo")
+        self.assertEqual(row.country_name, "Mali")
+        self.assertIn("ml-meteo", row.sample_topic)
+        self.assertEqual(row.hours_unregistered, 48)
+
+    def test_a_centre_the_registry_has_caught_up_with_is_not_reported(self):
+        self.seen("ml-meteo", registered=True)
+
+        self.assertEqual(self.report(), [])
+
+    def test_the_report_reads_longest_unregistered_first(self):
+        self.seen("ml-meteo", first_seen_hours_ago=10)
+        self.seen("td-meteo", first_seen_hours_ago=200)
+
+        self.assertEqual(
+            [row.centre_id for row in self.report()], ["td-meteo", "ml-meteo"]
+        )
+
+
+class UnattributedRateTests(GapReportTestCase):
+    """Which centres publish without saying which station the data came from."""
+
+    def report(self, **kwargs):
+        kwargs.setdefault("now", NOW)
+        return unattributed_rates(**kwargs)
+
+    def by_centre(self, **kwargs):
+        return {row.centre_id: row for row in self.report(**kwargs)}
+
+    def rollup(self, node=None, *, hours_ago=1, count=1, station=None, source=None):
+        return HourlyRollup.objects.create(
+            hour=NOW.replace(minute=0, second=0, microsecond=0)
+            - timedelta(hours=hours_ago),
+            source=source or self.global_broker,
+            node=node or self.kenya,
+            station=station,
+            message_count=count,
+        )
+
+    def test_a_centre_naming_no_station_is_reported_at_the_full_rate(self):
+        self.rollup(count=8)
+
+        (row,) = self.report()
+
+        self.assertEqual(row.centre_id, "ke-meteo")
+        self.assertEqual(row.message_count, 8)
+        self.assertEqual(row.unattributed_count, 8)
+        self.assertEqual(row.rate, 1)
+
+    def test_a_centre_naming_every_station_is_reported_at_no_rate(self):
+        self.rollup(count=8, station=self.station("0-20000-0-63741"))
+
+        (row,) = self.report()
+
+        self.assertEqual(row.unattributed_count, 0)
+        self.assertEqual(row.rate, 0)
+
+    def test_the_rate_is_the_share_of_messages_carrying_no_station(self):
+        self.rollup(count=3)
+        self.rollup(count=1, station=self.station("0-20000-0-63741"))
+
+        (row,) = self.report()
+
+        self.assertEqual(row.message_count, 4)
+        self.assertEqual(row.unattributed_count, 3)
+        self.assertEqual(row.rate, 0.75)
+        self.assertEqual(row.percent, 75)
+
+    def test_only_what_the_world_saw_is_counted(self):
+        """One publication is one message, however many vantage points saw it.
+
+        The same notification is observed at the centre's own broker and again
+        on every cache that carried it, so counting them all would report a
+        healthy centre's traffic several times over.
+        """
+        origin = origin_broker(self.kenya)
+        cache = MessageSource.objects.create(
+            name="Global Cache",
+            source_type=MessageSource.GLOBAL_CACHE,
+            host="cache.example.int",
+        )
+        self.rollup(count=2)
+        self.rollup(count=2, source=origin)
+        self.rollup(count=2, source=cache)
+
+        (row,) = self.report()
+
+        self.assertEqual(row.message_count, 2)
+
+    def test_traffic_older_than_the_window_is_not_counted(self):
+        self.rollup(count=5, hours_ago=1)
+        self.rollup(count=100, hours_ago=500)
+
+        (row,) = self.report(window_hours=24)
+
+        self.assertEqual(row.message_count, 5)
+
+    def test_a_centre_with_no_traffic_in_the_window_is_absent(self):
+        """There is no rate to report of a centre that published nothing.
+
+        A centre that has gone quiet is the overview's finding; reporting it
+        here at nought per cent would read as a centre doing this right.
+        """
+        self.node("dj-anm")
+        self.rollup(count=1)
+
+        self.assertEqual(list(self.by_centre()), ["ke-meteo"])
+
+    def test_the_report_reads_worst_rate_first(self):
+        uganda = self.node("ug-unma")
+        self.rollup(count=4, station=self.station("0-20000-0-63741"))
+        self.rollup(node=uganda, count=4)
+
+        self.assertEqual(
+            [row.centre_id for row in self.report()], ["ug-unma", "ke-meteo"]
+        )
+
+    def test_a_centre_carries_the_country_it_is_registered_under(self):
+        self.rollup(count=1)
+
+        (row,) = self.report()
+
+        self.assertEqual(row.country_name, "Kenya")
+
+
+class GapReportSummaryTests(GapReportTestCase):
+    """The index that says which of the five is worth opening."""
+
+    def test_every_report_is_summarised(self):
+        self.assertEqual(
+            [summary.slug for summary in gap_report_summaries(now=NOW)],
+            [report.slug for report in GAP_REPORTS],
+        )
+
+    def test_a_summary_counts_what_its_report_would_list(self):
+        self.in_oscar("0-20000-0-63741")
+        self.in_oscar("0-20000-0-63737")
+        self.transmitted("0-20000-0-63125")
+
+        counts = {
+            summary.slug: summary.count for summary in gap_report_summaries(now=NOW)
+        }
+
+        self.assertEqual(counts["declared-but-silent"], 2)
+        self.assertEqual(counts["transmitting-undeclared"], 1)
+        self.assertEqual(counts["propagation-gaps"], 0)
+
+    def test_the_unattributed_summary_counts_the_centres_with_something_to_answer_for(
+        self,
+    ):
+        """Not the rows it lists, which are every centre publishing.
+
+        An index promising findings that turn out to be centres doing it right
+        is an index that stops being read.
+        """
+        attributing = self.node("ug-unma")
+        HourlyRollup.objects.create(
+            hour=NOW.replace(minute=0, second=0, microsecond=0),
+            source=self.global_broker,
+            node=self.kenya,
+            message_count=4,
+        )
+        HourlyRollup.objects.create(
+            hour=NOW.replace(minute=0, second=0, microsecond=0),
+            source=self.global_broker,
+            node=attributing,
+            station=self.station("0-20000-0-63741"),
+            message_count=4,
+        )
+
+        counts = {
+            summary.slug: summary.count for summary in gap_report_summaries(now=NOW)
+        }
+
+        self.assertEqual(counts["unattributed-messages"], 1)
+        self.assertEqual(len(unattributed_rates(now=NOW)), 2)
+
+    def test_a_summary_carries_what_the_report_is_for(self):
+        (summary,) = [
+            summary
+            for summary in gap_report_summaries(now=NOW)
+            if summary.slug == "declared-but-silent"
+        ]
+
+        self.assertTrue(summary.title)
+        self.assertTrue(summary.description)

--- a/wis2watch/src/wis2watch/core/views.py
+++ b/wis2watch/src/wis2watch/core/views.py
@@ -1,18 +1,33 @@
 import csv
 from io import StringIO
 
-from django.http import HttpResponse
+from django.http import Http404, HttpResponse
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse_lazy
 from django.utils.translation import gettext as _
 from wagtail.admin import messages
+from wagtail.admin.paginator import WagtailPaginator
 
-from .analysis import Staleness, default_volume_hours, node_detail, node_overview
+from .analysis import (
+    GAP_REPORTS,
+    Staleness,
+    default_attribution_window_hours,
+    default_volume_hours,
+    gap_report,
+    gap_report_summaries,
+    node_detail,
+    node_overview,
+)
 from .forms import SyncNodeForm
 from .models import SyncLog, WIS2Node
 from .node_stations import sync_node_stations
 from .stations import node_stations_as_csv
 from .viewsets import WIS2NodeViewSet
+
+#: How many findings one page of a gap report shows. A report is bounded by
+#: its filters rather than by truncation -- everything it found is reachable by
+#: paging -- so this is only about how much of it arrives at once.
+GAP_REPORT_PAGE_SIZE = 50
 
 
 def node_overview_table(request):
@@ -38,9 +53,87 @@ def node_overview_table(request):
         "staleness": staleness,
         "order": order,
         "staleness_choices": Staleness.CHOICES,
+        # Named here rather than only on their own index, because a report
+        # nobody arrives at reports nothing: this table is what somebody has
+        # open when they start wondering what else is wrong.
+        "gap_reports": GAP_REPORTS,
     }
 
     return render(request, 'wis2watchcore/node_overview.html', context)
+
+
+def gap_report_index(request):
+    """Which of the gap reports is worth opening, and what each one finds.
+
+    Counts rather than findings: the index exists to point at a report, and
+    reading five reports in full to show five numbers would make the cheapest
+    page in the tool the most expensive.
+    """
+    context = {
+        "breadcrumbs_items": [
+            {"url": reverse_lazy("wagtailadmin_home"), "label": _("Home")},
+            # The leaf carries no URL at all rather than an empty one, which
+            # the breadcrumbs component renders as a link to the page you are
+            # already on.
+            {"url": None, "label": _("Gap reports")},
+        ],
+        "header_title": _("Gap reports"),
+        "header_icon": "warning",
+        "summaries": gap_report_summaries(),
+        "overview_url": reverse_lazy("node_overview"),
+    }
+
+    return render(request, 'wis2watchcore/gap_reports.html', context)
+
+
+def gap_report_table(request, slug):
+    """One gap report, in full, a page at a time.
+
+    Args:
+        request: HTTP request object.
+        slug (str): which of the reports to show.
+
+    Returns:
+        HttpResponse: the report's findings, rendered.
+    """
+    report = gap_report(slug)
+
+    if report is None:
+        raise Http404(f"no gap report is called {slug}")
+
+    findings = report.find_rows()
+    paginator = WagtailPaginator(findings, GAP_REPORT_PAGE_SIZE)
+    page = paginator.get_page(request.GET.get("p"))
+
+    context = {
+        "breadcrumbs_items": [
+            {"url": reverse_lazy("wagtailadmin_home"), "label": _("Home")},
+            {"url": reverse_lazy("gap_reports"), "label": _("Gap reports")},
+            {"url": None, "label": report.title},
+        ],
+        "header_title": report.title,
+        "header_icon": "warning",
+        "report": report,
+        "rows": page,
+        "page_obj": page,
+        "elided_page_range": paginator.get_elided_page_range(page.number),
+        # Carried for every report though only the unattributed one quotes it:
+        # its note has to say what window the share was worked out over, and a
+        # share whose window is unstated is a number nobody can check.
+        "attribution_hours": default_attribution_window_hours(),
+    }
+
+    return render(request, _gap_report_template(slug), context)
+
+
+def _gap_report_template(slug):
+    """The template one report's findings are laid out by.
+
+    Named after the report rather than mapped to it, because every report has
+    columns of its own and a mapping kept beside the reports is one more place
+    to forget when a sixth is added.
+    """
+    return f"wis2watchcore/gap_reports/{slug.replace('-', '_')}.html"
 
 
 def preview_node_stations_csv(request, node_id):

--- a/wis2watch/src/wis2watch/core/wagtail_hooks.py
+++ b/wis2watch/src/wis2watch/core/wagtail_hooks.py
@@ -5,6 +5,8 @@ from wagtail.snippets.models import register_snippet
 
 from wis2watch.core.viewsets import DatasetViewSet, admin_viewsets
 from .views import (
+    gap_report_index,
+    gap_report_table,
     get_node_stations_as_csv,
     node_details,
     node_overview_table,
@@ -16,6 +18,8 @@ from .views import (
 def urlconf_wis2watch():
     return [
         path("node-overview/", node_overview_table, name="node_overview"),
+        path("gap-reports/", gap_report_index, name="gap_reports"),
+        path("gap-reports/<slug:slug>/", gap_report_table, name="gap_report"),
         path("node-detail/<int:node_id>/", node_details, name="node_details"),
         path('node/<int:node_id>/stations/preview/', preview_node_stations_csv,
              name='preview_node_stations_csv'),
@@ -41,6 +45,17 @@ def construct_homepage_summary_items(request, summary_items):
 def register_overview_menu_item():
     """The headline table comes first: it is what someone opens the tool for."""
     return MenuItem('Overview', reverse('node_overview'), icon_name='list-ul', order=90)
+
+
+@hooks.register('register_admin_menu_item')
+def register_gap_reports_menu_item():
+    """Next to the overview, because it answers what the overview cannot.
+
+    The overview says how the centres somebody registered are doing. These say
+    what is missing from that picture entirely -- and a report reachable only
+    from a page you had to know to look at is one nobody reads.
+    """
+    return MenuItem('Gap reports', reverse('gap_reports'), icon_name='warning', order=91)
 
 
 @hooks.register("register_admin_viewset")


### PR DESCRIPTION
Closes #16.

The findings engine: five reports that surface problems nobody thought to look for, plus the index that says which one is worth opening.

## The five reports

| Report | What it finds |
| --- | --- |
| Declared but silent | Stations OSCAR/Surface calls operational that have never once been heard transmitting |
| Transmitting but undeclared | Stations being heard from that neither OSCAR nor any centre's own registry declares — one row per transmitting centre, since each has its own registration to close |
| Propagation gaps | Notifications seen at a centre's own broker that the Global Broker never carried, excluding centres whose broker cannot currently be reached |
| Unregistered centres | Centres of the region publishing with no discovery catalogue record, as the wildcard sweep found them |
| Unattributed messages | Each publishing centre's share of Global Broker traffic carrying no WIGOS station identifier |

Every row is a named entity rather than a count: a WIGOS identifier, a territory and the centre that ought to know about it is a conversation somebody can have, and "seventeen stations are silent" is not.

Two filters do the work that keeps them readable. OSCAR is notoriously stale, so only stations it still reports as fully operational count as declared. And a centre whose own broker has gone dark has its gaps withheld, because a gap recorded while the broker answered and read after it stopped cannot be told from this tool having stopped listening.

## Surfaces

- A **Gap reports** index with a count per report, reached from its own menu item and from the overview.
- A page per report at `/gap-reports/<slug>/`, all sharing one base template, paginated at 50.
- The overview links each report directly, so every one of them is reachable from the screen somebody has open when they start wondering what else is wrong.

## Shared definitions rather than second copies

- `MessageSourceQuerySet.watched_origins()` now decides which origin brokers may be judged on. The propagation evaluation and the report that lists its gaps ask it the same way, so a centre's gaps cannot appear on a page the evaluation had already decided it could not judge.
- `rollups.window_start()` holds the whole-bucket window rule, which the overview's volume column and the new attribution window both read.
- New setting `WIS2WATCH_ATTRIBUTION_WINDOW_HOURS` (default 168h). Wider than the overview's 24h on purpose: a share needs enough messages behind it to mean anything.

## Tests

38 new findings tests against a seeded database, covering all three provenance sources in every combination that changes the answer, the operational-status filter across `partlyOperational` / `closed` / `unknown` / blank, reachability suppression for propagation gaps, and the vantage-point double counting that would otherwise shrink every share. Plus view tests that render every report both with a finding and with nothing to show. Full suite: 781 passing.

## Left deliberately

- The unattributed card counts centres **with** unattributed messages while the page lists every publishing centre — said plainly in the card's own description. The alternative was a card promising findings that turn out to be centres doing it right.
- The OSCAR "record not updated in several years" lever: #16 makes it conditional on the operational filter proving insufficient, and the schema holds no OSCAR-update timestamp.
- `PropagationGap.objects.open()` has no horizon, so gaps whose evidence has expired can never resolve and accumulate. Pre-existing from #8; worth its own issue.