### PR TITLE
Ask the centre where it says its own files are

### DIFF
--- a/wis2watch/src/wis2watch/core/catalogue.py
+++ b/wis2watch/src/wis2watch/core/catalogue.py
@@ -48,6 +48,12 @@ PAGE_SIZE = 500
 
 FETCH_TIMEOUT = 60
 
+#: What :meth:`WIS2Node.save` works out from a base URL. Named alongside it
+#: wherever it is written, because an ``update_fields`` naming the base URL
+#: alone would drop them -- and the station registry URL is the whole reason
+#: the base URL is worth learning.
+DERIVED_FROM_BASE_URL = ("discovery_metadata_url", "stations_url")
+
 
 def discovery_metadata_url(catalogue):
     """Where a catalogue serves its discovery metadata records."""
@@ -68,11 +74,38 @@ def fetch_discovery_pages(catalogue):
     )
 
 
+def _fill_base_url(node, base_url):
+    """Give a node the address its own records point at, where it has none.
+
+    Nothing else ever learns it. Without a base URL a node has no station
+    registry URL either, and the sync that asks every centre what stations it
+    declares passes over it in silence -- so a centre reads as declaring
+    nothing when nobody has asked it.
+
+    Filled once and never written over. The address is an inference from where
+    a centre serves its metadata rather than something the catalogue states, so
+    it is offered where there is nothing and withdrawn in favour of anything a
+    later run or an operator has put there. A record advertising no address
+    leaves what is there alone, in the way a record advertising no broker does:
+    most centres carry a canonical link on some of their records and not
+    others, and absence in one is not evidence about the centre.
+    """
+    if not base_url or node.base_url:
+        return
+
+    node.base_url = base_url
+    node.save(update_fields=["base_url", *DERIVED_FROM_BASE_URL, "modified"])
+
+
 def _apply_node(discovered):
     """The node a record belongs to, created or refreshed."""
     node, created = WIS2Node.objects.get_or_create(
         centre_id=discovered.centre_id,
-        defaults={"name": discovered.centre_id, "country": discovered.country},
+        defaults={
+            "name": discovered.centre_id,
+            "country": discovered.country,
+            "base_url": discovered.base_url,
+        },
     )
 
     if created or node.is_manually_managed:
@@ -81,6 +114,8 @@ def _apply_node(discovered):
     if discovered.country and node.country != discovered.country:
         node.country = discovered.country
         node.save(update_fields=["country", "modified"])
+
+    _fill_base_url(node, discovered.base_url)
 
     return node
 

--- a/wis2watch/src/wis2watch/core/interpretation/discovery.py
+++ b/wis2watch/src/wis2watch/core/interpretation/discovery.py
@@ -14,10 +14,15 @@ is looser than WCMP2 suggests, so every rule here is a response to real data:
   and plenty of records advertise no such link at all.
 - Some records carry no topic anywhere. Nothing can be monitored from them, so
   they are skipped.
+- No record says where the node's own API lives, but its ``canonical`` link
+  names a file on the node's own host. That host is the only thing a catalogue
+  offers about where to ask a centre directly, so it is read here as the node's
+  base URL.
 """
 
 from dataclasses import dataclass
 from datetime import datetime
+from urllib.parse import urlsplit
 
 from ..countries import monitored_country_code_for_centre_id
 from .brokers import BrokerConnection, parse_broker_url
@@ -30,13 +35,25 @@ IDENTIFIER_PREFIX = ("urn", "wmo", "md")
 #: How a catalogue titles the notification links it adds for Global Brokers.
 GLOBAL_BROKER_MARKER = "global broker"
 
+#: The URL schemes a node's own web presence is served over. A ``canonical``
+#: link is occasionally something else -- a broker, a DOI -- and a scheme and
+#: host taken from one of those would name a host nothing can be asked of.
+WEB_SCHEMES = ("http", "https")
+
 
 @dataclass(frozen=True)
 class DiscoveredNode:
-    """The publishing centre a discovery record belongs to."""
+    """The publishing centre a discovery record belongs to.
+
+    ``base_url`` is where the centre's own API is expected to answer, and is
+    empty for a record that advertises no canonical link -- which is normal
+    rather than a fault, since a centre indexed by several records commonly
+    carries one on only some of them.
+    """
 
     centre_id: str
     country: str
+    base_url: str = ""
 
     @property
     def is_monitored(self):
@@ -131,6 +148,32 @@ def _link_href(feature, rel):
     return ""
 
 
+def _node_base_url(feature):
+    """Where the node's own API is, read from its canonical link, or empty.
+
+    A canonical link points at the metadata file on the centre's own host --
+    ``https://wis2.meteo.sc/data/metadata/urn:wmo:md:....json`` -- so the scheme
+    and host of it are the node itself. Only those two are kept: what follows is
+    the file's place in the centre's public tree and says nothing about where
+    its API answers.
+
+    A record may carry more than one canonical link, and the first is taken.
+    Where a centre advertises several they name one host between them; taking
+    the first is what keeps the reading from depending on the order a catalogue
+    happens to return links in.
+    """
+    for link in feature.get("links", []) or []:
+        if link.get("rel") != "canonical":
+            continue
+
+        parts = urlsplit((link.get("href") or "").strip())
+
+        if parts.scheme in WEB_SCHEMES and parts.netloc:
+            return f"{parts.scheme}://{parts.netloc}"
+
+    return ""
+
+
 def extract_discovery_record(feature):
     """A discovery metadata feature as a node and dataset, or None to skip it.
 
@@ -161,6 +204,7 @@ def extract_discovery_record(feature):
         node=DiscoveredNode(
             centre_id=centre_id,
             country=monitored_country_code_for_centre_id(centre_id),
+            base_url=_node_base_url(feature),
         ),
         dataset=DiscoveredDataset(
             identifier=identifier,

--- a/wis2watch/src/wis2watch/core/tests/fixtures/gdc_discovery_metadata.json
+++ b/wis2watch/src/wis2watch/core/tests/fixtures/gdc_discovery_metadata.json
@@ -1384,10 +1384,176 @@
      "sampleRequest": "https://fleetmonitoring.euro-argo.eu/dashboard?Status=Active&Variable=OXYGEN"
     }
    ]
+  },
+  {
+   "id": "urn:wmo:md:tg-anamet:core.surface-based-observations.synop",
+   "conformsTo": [
+    "http://wis.wmo.int/spec/wcmp/2/conf/core"
+   ],
+   "type": "Feature",
+   "time": {
+    "interval": [
+     "2025-11-10",
+     ".."
+    ]
+   },
+   "geometry": {
+    "type": "Polygon",
+    "coordinates": [
+     [
+      [
+       -0.05,
+       5.93
+      ],
+      [
+       -0.05,
+       11.02
+      ],
+      [
+       1.87,
+       11.02
+      ],
+      [
+       1.87,
+       5.93
+      ],
+      [
+       -0.05,
+       5.93
+      ]
+     ]
+    ]
+   },
+   "properties": {
+    "identifier": "urn:wmo:md:tg-anamet:core.surface-based-observations.synop",
+    "title": "Hourly synoptic observations from fixed-land stations (SYNOP) (tg-anamet)",
+    "description": "3-Hourly synoptic observations from Togo fixed-land stations",
+    "themes": [
+     {
+      "concepts": [
+       {
+        "id": "weather"
+       }
+      ],
+      "scheme": "https://codes.wmo.int/wis/topic-hierarchy/earth-system-discipline"
+     }
+    ],
+    "type": "dataset",
+    "created": "2025-11-10T00:00:00Z",
+    "updated": "2025-12-25T10:30:14Z",
+    "contacts": [
+     {
+      "addresses": [
+       {
+        "country": "TGO"
+       }
+      ],
+      "roles": [
+       "host"
+      ],
+      "organization": "Agence Nationale de la Météorologie du TOGO (ANAMET)",
+      "emails": [
+       {
+        "value": "meteo_togo@yahoo.fr"
+       }
+      ],
+      "links": [
+       {
+        "rel": "canonical",
+        "type": "text/html",
+        "href": "https://meteotogo.tg"
+       }
+      ]
+     }
+    ],
+    "keywords": [
+     "observations",
+     "weather",
+     "synop"
+    ],
+    "wmo:dataPolicy": "core",
+    "id": "urn:wmo:md:tg-anamet:core.surface-based-observations.synop",
+    "centre-id": "tg-anamet"
+   },
+   "links": [
+    {
+     "href": "https://wis2.meteotogo.tg",
+     "type": "WWW:LINK",
+     "rel": "canonical",
+     "title": "WIS2BOX"
+    },
+    {
+     "href": "mqtts://everyone:everyone@gb.wis.cma.cn:8883",
+     "type": "application/geo+json",
+     "name": "origin/a/wis2/tg-anamet/data/core/weather/surface-based-observations/synop",
+     "rel": "items",
+     "channel": "cache/a/wis2/tg-anamet/data/core/weather/surface-based-observations/synop",
+     "filters": {
+      "wigos_station_identifier": {
+       "type": "string",
+       "title": "WIGOS Station Identifier",
+       "description": "Filter by WIGOS Station Identifier"
+      }
+     },
+     "title": "Notifications from China Meteorological Agency, Global Broker Service (cn-cma-global-broker)"
+    },
+    {
+     "href": "mqtts://everyone:everyone@globalbroker.meteo.fr:8883",
+     "type": "application/geo+json",
+     "name": "origin/a/wis2/tg-anamet/data/core/weather/surface-based-observations/synop",
+     "rel": "items",
+     "channel": "cache/a/wis2/tg-anamet/data/core/weather/surface-based-observations/synop",
+     "filters": {
+      "wigos_station_identifier": {
+       "type": "string",
+       "title": "WIGOS Station Identifier",
+       "description": "Filter by WIGOS Station Identifier"
+      }
+     },
+     "title": "Notifications from Météo-France, Global Broker Service (fr-meteofrance-global-broker)"
+    },
+    {
+     "href": "mqtts://everyone:everyone@globalbroker.inmet.gov.br:8883",
+     "type": "application/geo+json",
+     "name": "origin/a/wis2/tg-anamet/data/core/weather/surface-based-observations/synop",
+     "rel": "items",
+     "channel": "cache/a/wis2/tg-anamet/data/core/weather/surface-based-observations/synop",
+     "filters": {
+      "wigos_station_identifier": {
+       "type": "string",
+       "title": "WIGOS Station Identifier",
+       "description": "Filter by WIGOS Station Identifier"
+      }
+     },
+     "title": "Notifications from Instituto Nacional de Meteorologia (Brazil), Global Broker Service (br-inmet-global-broker)"
+    },
+    {
+     "href": "mqtts://everyone:everyone@wis2globalbroker.nws.noaa.gov:8883",
+     "type": "application/geo+json",
+     "name": "origin/a/wis2/tg-anamet/data/core/weather/surface-based-observations/synop",
+     "rel": "items",
+     "channel": "cache/a/wis2/tg-anamet/data/core/weather/surface-based-observations/synop",
+     "filters": {
+      "wigos_station_identifier": {
+       "type": "string",
+       "title": "WIGOS Station Identifier",
+       "description": "Filter by WIGOS Station Identifier"
+      }
+     },
+     "title": "Notifications from National Oceanic and Atmospheric Administration, National Weather Service, Global Broker Service (us-noaa-nws-global-broker)"
+    },
+    {
+     "href": "https://wis2.meteotogo.tg/data/metadata/urn:wmo:md:tg-anamet:core.surface-based-observations.synop.json",
+     "type": "application/geo+json",
+     "name": "urn:wmo:md:tg-anamet:core.surface-based-observations.synop",
+     "rel": "canonical",
+     "title": "urn:wmo:md:tg-anamet:core.surface-based-observations.synop"
+    }
+   ]
   }
  ],
- "numberMatched": 9,
- "numberReturned": 9,
+ "numberMatched": 10,
+ "numberReturned": 10,
  "links": [
   {
    "type": "application/geo+json",

--- a/wis2watch/src/wis2watch/core/tests/test_catalogue_sync.py
+++ b/wis2watch/src/wis2watch/core/tests/test_catalogue_sync.py
@@ -4,9 +4,10 @@ The sync runs against the committed GDC fixture rather than the network: the
 page fetch is an argument, so these tests exercise the writing rules against
 records the catalogue really returns.
 
-Of the fixture's nine records, seven are usable and four name a monitored
-centre -- ``ke-meteo``, ``cg-met``, ``sz-swazimet`` and ``gh-gmet``. Only
-``cg-met`` advertises a broker of its own.
+Of the fixture's ten records, eight are usable and five name a monitored
+centre -- ``ke-meteo``, ``cg-met``, ``sz-swazimet``, ``gh-gmet`` and
+``tg-anamet``. Only ``cg-met`` advertises a broker of its own, and only
+``ke-meteo`` and ``tg-anamet`` advertise an address of their own.
 """
 
 from io import StringIO
@@ -33,7 +34,7 @@ from .support import failing_fetch, load_json_fixture, pages
 
 CATALOGUE = "gdc_discovery_metadata.json"
 
-MONITORED_CENTRE_IDS = {"ke-meteo", "cg-met", "sz-swazimet", "gh-gmet"}
+MONITORED_CENTRE_IDS = {"ke-meteo", "cg-met", "sz-swazimet", "gh-gmet", "tg-anamet"}
 
 KE_DATASET = "urn:wmo:md:ke-meteo:synop-dataset-surface-observations"
 CG_DATASET = "urn:wmo:md:cg-met:core.climate.surface-based-observations.climat"
@@ -95,6 +96,7 @@ class WriterCatalogueTests(CatalogueSyncTestCase):
                 CG_DATASET,
                 "urn:wmo:md:sz-swazimet:surface-based-observations.synop",
                 "urn:wmo:md:gh-gmet:urn:wmo:md:gh-gmet:core.surface-based-observations.synop",
+                "urn:wmo:md:tg-anamet:core.surface-based-observations.synop",
             },
         )
 
@@ -145,6 +147,96 @@ class WriterCatalogueTests(CatalogueSyncTestCase):
         self.assertEqual(
             WIS2Node.objects.filter(centre_id__iexact="ke-meteo").count(), 1
         )
+
+
+class NodeAddressTests(CatalogueSyncTestCase):
+    """A node's own address, without which nothing can ask it anything.
+
+    The station registry URL is derived from it, and the sync that asks every
+    centre what stations it declares passes over a node that has none -- so a
+    centre with no address reads as declaring nothing, having never been asked.
+    """
+
+    def test_a_new_node_takes_the_address_its_records_point_at(self):
+        self.sync()
+
+        self.assertEqual(
+            WIS2Node.objects.get(centre_id="ke-meteo").base_url,
+            "http://wis.meteo.go.ke",
+        )
+
+    def test_the_address_gives_the_node_a_station_registry_to_ask(self):
+        self.sync()
+
+        self.assertEqual(
+            WIS2Node.objects.get(centre_id="ke-meteo").stations_url,
+            "http://wis.meteo.go.ke/oapi/collections/stations/items?f=json",
+        )
+
+    def test_a_node_that_had_no_address_is_given_its_registry_too(self):
+        """The station registry URL is worked out on save, and must be stored.
+
+        A node from an earlier sync has no address at all. Filling one while
+        naming only that field would leave the registry URL unwritten, and the
+        centre would still be passed over -- the very fault this addresses,
+        one layer further down.
+        """
+        WIS2Node.objects.create(centre_id="ke-meteo", name="Kenya Met")
+
+        self.sync()
+
+        node = WIS2Node.objects.get(centre_id="ke-meteo")
+
+        self.assertEqual(node.base_url, "http://wis.meteo.go.ke")
+        self.assertEqual(
+            node.stations_url,
+            "http://wis.meteo.go.ke/oapi/collections/stations/items?f=json",
+        )
+
+    def test_every_addressed_node_is_one_the_station_sync_would_ask(self):
+        self.sync()
+
+        self.assertEqual(
+            set(
+                WIS2Node.objects.exclude(stations_url="").values_list(
+                    "centre_id", flat=True
+                )
+            ),
+            {"ke-meteo", "tg-anamet"},
+        )
+
+    def test_a_record_advertising_no_address_leaves_the_node_without_one(self):
+        self.sync()
+
+        self.assertEqual(WIS2Node.objects.get(centre_id="cg-met").base_url, "")
+        self.assertEqual(WIS2Node.objects.get(centre_id="cg-met").stations_url, "")
+
+    def test_an_address_already_recorded_is_not_written_over(self):
+        """Filled once. What is there was put there by a run or by a person."""
+        WIS2Node.objects.create(
+            centre_id="ke-meteo",
+            name="Kenya Met",
+            base_url="https://wis2.meteo.go.ke",
+        )
+
+        self.sync()
+
+        node = WIS2Node.objects.get(centre_id="ke-meteo")
+
+        self.assertEqual(node.base_url, "https://wis2.meteo.go.ke")
+        self.assertEqual(
+            node.stations_url,
+            "https://wis2.meteo.go.ke/oapi/collections/stations/items?f=json",
+        )
+
+    def test_a_manually_managed_node_is_not_given_an_address(self):
+        WIS2Node.objects.create(
+            centre_id="ke-meteo", name="Kenya Met", is_manually_managed=True
+        )
+
+        self.sync()
+
+        self.assertEqual(WIS2Node.objects.get(centre_id="ke-meteo").base_url, "")
 
 
 class OriginBrokerTests(CatalogueSyncTestCase):
@@ -454,7 +546,7 @@ class SyncCommandTests(CatalogueSyncTestCase):
         output = self.run_command()
 
         self.assertIn(self.catalogue.centre_id, output)
-        self.assertIn("created=4", output)
+        self.assertIn(f"created={len(MONITORED_CENTRE_IDS)}", output)
 
     def test_it_says_so_when_there_is_nothing_to_sync(self):
         GlobalDiscoveryCatalogue.objects.all().delete()

--- a/wis2watch/src/wis2watch/core/tests/test_interpretation_discovery.py
+++ b/wis2watch/src/wis2watch/core/tests/test_interpretation_discovery.py
@@ -1,11 +1,12 @@
 """WCMP2 discovery metadata extraction, against records captured from a GDC.
 
 The fixture is a real response from the Canadian Global Discovery Catalogue,
-trimmed to nine records that between them cover what the catalogue actually
+trimmed to ten records that between them cover what the catalogue actually
 returns: records whose topic lives in ``wmo:topicHierarchy``, records where it
 lives only in a link, records with no centre ID property, records whose own
-broker is advertised and records where only Global Brokers are, and records
-that carry no topic anywhere and so cannot be used at all.
+broker is advertised and records where only Global Brokers are, records
+carrying a canonical link and records carrying none, and records that carry no
+topic anywhere and so cannot be used at all.
 """
 
 from datetime import datetime, timezone
@@ -146,6 +147,58 @@ class NodeExtractionTests(NoNetworkTestCase):
         self.assertFalse(record.node.is_monitored)
 
 
+class NodeBaseUrlTests(NoNetworkTestCase):
+    """Where to ask a centre directly, read from where it serves its metadata."""
+
+    def test_the_base_url_is_the_scheme_and_host_of_the_canonical_link(self):
+        """``ke-meteo`` serves its metadata from ``/data/metadata`` on its own host."""
+        record = extract_discovery_record(
+            feature("urn:wmo:md:ke-meteo:synop-dataset-surface-observations")
+        )
+
+        self.assertEqual(record.node.base_url, "http://wis.meteo.go.ke")
+
+    def test_a_canonical_link_that_is_only_a_host_still_names_the_node(self):
+        """``tg-anamet`` advertises its wis2box as a bare host, and the file too."""
+        record = extract_discovery_record(
+            feature("urn:wmo:md:tg-anamet:core.surface-based-observations.synop")
+        )
+
+        self.assertEqual(record.node.base_url, "https://wis2.meteotogo.tg")
+
+    def test_a_record_with_no_canonical_link_names_no_base_url(self):
+        record = extract_discovery_record(
+            feature("urn:wmo:md:sz-swazimet:surface-based-observations.synop")
+        )
+
+        self.assertEqual(record.node.base_url, "")
+
+    def test_broker_links_are_not_mistaken_for_the_nodes_address(self):
+        """``cg-met`` advertises its own broker and no canonical link at all."""
+        record = extract_discovery_record(
+            feature("urn:wmo:md:cg-met:core.climate.surface-based-observations.climat")
+        )
+
+        self.assertEqual(record.node.base_url, "")
+
+    def test_a_canonical_link_that_is_not_web_addressed_is_passed_over(self):
+        """A host reached over anything but HTTP is not one the API answers on."""
+        source = feature("urn:wmo:md:ke-meteo:synop-dataset-surface-observations")
+        for link in source["links"]:
+            if link.get("rel") == "canonical":
+                link["href"] = "mqtts://everyone:everyone@wis.meteo.go.ke:8883"
+
+        self.assertEqual(extract_discovery_record(source).node.base_url, "")
+
+    def test_a_canonical_link_naming_no_host_is_passed_over(self):
+        source = feature("urn:wmo:md:ke-meteo:synop-dataset-surface-observations")
+        for link in source["links"]:
+            if link.get("rel") == "canonical":
+                link["href"] = "/data/metadata/urn:wmo:md:ke-meteo:synop.json"
+
+        self.assertEqual(extract_discovery_record(source).node.base_url, "")
+
+
 class OriginBrokerExtractionTests(NoNetworkTestCase):
     def test_the_nodes_own_broker_is_extracted_from_its_notification_link(self):
         record = extract_discovery_record(
@@ -225,7 +278,9 @@ class CollectionExtractionTests(NoNetworkTestCase):
         monitored = {r.node.centre_id for r in records if r.node.is_monitored}
         unmonitored = {r.node.centre_id for r in records if not r.node.is_monitored}
 
-        self.assertEqual(monitored, {"ke-meteo", "cg-met", "sz-swazimet", "gh-gmet"})
+        self.assertEqual(
+            monitored, {"ke-meteo", "cg-met", "sz-swazimet", "gh-gmet", "tg-anamet"}
+        )
         self.assertEqual(unmonitored, {"il-ims", "int-eumetsat", "us-cimss"})
 
     def test_a_collection_with_no_features_yields_nothing(self):


### PR DESCRIPTION
Closes #38.

## What was wrong

The node-registry station sync has never run, for any node, on any install.

`run_sync_all_node_stations` queues `WIS2Node.objects.exclude(stations_url="")`. `stations_url` is worked out in `WIS2Node.save()` from the node's `base_url`. Nothing has ever written a `base_url` -- `_apply_node` creates a node from its centre ID, name and country alone. So the query matched nothing, every hour, on every deployment.

One of the three station pictures this tool exists to compare -- what a centre's own registry claims, beside what OSCAR declares and what is heard transmitting -- has been structurally empty, and the sync that should have filled it reported nothing wrong.

## What this does

Derives the node's `base_url` as `scheme://netloc` of its records' `rel="canonical"` link. Reading it is `interpretation/discovery.py`'s job (a new field on `DiscoveredNode`), writing it is `catalogue.py`'s.

A canonical link points at the metadata file on the centre's own host -- `https://wis2.meteo.sc/data/metadata/urn:wmo:md:....json` -- and the scheme and host of it are the node.

Checked against the live ECCC catalogue, all 550 records:

- 32 African centres indexed, **20 carry a canonical host**, and no centre disagrees with itself.
- Path shape is uniform worldwide (183 `/data`, 13 `/archive`, 8 `/collections`, 2 `/metadata`, 1 bare), so there is no path prefix to strip.
- Of the 21 African hosts reachable at the time of writing, **19 answered the derived station endpoint with real counts** -- `za-weathersa` 126, `tz-tma` 92, `cm-meteocameroon` 78. The two that did not (`ly-lnmc` hangs, `zm-zmd` refuses) are findings this tool exists to report.

## The rules

- **Canonical rel only**, http(s) only.
- **Filled once, never written over.** A record advertising no canonical link changes nothing, matching the origin-broker rule: absence in one record is not evidence about the centre.
- **Manually-managed nodes untouched.**
- **Stored unverified.** The catalogue sync stays a pure metadata read; probing per node inside it would spend minutes on hosts already known to hang and would confuse "unreachable today" with "never learned". A wrong address surfaces as a failed `NODE_STATIONS` sync log, which is where an unreachable registry is already reported.
- **No migration** -- existing nodes have a blank address and fill on the next sync, within six hours.
- **No first-start kick** -- node stations cannot join `FIRST_SYNCS`, since no node exists at that moment. The hourly beat picks them up.

## The trap this had to avoid

`stations_url` is derived on save, so filling `base_url` with `update_fields=["base_url", "modified"]` would drop it and the centre would still be passed over -- the same fault, one layer down. `DERIVED_FROM_BASE_URL` names it wherever the address is written, and `test_a_node_that_had_no_address_is_given_its_registry_too` is the guard.

## Tests

892 pass. New coverage: canonical -> host, bare-host canonical, no canonical, broker links not mistaken for an address, non-http canonical, host-less canonical; and on the writing side: a new node takes the address, an existing addressless node gets its registry too, an address already recorded is not written over, a manually-managed node is untouched, and the set of nodes the station sync would now queue.

The fixture gains `tg-anamet` -- a real record whose first canonical link is a bare host rather than a file, the one shape that would otherwise have gone untested.

## Deliberately not here

- #39 -- a centre with no canonical link still reads as declaring no stations rather than as one nobody asked. 12 of 32 centres.
- #40 -- an address filled once does not follow a centre that moves host, and four of the region's are bare IPs.