### PR TITLE
Judge the hours it can prove it was listening through

### DIFF
--- a/wis2watch/src/wis2watch/core/propagation.py
+++ b/wis2watch/src/wis2watch/core/propagation.py
@@ -15,11 +15,38 @@ than finding every gap. A grace period absorbs ordinary propagation latency,
 counted from when this tool saw the message at origin rather than from the
 time the publisher stamped on it -- a centre whose clock runs hours behind
 would otherwise have every message instantly overdue. Evaluation is suppressed
-entirely for nodes whose own broker is not currently reachable, and for every
-node while no Global Broker is: comparing a partial view of either side
-against a complete view of the other reports this tool's blind spot as the
-centre's loss. And a gap the world turns out to have received after all is
-closed rather than left standing.
+entirely for nodes whose own broker is not currently reachable, and one
+notification at a time for the hours this tool cannot show it was hearing the
+world through: comparing a partial view of either side against a complete view
+of the other reports this tool's blind spot as the centre's loss. And a gap
+the world turns out to have received after all is closed rather than left
+standing.
+
+That second suppression is a statement about the hours being judged rather
+than about the instant a run happened to start, because those are not the same
+hours. A Global Broker connection that drops does not stop the origin brokers
+delivering; refusing to judge while it is down only defers the question to the
+next run, which recomputes a trailing window and reaches those hours anyway --
+and a broker does not redeliver what it sent while nobody was listening, so
+every notification seen at origin during the outage would become a gap nothing
+could ever close. So a notification is judged only where some Global Broker
+message arrived inside the same grace period it is judged against. Silence
+there means the tool was not hearing the world, whatever the reason: a dropped
+connection, an instance switched off, an install that has never run. Reading
+it off the traffic rather than off a recorded outage is what covers the last
+of those, which recorded nothing because nothing was running to record it.
+
+Sparse traffic makes this suppress more, and the gaps it passes over are gaps
+missed rather than invented, which is this module's governing trade.
+
+One edge is known and left open. At the moment a connection comes back, the
+burst delivered on reconnect can fall inside the grace period of a
+notification observed shortly before it -- so that one notification is judged
+on evidence that arrived at the end of its window rather than through it, and
+can still become a phantom gap one grace period wide. Closing it means
+demanding Global Broker arrivals on both sides of the origin sighting, which
+would suppress more of the ordinary sparse-traffic case; it is written down
+here rather than fixed.
 
 Gaps are written down rather than derived when asked for. Raw messages are
 kept for a forensic window only and the rollups carry counts rather than
@@ -35,7 +62,14 @@ from dataclasses import dataclass
 from datetime import timedelta
 
 from django.conf import settings
-from django.db.models import Exists, OuterRef, Subquery
+from django.db.models import (
+    DateTimeField,
+    Exists,
+    ExpressionWrapper,
+    F,
+    OuterRef,
+    Subquery,
+)
 from django.utils import timezone as dj_timezone
 
 from .models import MessageSource, NotificationMessage, PropagationGap
@@ -61,13 +95,20 @@ class PropagationCounts:
     resolved: int = 0
     nodes_evaluated: int = 0
     nodes_suppressed: int = 0
+    unheard: int = 0
 
     @property
     def summary(self):
-        """What the run came to, in one line, for a log."""
+        """What the run came to, in one line, for a log.
+
+        The unjudged are said as well as the found, because a run that found
+        nothing and a run that could judge nothing read identically otherwise,
+        and only one of them is good news.
+        """
         return (
             f"detected={self.detected} resolved={self.resolved} "
-            f"evaluated={self.nodes_evaluated} suppressed={self.nodes_suppressed}"
+            f"evaluated={self.nodes_evaluated} suppressed={self.nodes_suppressed} "
+            f"unheard={self.unheard}"
         )
 
 
@@ -110,7 +151,9 @@ def evaluate_propagation(*, now=None, grace_minutes=None, window_hours=None):
 
     Only nodes whose own broker is currently reachable are judged; the rest
     are counted as suppressed, because the tool cannot tell what it did not
-    see from what was never published.
+    see from what was never published. Of what those brokers delivered, only
+    the notifications the tool can show it was hearing the world through are
+    judged; the rest are counted as unheard.
 
     The window is recomputed rather than advanced, so a run is safe to repeat:
     a gap already recorded is left as it was found, including the moment it
@@ -127,16 +170,14 @@ def evaluate_propagation(*, now=None, grace_minutes=None, window_hours=None):
     # same question of the same brokers: the two answering differently would
     # put a centre's gaps on a page the evaluation had decided it could not
     # judge.
-    sources = (
-        list(MessageSource.objects.watched_origins())
-        if _the_world_is_watched()
-        else []
-    )
+    sources = list(MessageSource.objects.watched_origins())
     counts = PropagationCounts(
         nodes_evaluated=len(sources),
-        # Whatever was not judged was suppressed, for whichever of the two
-        # reasons. A node has at most one broker of its own, so counting the
-        # sources not evaluated counts the centres not judged.
+        # A node has at most one broker of its own, so counting the sources
+        # not evaluated counts the centres passed over entirely. What is
+        # passed over one notification at a time, for hours the world was not
+        # being heard through, is counted separately: it is a bound on what
+        # this run could judge, not on which centres it looked at.
         nodes_suppressed=MessageSource.objects.origin_brokers().count() - len(sources),
     )
 
@@ -146,8 +187,8 @@ def evaluate_propagation(*, now=None, grace_minutes=None, window_hours=None):
     counts.resolved = _close_arrivals(since=since)
 
     if sources:
-        counts.detected = _record_gaps(
-            sources, since=since, seen_by=now - grace, now=now
+        counts.detected, counts.unheard = _record_gaps(
+            sources, since=since, grace=grace, seen_by=now - grace, now=now
         )
 
     logger.info("Propagation evaluated back to %s: %s", since, counts.summary)
@@ -155,21 +196,37 @@ def evaluate_propagation(*, now=None, grace_minutes=None, window_hours=None):
     return counts
 
 
-def _the_world_is_watched():
-    """Whether there is a current view of what the world actually received.
+def _the_world_was_heard():
+    """Whether anything at all arrived from the world while the outer row waited.
 
-    The other half of the same blind spot. A Global Broker connection that is
-    down does not stop the origin brokers delivering, so every notification
-    seen at origin while it is down looks unpropagated -- and, because a
-    broker does not redeliver what it sent while nobody was listening, those
-    would be phantom gaps nothing could ever close. Judging nothing until the
-    world's view is back is the only honest answer.
+    The other half of the same blind spot, asked of the hours being judged
+    rather than of the instant the run started. Correlated on the outer row's
+    arrival and on its ``overdue_at``, which the query it is used in has to
+    carry: the window is the notification's own grace period, and what is
+    looked for in it is some Global Broker message stored between the moment
+    this tool saw the notification at origin and the moment it fell due.
+
+    Any Global Broker message will do, from any centre. What it is evidence of
+    is not that the notification propagated -- that is the UUID's question --
+    but that the connection this tool would have seen it on was delivering,
+    and so that absence from the Global Broker is a fact about the message
+    rather than about the listener.
+
+    Matched on ``received_datetime`` alone, and deliberately not bounded by
+    publication time: an arrival is when this tool stored the row, while
+    ``time`` is the publisher's own claim, and a message from a centre whose
+    clock runs behind is still proof the connection was up when it landed.
+    That costs what the UUID match gets for free -- ``time`` partitions the
+    hypertable, so this one cannot be narrowed to a few chunks the way that
+    one is. Buying the pruning back would mean discarding exactly the arrivals
+    a skewed clock stamped outside the window, which is evidence of a live
+    connection thrown away to read fewer chunks.
     """
-    return MessageSource.objects.filter(
-        source_type=MessageSource.GLOBAL_BROKER,
-        is_active=True,
-        is_reachable=True,
-    ).exists()
+    return NotificationMessage.objects.filter(
+        source__source_type=MessageSource.GLOBAL_BROKER,
+        received_datetime__gte=OuterRef("received_datetime"),
+        received_datetime__lte=OuterRef("overdue_at"),
+    )
 
 
 def _seen_on_a_global_broker(since):
@@ -194,8 +251,12 @@ def _seen_on_a_global_broker(since):
     )
 
 
-def _record_gaps(sources, *, since, seen_by, now):
-    """Write down the notifications the world has not carried in time."""
+def _record_gaps(sources, *, since, grace, seen_by, now):
+    """Write down the notifications the world has not carried in time.
+
+    Returns what was found, and what was passed over because the hours it fell
+    in cannot be shown to have been heard.
+    """
     node_of = {source.pk: source.node_id for source in sources}
 
     unseen = (
@@ -204,10 +265,22 @@ def _record_gaps(sources, *, since, seen_by, now):
             time__gte=since,
             received_datetime__lte=seen_by,
         )
+        .annotate(
+            # When this notification stopped being merely in flight, which is
+            # the far end of the window both questions below are asked over.
+            overdue_at=ExpressionWrapper(
+                F("received_datetime") + grace, output_field=DateTimeField()
+            )
+        )
         .filter(~Exists(_seen_on_a_global_broker(since)))
+        # Asked of every candidate rather than filtered on, so that the ones
+        # passed over can be counted. A run that judged nothing because it was
+        # blind must not report the same nought as a run that found nothing
+        # wrong.
+        .annotate(world_was_heard=Exists(_the_world_was_heard()))
         .values(
             "source_id", "notification_id", "topic", "dataset_id", "time",
-            "received_datetime",
+            "received_datetime", "world_was_heard",
         )
     )
 
@@ -224,8 +297,13 @@ def _record_gaps(sources, *, since, seen_by, now):
     )
 
     gaps = []
+    unheard = 0
 
     for row in unseen:
+        if not row["world_was_heard"]:
+            unheard += 1
+            continue
+
         node_id = node_of[row["source_id"]]
 
         if (node_id, row["notification_id"]) in recorded:
@@ -248,7 +326,7 @@ def _record_gaps(sources, *, since, seen_by, now):
     if gaps:
         PropagationGap.objects.bulk_create(gaps, batch_size=1000, ignore_conflicts=True)
 
-    return len(gaps)
+    return len(gaps), unheard
 
 
 def _close_arrivals(*, since):

--- a/wis2watch/src/wis2watch/core/tests/test_propagation.py
+++ b/wis2watch/src/wis2watch/core/tests/test_propagation.py
@@ -35,8 +35,24 @@ NOW = at("2026-08-11T12:00:00")
 #: without a time of its own is one the tool is entitled to judge.
 LONG_ENOUGH_AGO = NOW - timedelta(hours=1)
 
+#: How far back the world is heard by default: wider than the evaluation
+#: window these cases use, so that anything inside it is in hours the run can
+#: prove it was listening through.
+HEARD_SINCE = NOW - timedelta(hours=50)
+
 
 class PropagationTestCase(TestCase):
+    """One centre, one Global Broker, and a world that is being heard.
+
+    The last of those is a fixture rather than a subject: a run judges only
+    the hours it can prove it was listening through, so ordinary Global Broker
+    traffic is the background every case about something else is set against.
+    A case about blindness turns it off.
+    """
+
+    #: Whether to seed that background.
+    the_world_is_heard = True
+
     def setUp(self):
         self.global_broker = MessageSource.objects.create(
             name="Global Broker",
@@ -46,6 +62,38 @@ class PropagationTestCase(TestCase):
         )
         self.kenya = WIS2Node.objects.create(centre_id="ke-meteo", name="Kenya Met")
         self.kenya_origin = origin_broker(self.kenya, is_reachable=True)
+
+        if self.the_world_is_heard:
+            self.world_heard_throughout()
+
+    def world_heard_throughout(
+        self, since=HEARD_SINCE, until=NOW, every=timedelta(minutes=10)
+    ):
+        """The rest of the world's traffic, arriving steadily on the Global Broker.
+
+        Nothing here is about these messages: they belong to no monitored
+        centre and are never matched against anything. What they are is the
+        evidence that the connection was up, arriving often enough that every
+        grace period in these cases contains one -- and a run will not judge a
+        notification whose grace period contains none.
+        """
+        arrivals = []
+        arrival = since
+
+        while arrival <= until:
+            arrivals.append(
+                NotificationMessage(
+                    source=self.global_broker,
+                    notification_id=f"elsewhere-{arrival.isoformat()}",
+                    topic="origin/a/wis2/xx-elsewhere/data/core/weather",
+                    time=arrival,
+                    received_datetime=arrival,
+                    raw_json={},
+                )
+            )
+            arrival += every
+
+        NotificationMessage.objects.bulk_create(arrivals)
 
     def observe(self, source, notification_id, *, node, published=None, received=None):
         """One notification, as one vantage point observed it.
@@ -357,32 +405,17 @@ class SuppressionTests(PropagationTestCase):
         self.assertEqual(counts.nodes_evaluated, 1)
         self.assertEqual(counts.nodes_suppressed, 1)
 
-    def test_nothing_is_judged_while_the_world_itself_is_not_being_watched(self):
-        """The other half of the blind spot, and the one that scales.
+    def test_what_the_connection_record_says_now_does_not_unjudge_past_hours(self):
+        """Blindness is read off the traffic, not off a side record.
 
-        A Global Broker connection that is down does not stop the origin
-        brokers delivering, and a broker does not redeliver what it sent while
-        nobody was listening -- so every centre at once would accrue phantom
-        gaps that nothing could ever close.
+        A connection marked down at the moment a run happens says nothing
+        about the hours that run is judging, which are hours it heard the
+        world throughout.
         """
-        self.at_origin("published-during-our-own-outage")
-        self.global_broker.is_reachable = False
-        self.global_broker.save()
-
-        counts = self.evaluate()
-
-        self.assertEqual(self.missing(), [])
-        self.assertEqual(counts.nodes_evaluated, 0)
-        self.assertEqual(counts.nodes_suppressed, 1)
-
-    def test_judging_resumes_once_the_world_is_watched_again(self):
         self.at_origin("really-lost")
         self.global_broker.is_reachable = False
         self.global_broker.save()
-        self.evaluate()
 
-        self.global_broker.is_reachable = True
-        self.global_broker.save()
         self.evaluate()
 
         self.assertEqual(self.missing(), ["really-lost"])
@@ -397,6 +430,142 @@ class SuppressionTests(PropagationTestCase):
         self.evaluate()
 
         self.assertEqual(self.missing(), ["lost-while-watching"])
+
+
+class UnheardWorldTests(PropagationTestCase):
+    """The hours the tool cannot prove it was listening through.
+
+    A Global Broker connection that drops does not stop the origin brokers
+    delivering, so every notification observed at origin during the outage
+    looks unpropagated -- and a broker does not redeliver what it sent while
+    nobody was listening, so each of those would be a phantom gap nothing
+    could ever close. The connection coming back does not make those hours
+    judgeable; it only makes a recompute reach them.
+
+    So blindness is read off the evidence: a notification is judged only if
+    some Global Broker message arrived inside the same grace period it is
+    being judged against. Hours with no arrivals in them are hours the tool
+    was not hearing the world, whatever the reason -- a dropped connection, an
+    instance switched off, a machine that never ran at all.
+
+    One edge stays open, and is known: at the moment a connection comes back,
+    the burst delivered on reconnect can fall inside the grace period of a
+    notification observed shortly before it, which makes that one notification
+    judgeable on evidence that arrived after its window opened rather than
+    through it. See the module's own documentation.
+    """
+
+    the_world_is_heard = False
+
+    OUTAGE_BEGAN = NOW - timedelta(hours=4)
+    OUTAGE_ENDED = NOW - timedelta(hours=1)
+
+    def the_connection_dropped_and_came_back(self):
+        """What an outage leaves behind, which is not a record of itself.
+
+        Traffic up to the moment the connection dropped, traffic from the
+        moment it returned, and hours in between with nothing in them.
+        """
+        self.world_heard_throughout(until=self.OUTAGE_BEGAN)
+        self.world_heard_throughout(since=self.OUTAGE_ENDED)
+
+    def published_at_origin(self, notification_id, when):
+        """A notification the centre published, and this tool saw, at one instant.
+
+        Which hour a notification belongs to is the whole subject here, so
+        both times are the same one and are said rather than defaulted.
+        """
+        return self.at_origin(notification_id, published=when, received=when)
+
+    def test_a_notification_seen_at_origin_during_the_outage_is_never_a_gap(self):
+        """The whole point: a recompute after recovery must not judge those hours."""
+        self.the_connection_dropped_and_came_back()
+        self.published_at_origin("published-in-the-dark", NOW - timedelta(hours=3))
+
+        self.evaluate()
+
+        self.assertEqual(self.missing(), [])
+
+    def test_a_notification_lost_while_the_world_was_heard_is_still_a_gap(self):
+        """Suppressing the blind hours must not suppress the ones either side."""
+        self.the_connection_dropped_and_came_back()
+        self.published_at_origin("lost-before-the-outage", NOW - timedelta(hours=6))
+        self.published_at_origin("lost-after-the-outage", NOW - timedelta(minutes=40))
+
+        self.evaluate()
+
+        self.assertEqual(
+            self.missing(), ["lost-after-the-outage", "lost-before-the-outage"]
+        )
+
+    def test_an_installation_that_has_heard_no_global_broker_traffic_judges_nothing(
+        self,
+    ):
+        """A tool that has never heard the world knows nothing about the world.
+
+        The failure mode this shape has to survive: not an outage but an
+        instance that was simply never listening, which recorded no outage
+        because nothing was running to record one. Judging on that would call
+        every notification every centre published a gap.
+        """
+        self.at_origin("the-only-thing-anyone-saw")
+
+        counts = self.evaluate()
+
+        self.assertEqual(self.missing(), [])
+        self.assertEqual(counts.detected, 0)
+
+    def test_the_run_says_how_much_it_could_not_judge(self):
+        """A run that judged nothing because it was blind is not good news.
+
+        Nothing found and nothing judgeable read identically in a log unless
+        the run says which it was.
+        """
+        self.the_connection_dropped_and_came_back()
+        self.published_at_origin("in-the-dark", NOW - timedelta(hours=3))
+        self.published_at_origin("also-in-the-dark", NOW - timedelta(hours=2))
+        self.published_at_origin("really-lost", NOW - timedelta(hours=6))
+
+        counts = self.evaluate()
+
+        self.assertEqual(counts.detected, 1)
+        self.assertEqual(counts.unheard, 2)
+        self.assertIn("unheard=2", counts.summary)
+
+    def test_a_gap_found_before_the_outage_keeps_the_moment_it_was_found(self):
+        """The change is to what is newly found, not to what is on the record."""
+        self.the_connection_dropped_and_came_back()
+        self.published_at_origin("lost-before-the-outage", NOW - timedelta(hours=6))
+
+        found_at = NOW - timedelta(hours=5)
+        self.evaluate(now=found_at)
+
+        counts = self.evaluate()
+
+        self.assertEqual(self.missing(), ["lost-before-the-outage"])
+        self.assertEqual(self.gaps()[0].detected_at, found_at)
+        self.assertEqual(counts.detected, 0)
+
+    def test_a_gap_recorded_before_the_outage_is_still_closed_by_a_late_arrival(self):
+        """Blindness bounds what is found, not what is settled.
+
+        A message the world turns out to have carried after all is closed
+        whenever the evidence of it shows up, including the reconnection burst
+        that ends an outage.
+        """
+        self.the_connection_dropped_and_came_back()
+        self.published_at_origin("very-slow", NOW - timedelta(hours=6))
+        self.evaluate(now=NOW - timedelta(hours=5))
+
+        self.at_global(
+            "very-slow",
+            published=NOW - timedelta(hours=6),
+            received=self.OUTAGE_ENDED,
+        )
+        counts = self.evaluate()
+
+        self.assertEqual(self.gaps()[0].resolved_at, self.OUTAGE_ENDED)
+        self.assertEqual(counts.resolved, 1)
 
 
 class WindowTests(PropagationTestCase):


### PR DESCRIPTION
Closes #52

## The fault

A Global Broker connection that drops does not stop the origin brokers delivering. Propagation refused to judge while that was happening, but the check asked whether the world was watched at the *instant a run started* — and the job recomputes a trailing forty-eight hours. The first run after recovery reached back into the outage and judged those hours anyway. Every notification seen at origin while nobody was listening had no Global Broker counterpart, became a recorded `PropagationGap`, and could never be closed, because a broker does not redeliver what it sent while nobody was listening.

One morning's outage, one page of findings, every one of them a centre that did nothing wrong.

## The change

Suppression is now a statement about the hours being judged rather than about the instant the job happened to run. A notification is judged only where some Global Broker message arrived inside the same grace period the notification is judged against — the candidate's own window, annotated as `overdue_at` (`received_datetime + grace`) and correlated on. Silence in that window means the tool was not hearing the world, whatever the reason.

- `_the_world_is_watched()` (reachability on a `MessageSource` row) is gone.
- `_the_world_was_heard()` is a correlated `EXISTS` over Global Broker arrivals in the candidate's grace window.
- Evidence is matched on arrival time only, never publication time: a message from a centre whose clock runs behind is still proof the connection was up when it landed.

Reading blindness off the traffic rather than off a recorded outage covers the case a `HardFailure` structurally cannot — an instance that was simply switched off recorded no outage, because nothing was running to write one. A fresh install holding no Global Broker rows at all now judges nothing, where before it would have called every notification every centre published a gap.

Sparse traffic makes this suppress more, which is gaps missed rather than gaps invented — the trade this module already states as its governing principle. What is on the record is untouched: the change is to what a run newly finds, and a gap keeps the moment it was first detected.

## Beyond what the issue asked for

`PropagationCounts.unheard`, and an `unheard=N` field in the run's log line. Removing the whole-run suppression means a blind run no longer stops early, so `detected=0` would otherwise read the same whether nothing was wrong or nothing was judgeable. Easy to drop if it isn't wanted.

## Known and left open

At a reconnection boundary, the burst delivered on reconnect can fall inside the window of a notification observed shortly before it, leaving a phantom gap one grace period wide. It is written down in the module's own documentation rather than fixed here — closing it means demanding Global Broker arrivals on *both* sides of the origin sighting, which suppresses more of the ordinary sparse-traffic case.

## Testing

New `UnheardWorldTests` covers all five acceptance criteria: outage-then-recompute records nothing for the blind hours; gaps either side of the outage are still found; an installation with no Global Broker rows judges nothing; a gap found before the outage keeps its `detected_at`; late arrivals still close gaps across the boundary.

The shared test base now seeds ordinary Global Broker traffic as a fixture (`world_heard_throughout`) — under the new rule a detection test that seeds no world traffic is testing a blind installation, not a working one.

Full suite: 897 tests, green. `ruff check` clean.