### PR TITLE
A centre's own archive as a vantage point

### DIFF
--- a/wis2watch/src/wis2watch/core/alerts.py
+++ b/wis2watch/src/wis2watch/core/alerts.py
@@ -291,9 +291,17 @@ def _ingestion_symptom(*, now):
     a centre whose clock is days out is not a stall. The publication time is
     the publisher's claim, and this is a question about this tool.
 
-    Any source counts. One centre's origin broker still delivering is not a
-    healthy region, but it is not a stall either, and this alert exists for
+    Any connection counts. One centre's origin broker still delivering is not
+    a healthy region, but it is not a stall either, and this alert exists for
     the case where nothing is arriving at all.
+
+    What a poller wrote does not count, and that exclusion is the whole
+    integrity of this alert. It is the only thing standing between the
+    single-replica ingest process dying and nobody noticing, and it works by
+    reading a clock that only that process winds. A poller runs elsewhere, on
+    a schedule of its own, and its rows would hold the clock up indefinitely
+    while nothing at all was being listened to -- an alert silently disabled
+    by another feature working correctly.
 
     Unlike the broker check, this one can date its own failure: the moment the
     last message arrived is the moment ingestion stopped. An installation that
@@ -301,7 +309,10 @@ def _ingestion_symptom(*, now):
     was first looked at instead.
     """
     arrived = (
-        NotificationMessage.objects.order_by("-received_datetime")
+        NotificationMessage.objects.exclude(
+            source__source_type=MessageSource.ORIGIN_API
+        )
+        .order_by("-received_datetime")
         .values_list("received_datetime", flat=True)
         .first()
     )

--- a/wis2watch/src/wis2watch/core/catalogue.py
+++ b/wis2watch/src/wis2watch/core/catalogue.py
@@ -54,6 +54,14 @@ FETCH_TIMEOUT = 60
 #: the base URL is worth learning.
 DERIVED_FROM_BASE_URL = ("discovery_metadata_url", "stations_url")
 
+#: Where a wis2box serves the archive of the notifications it has published,
+#: relative to the node's own address. A wis2box convention rather than a WIS2
+#: requirement: nodes running other software answer 404 here, and among those
+#: that do serve it the retention observed in the wild runs from about a day
+#: to several months. Nothing in WCMP2 advertises it, which is why this is a
+#: guess offered to an operator rather than a fact read off a record.
+MESSAGE_ARCHIVE_PATH = "/oapi/collections/messages"
+
 
 def discovery_metadata_url(catalogue):
     """Where a catalogue serves its discovery metadata records."""
@@ -145,6 +153,44 @@ def _apply_origin_broker(node, broker):
     )
 
 
+def message_archive_url(base_url):
+    """Where a node is expected to serve its own notification archive."""
+    return f"{base_url.rstrip('/')}{MESSAGE_ARCHIVE_PATH}"
+
+
+def _apply_origin_api(node):
+    """The node's own message archive, as a vantage point on it.
+
+    Created beside the origin broker, and settled by nothing: reachability
+    stays null until something has actually asked, in the way a freshly synced
+    broker's does until something dials it. A row here is the tool knowing
+    where a centre's archive would be, not a claim that one is there.
+
+    Offered once and never written over, because the address is a guess twice
+    removed -- a path a wis2box happens to serve, under a base URL inferred
+    from a canonical link -- and an operator who has corrected it knows
+    something this sync does not. That is also why it is offered to a manually
+    managed node: what it is derived from is the node's own address, which for
+    such a node is the operator's own correction rather than the catalogue's.
+
+    A node with no address of its own gets nothing. There is nowhere to guess
+    from, and a row pointing at a path with no host would be a vantage point on
+    nothing.
+    """
+    if not node.base_url:
+        return
+
+    MessageSource.objects.get_or_create(
+        node=node,
+        source_type=MessageSource.ORIGIN_API,
+        defaults={
+            "name": f"{node.centre_id} origin API",
+            "centre_id": node.centre_id,
+            "api_url": message_archive_url(node.base_url),
+        },
+    )
+
+
 def _apply_dataset(node, discovered):
     """The dataset a record describes, created or refreshed."""
     _, created = Dataset.objects.update_or_create(
@@ -181,6 +227,8 @@ def apply_discovery_record(record):
 
             if not node.is_manually_managed:
                 _apply_origin_broker(node, record.origin_broker)
+
+            _apply_origin_api(node)
 
             return _apply_dataset(node, record.dataset)
     except Exception as exc:

--- a/wis2watch/src/wis2watch/core/migrations/0016_a_centres_own_archive_as_a_vantage_point.py
+++ b/wis2watch/src/wis2watch/core/migrations/0016_a_centres_own_archive_as_a_vantage_point.py
@@ -39,7 +39,7 @@ class Migration(migrations.Migration):
             field=models.BooleanField(
                 blank=True,
                 default=None,
-                help_text="Null until a connection to this broker has been attempted",
+                help_text="Empty until this vantage point has actually been asked",
                 null=True,
             ),
         ),

--- a/wis2watch/src/wis2watch/core/migrations/0016_a_centres_own_archive_as_a_vantage_point.py
+++ b/wis2watch/src/wis2watch/core/migrations/0016_a_centres_own_archive_as_a_vantage_point.py
@@ -1,0 +1,65 @@
+"""Let a centre's own notification archive be a vantage point of its own.
+
+A message source gains an archive address, and a kind that carries one. The
+host stops being required along with it: an archive is reached over HTTP and
+has no broker to dial, so which address a source needs is now a question about
+its kind and is asked in ``MessageSource.clean`` rather than of every row.
+
+Reachability is marked blank for the same reason: it is validated now that
+something validates this model, and "not attempted yet" has always been one of
+its answers.
+"""
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("wis2watchcore", "0015_name_the_global_broker"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="messagesource",
+            name="api_url",
+            field=models.URLField(
+                blank=True,
+                help_text=(
+                    "Where this centre serves its own notification archive. "
+                    "Offered from the node's address, which is a guess; correct "
+                    "it here and the correction stands."
+                ),
+                max_length=1000,
+                verbose_name="Message archive URL",
+            ),
+        ),
+        migrations.AlterField(
+            model_name="messagesource",
+            name="is_reachable",
+            field=models.BooleanField(
+                blank=True,
+                default=None,
+                help_text="Null until a connection to this broker has been attempted",
+                null=True,
+            ),
+        ),
+        migrations.AlterField(
+            model_name="messagesource",
+            name="host",
+            field=models.CharField(blank=True, max_length=255),
+        ),
+        migrations.AlterField(
+            model_name="messagesource",
+            name="source_type",
+            field=models.CharField(
+                choices=[
+                    ("global_broker", "Global Broker"),
+                    ("global_cache", "Global Cache"),
+                    ("origin_broker", "Origin Broker"),
+                    ("origin_api", "Origin API"),
+                ],
+                default="global_broker",
+                max_length=20,
+            ),
+        ),
+    ]

--- a/wis2watch/src/wis2watch/core/models.py
+++ b/wis2watch/src/wis2watch/core/models.py
@@ -382,7 +382,7 @@ class MessageSource(TimeStampedModel):
         null=True,
         blank=True,
         default=None,
-        help_text=_("Null until a connection to this broker has been attempted"),
+        help_text=_("Empty until this vantage point has actually been asked"),
     )
     last_connected_at = models.DateTimeField(null=True, blank=True)
     last_error = models.TextField(blank=True)
@@ -482,6 +482,21 @@ class MessageSource(TimeStampedModel):
                 )
         elif not self.host:
             raise ValidationError({"host": _("A broker needs a host to dial.")})
+
+    @property
+    def address(self):
+        """Where this vantage point is reached, however it is reached.
+
+        A listing that showed the host and port of every row would print a
+        blank host and a port of 1883 against a centre's archive -- a broker
+        address for something that is not a broker, and an invitation to
+        correct a field that means nothing here. One column that says where
+        the row actually points is the honest form of the same information.
+        """
+        if self.source_type == self.ORIGIN_API:
+            return self.api_url
+
+        return f"{self.host}:{self.port}"
 
     @property
     def owning_centre_id(self):

--- a/wis2watch/src/wis2watch/core/models.py
+++ b/wis2watch/src/wis2watch/core/models.py
@@ -1,6 +1,7 @@
 from django.contrib.gis.db import models
 from django.contrib.gis.geos import Polygon
 from django.contrib.postgres.fields import ArrayField
+from django.core.exceptions import ValidationError
 from django.utils import timezone as dj_timezone
 from django.utils.translation import gettext_lazy as _
 from django_countries.fields import CountryField
@@ -225,33 +226,50 @@ class MessageSourceQuerySet(models.QuerySet):
         """
         return self.filter(carried_by__isnull=True)
 
-    def origin_brokers(self):
-        """The nodes' own brokers this tool is currently meant to be watching.
+    def dialled(self):
+        """The sources a connection is actually opened to.
 
-        A broker switched off in the admin is not one of them: reachability is
-        only ever what the last live connection recorded, so a source nothing
-        is dialling any more carries an answer that has since gone stale.
+        Narrower than :meth:`connections` by one more kind: a centre's own
+        message archive is read over HTTP on a schedule, so it has an address
+        of its own to correct but nothing that holds a connection open. Asked
+        wherever the question is how the connections are faring, since an
+        archive counted among them would sit there for ever as one that never
+        came up.
+        """
+        return self.connections().exclude(source_type=MessageSource.ORIGIN_API)
+
+    def origin_vantages(self):
+        """The centres' own vantage points this tool is meant to be watching.
+
+        Both transports a centre offers on its own account: the broker it
+        publishes to, and the archive of those notifications it serves over
+        HTTP. Which of the two a centre was heard through does not change what
+        being heard entitles this tool to say about it.
+
+        A vantage point switched off in the admin is not one of them:
+        reachability is only ever what the last attempt recorded, so a source
+        nothing is asking any more carries an answer that has since gone stale.
         """
         return self.filter(
-            source_type=MessageSource.ORIGIN_BROKER,
+            source_type__in=MessageSource.ORIGIN_TRANSPORTS,
             is_active=True,
             node__isnull=False,
         )
 
     def watched_origins(self):
-        """The origin brokers whose view of their centre can be trusted now.
+        """The origin vantage points whose view of their centre can be trusted now.
 
         What decides whether a centre may be judged on the difference between
-        its own broker and the Global Broker -- and so is asked both by the
-        evaluation that records propagation gaps and by the report that lists
-        them. Written once, because a gap recorded while a broker answered and
-        then reported after it went dark is exactly the finding neither of them
-        should stand behind.
+        what it published itself and what the Global Broker carried -- and so
+        is asked both by the evaluation that records propagation gaps and by
+        the report that lists them. Written once, because a gap recorded while
+        a centre answered and then reported after it went dark is exactly the
+        finding neither of them should stand behind.
 
         A null reachability is "not attempted yet", and is no more a licence to
         judge a centre than a failure is.
         """
-        return self.origin_brokers().filter(is_reachable=True)
+        return self.origin_vantages().filter(is_reachable=True)
 
 
 class MessageSource(TimeStampedModel):
@@ -268,18 +286,28 @@ class MessageSource(TimeStampedModel):
     A vantage point is not always a connection of its own. Global Cache pickup
     is read off the ``cache/`` topics of a Global Broker connection, so its
     source records which connection carries it rather than an address anything
-    dials; ``carried_by`` is what says so.
+    dials; ``carried_by`` is what says so. Nor is it always a connection at
+    all: a centre's own notification archive is an HTTP endpoint asked on a
+    schedule, and what it carries is the same centre's traffic seen a second
+    way rather than a second kind of finding.
     """
 
     GLOBAL_BROKER = "global_broker"
     GLOBAL_CACHE = "global_cache"
     ORIGIN_BROKER = "origin_broker"
+    ORIGIN_API = "origin_api"
 
     SOURCE_TYPE_CHOICES = [
         (GLOBAL_BROKER, _("Global Broker")),
         (GLOBAL_CACHE, _("Global Cache")),
         (ORIGIN_BROKER, _("Origin Broker")),
+        (ORIGIN_API, _("Origin API")),
     ]
+
+    #: The ways a centre offers its own traffic on its own account. Both are
+    #: the centre speaking for itself, which is what a propagation finding is
+    #: entitled to be judged against; how it was reached is transport.
+    ORIGIN_TRANSPORTS = (ORIGIN_BROKER, ORIGIN_API)
 
     name = models.CharField(max_length=200)
     source_type = models.CharField(
@@ -312,11 +340,29 @@ class MessageSource(TimeStampedModel):
         ),
     )
 
-    host = models.CharField(max_length=255)
+    host = models.CharField(max_length=255, blank=True)
     port = models.IntegerField(default=1883)
     username = models.CharField(max_length=100, blank=True)
     password = models.CharField(max_length=255, blank=True)
     use_tls = models.BooleanField(default=False)
+
+    # Nothing advertises where a centre's notification archive lives: no WCMP2
+    # link relation names it, and serving one at all is a wis2box convention
+    # rather than a WIS2 requirement. So the address is worked out from the
+    # node's base URL, which is itself inferred from a canonical link -- and a
+    # centre that publishes those into separate object storage yields a base
+    # URL the archive does not live under. Correcting it by hand has to be the
+    # last word, which is why a sync offers this once and never writes over it.
+    api_url = models.URLField(
+        max_length=1000,
+        blank=True,
+        verbose_name=_("Message archive URL"),
+        help_text=_(
+            "Where this centre serves its own notification archive. Offered "
+            "from the node's address, which is a guess; correct it here and "
+            "the correction stands."
+        ),
+    )
 
     is_active = models.BooleanField(
         default=True,
@@ -334,6 +380,7 @@ class MessageSource(TimeStampedModel):
     # catalogue sync has just advertised is in the first state, not the second.
     is_reachable = models.BooleanField(
         null=True,
+        blank=True,
         default=None,
         help_text=_("Null until a connection to this broker has been attempted"),
     )
@@ -362,15 +409,23 @@ class MessageSource(TimeStampedModel):
             ],
             heading=_("Broker Connection"),
         ),
+        # Editable, and the only field on this form that is meant to be
+        # corrected by hand: the address is derived from an inference about
+        # where the centre answers, and the operator is the one who can tell
+        # that it is wrong.
+        MultiFieldPanel(
+            [FieldPanel("api_url")],
+            heading=_("Message Archive"),
+        ),
         FieldPanel("is_active"),
     ]
 
     class Meta:
         ordering = ["source_type", "name"]
         constraints = [
-            # A node has one broker of any given kind. The source type takes
-            # part so that a node can later gain a second vantage point (a
-            # cache feed, say) without a schema change.
+            # A node has one vantage point of any given kind: one broker of
+            # its own, and one archive of its own. The source type takes part
+            # so that a node can gain a further one without a schema change.
             models.UniqueConstraint(
                 fields=["node", "source_type"],
                 condition=models.Q(node__isnull=False),
@@ -403,13 +458,39 @@ class MessageSource(TimeStampedModel):
     def __str__(self):
         return f"{self.name} ({self.get_source_type_display()})"
 
+    def clean(self):
+        """A vantage point is nothing without the address it is reached at.
+
+        Which address that is depends on what kind it is, and neither field
+        can be required of every kind: a broker has no archive to read and an
+        archive has no host to dial. Checked here rather than on the fields so
+        that the admin refuses the one that is actually missing, instead of
+        asking an operator correcting an archive's URL for a broker host that
+        would mean nothing.
+        """
+        super().clean()
+
+        if self.source_type == self.ORIGIN_API:
+            if not self.api_url:
+                raise ValidationError(
+                    {
+                        "api_url": _(
+                            "An origin API needs the address of the archive it "
+                            "is read from."
+                        )
+                    }
+                )
+        elif not self.host:
+            raise ValidationError({"host": _("A broker needs a host to dial.")})
+
     @property
     def owning_centre_id(self):
         """The centre this source belongs to, or an empty string.
 
-        A Global Broker names its own centre; an origin broker's centre is the
-        node it belongs to. Resolving that here keeps callers from walking the
-        node relation and guessing which of the two applies.
+        A Global Broker names its own centre; a centre's own vantage points
+        take their centre from the node they belong to. Resolving that here
+        keeps callers from walking the node relation and guessing which of the
+        two applies.
         """
         if self.centre_id:
             return self.centre_id

--- a/wis2watch/src/wis2watch/core/propagation.py
+++ b/wis2watch/src/wis2watch/core/propagation.py
@@ -171,7 +171,7 @@ def evaluate_propagation(*, now=None, grace_minutes=None, window_hours=None):
     # differently would put a centre's gaps on a page the evaluation had
     # decided it could not judge.
     sources = list(MessageSource.objects.watched_origins())
-    evaluated = {source.node_id for source in sources}
+    evaluated_nodes = {source.node_id for source in sources}
     counts = PropagationCounts(
         # Counted by centre rather than by row. A centre may offer more than
         # one vantage point on itself -- its broker and its own archive -- and
@@ -180,10 +180,10 @@ def evaluate_propagation(*, now=None, grace_minutes=None, window_hours=None):
         # passed over one notification at a time, for hours the world was not
         # being heard through, is counted separately: it is a bound on what
         # this run could judge, not on which centres it looked at.
-        nodes_evaluated=len(evaluated),
+        nodes_evaluated=len(evaluated_nodes),
         nodes_suppressed=(
             MessageSource.objects.origin_vantages()
-            .exclude(node_id__in=evaluated)
+            .exclude(node_id__in=evaluated_nodes)
             .values("node_id")
             .distinct()
             .count()

--- a/wis2watch/src/wis2watch/core/propagation.py
+++ b/wis2watch/src/wis2watch/core/propagation.py
@@ -165,20 +165,29 @@ def evaluate_propagation(*, now=None, grace_minutes=None, window_hours=None):
     )
     since = evaluation_window_start(now, window_hours)
 
-    # Which brokers may be judged on is the model's answer rather than this
-    # module's, because the report that lists the gaps recorded here asks the
-    # same question of the same brokers: the two answering differently would
-    # put a centre's gaps on a page the evaluation had decided it could not
-    # judge.
+    # Which vantage points may be judged on is the model's answer rather than
+    # this module's, because the report that lists the gaps recorded here asks
+    # the same question of the same vantage points: the two answering
+    # differently would put a centre's gaps on a page the evaluation had
+    # decided it could not judge.
     sources = list(MessageSource.objects.watched_origins())
+    evaluated = {source.node_id for source in sources}
     counts = PropagationCounts(
-        nodes_evaluated=len(sources),
-        # A node has at most one broker of its own, so counting the sources
-        # not evaluated counts the centres passed over entirely. What is
+        # Counted by centre rather than by row. A centre may offer more than
+        # one vantage point on itself -- its broker and its own archive -- and
+        # what these two numbers are about is which centres this run could
+        # look at, not how many ways it could have looked at them. What is
         # passed over one notification at a time, for hours the world was not
         # being heard through, is counted separately: it is a bound on what
         # this run could judge, not on which centres it looked at.
-        nodes_suppressed=MessageSource.objects.origin_brokers().count() - len(sources),
+        nodes_evaluated=len(evaluated),
+        nodes_suppressed=(
+            MessageSource.objects.origin_vantages()
+            .exclude(node_id__in=evaluated)
+            .values("node_id")
+            .distinct()
+            .count()
+        ),
     )
 
     # Closing first costs nothing and keeps a run's own two halves consistent:

--- a/wis2watch/src/wis2watch/core/tests/support.py
+++ b/wis2watch/src/wis2watch/core/tests/support.py
@@ -106,6 +106,25 @@ def origin_broker(node, **kwargs):
     )
 
 
+def origin_api(node, **kwargs):
+    """A node's own message archive, as a catalogue sync leaves it.
+
+    Nothing is said about whether it answers, for the same reason a freshly
+    synced broker says nothing: no poll has settled it yet.
+    """
+    base_url = node.base_url or f"https://wis2.{node.centre_id}.example.int"
+
+    kwargs.setdefault("name", f"{node.centre_id} origin API")
+    kwargs.setdefault("api_url", f"{base_url}/oapi/collections/messages")
+
+    return MessageSource.objects.create(
+        source_type=MessageSource.ORIGIN_API,
+        node=node,
+        centre_id=node.centre_id,
+        **kwargs,
+    )
+
+
 class NetworkAccessInTest(AssertionError):
     """Raised when a test that must be offline opens a socket."""
 

--- a/wis2watch/src/wis2watch/core/tests/test_admin.py
+++ b/wis2watch/src/wis2watch/core/tests/test_admin.py
@@ -76,6 +76,61 @@ class AdminSmokeTests(TestCase):
         self.assertContains(response, "Global Broker")
         self.assertNotContains(response, "Global Cache via")
 
+    def test_a_centre_own_archive_is_listed_at_the_address_it_is_read_from(self):
+        """Nothing dials it, so what it needs corrected is its URL, not a port."""
+        node = WIS2Node.objects.create(
+            centre_id="ke-meteo", name="Kenya Met", base_url="https://wis2.meteo.test"
+        )
+        MessageSource.objects.create(
+            name="ke-meteo origin API",
+            source_type=MessageSource.ORIGIN_API,
+            node=node,
+            centre_id="ke-meteo",
+            api_url="https://wis2.meteo.test/oapi/collections/messages",
+        )
+
+        response = self.client.get(reverse(MessageSourceViewSet().get_url_name("index")))
+
+        self.assertContains(response, "ke-meteo origin API")
+        self.assertContains(
+            response, "https://wis2.meteo.test/oapi/collections/messages"
+        )
+
+    def test_a_guessed_archive_address_can_be_corrected_by_hand(self):
+        """The whole reason the field is editable: the guess is often wrong."""
+        node = WIS2Node.objects.create(
+            centre_id="ke-meteo", name="Kenya Met", base_url="https://files.meteo.test"
+        )
+        source = MessageSource.objects.create(
+            name="ke-meteo origin API",
+            source_type=MessageSource.ORIGIN_API,
+            node=node,
+            centre_id="ke-meteo",
+            api_url="https://files.meteo.test/oapi/collections/messages",
+        )
+
+        response = self.client.post(
+            reverse(MessageSourceViewSet().get_url_name("edit"), args=[source.pk]),
+            {
+                "name": source.name,
+                "source_type": MessageSource.ORIGIN_API,
+                "centre_id": "ke-meteo",
+                "node": node.pk,
+                "host": "",
+                "port": "1883",
+                "username": "",
+                "password": "",
+                "api_url": "https://wis2.meteo.test/oapi/collections/messages",
+                "is_active": "on",
+            },
+        )
+
+        self.assertEqual(response.status_code, 302)
+        source.refresh_from_db()
+        self.assertEqual(
+            source.api_url, "https://wis2.meteo.test/oapi/collections/messages"
+        )
+
     def test_a_node_can_be_created_by_hand(self):
         response = self.client.post(
             reverse(WIS2NodeViewSet().get_url_name("add")),

--- a/wis2watch/src/wis2watch/core/tests/test_alerts.py
+++ b/wis2watch/src/wis2watch/core/tests/test_alerts.py
@@ -73,19 +73,34 @@ class HardFailureTestCase(TestCase):
 
         return source
 
-    def ingested(self, *, minutes_ago, published=None):
+    def ingested(self, *, minutes_ago, published=None, source=None):
         """One notification, stored when this tool actually received it."""
         received = NOW - timedelta(minutes=minutes_ago)
+        source = source or self.global_broker
 
         return NotificationMessage.objects.create(
-            source=self.global_broker,
+            source=source,
             node=self.node,
-            notification_id=f"notification-{minutes_ago}",
+            notification_id=f"notification-{source.pk}-{minutes_ago}",
             topic="origin/a/wis2/ke-meteo/data/core/weather",
             time=published or received,
             received_datetime=received,
             raw_json={},
         )
+
+    def polled(self, *, minutes_ago):
+        """One notification read out of a centre's own message archive."""
+        archive, _ = MessageSource.objects.get_or_create(
+            node=self.node,
+            source_type=MessageSource.ORIGIN_API,
+            defaults={
+                "name": "ke-meteo origin API",
+                "centre_id": "ke-meteo",
+                "api_url": "https://wis2.meteo.go.ke/oapi/collections/messages",
+            },
+        )
+
+        return self.ingested(minutes_ago=minutes_ago, source=archive)
 
     # -- reading ---------------------------------------------------------
 
@@ -263,6 +278,20 @@ class IngestionStalledTests(HardFailureTestCase):
 
         (sent,) = mail.outbox
         self.assertIn("Ingestion", sent.subject)
+
+    def test_rows_a_poller_wrote_do_not_hold_the_clock_up(self):
+        """The alert is what stands between the ingest dying and nobody noticing.
+
+        A poller writes rows on a schedule of its own, from a process that is
+        not the one this alert is watching, so counting them would leave the
+        clock permanently fresh and the alert permanently silent.
+        """
+        self.ingested(minutes_ago=STALL_MINUTES + 10)
+        self.polled(minutes_ago=1)
+
+        self.check()
+
+        self.assertIsNotNone(self.open_failure(self.KIND))
 
     def test_a_stall_is_measured_from_when_a_message_arrived(self):
         """A cache republishing an old notification is still ingestion alive."""

--- a/wis2watch/src/wis2watch/core/tests/test_catalogue_sync.py
+++ b/wis2watch/src/wis2watch/core/tests/test_catalogue_sync.py
@@ -245,7 +245,9 @@ class OriginBrokerTests(CatalogueSyncTestCase):
     def test_an_advertised_origin_broker_becomes_a_message_source(self):
         self.sync()
 
-        source = MessageSource.objects.get(node__centre_id="cg-met")
+        source = MessageSource.objects.get(
+            node__centre_id="cg-met", source_type=MessageSource.ORIGIN_BROKER
+        )
 
         self.assertEqual(source.source_type, MessageSource.ORIGIN_BROKER)
         self.assertEqual(source.host, "wis.dirmet.cg")
@@ -259,7 +261,9 @@ class OriginBrokerTests(CatalogueSyncTestCase):
         self.sync()
 
         self.assertFalse(
-            MessageSource.objects.filter(node__centre_id="ke-meteo").exists()
+            MessageSource.objects.filter(
+                node__centre_id="ke-meteo", source_type=MessageSource.ORIGIN_BROKER
+            ).exists()
         )
 
     def test_a_re_advertised_broker_updates_in_place(self):
@@ -273,10 +277,128 @@ class OriginBrokerTests(CatalogueSyncTestCase):
 
         self.sync(moved)
 
-        source = MessageSource.objects.get(node__centre_id="cg-met")
+        source = MessageSource.objects.get(
+            node__centre_id="cg-met", source_type=MessageSource.ORIGIN_BROKER
+        )
 
         self.assertEqual(source.port, 8883)
         self.assertTrue(source.use_tls)
+
+
+class OriginApiTests(CatalogueSyncTestCase):
+    """A centre's own message archive, offered from where its node answers.
+
+    Nothing advertises the archive -- no WCMP2 link relation names it -- so its
+    address is worked out from the node's base URL, which is itself an
+    inference from a canonical link. That is why the address is offered rather
+    than asserted: an operator correcting it has to be the last word.
+    """
+
+    def api_source(self, centre_id):
+        return MessageSource.objects.filter(
+            node__centre_id=centre_id, source_type=MessageSource.ORIGIN_API
+        ).first()
+
+    def test_a_node_with_an_address_gains_a_vantage_on_its_own_archive(self):
+        self.sync()
+
+        source = self.api_source("ke-meteo")
+
+        self.assertEqual(
+            source.api_url, "http://wis.meteo.go.ke/oapi/collections/messages"
+        )
+        self.assertEqual(source.centre_id, "ke-meteo")
+
+    def test_a_node_with_no_address_gains_nothing(self):
+        """Where the node answers is unknown, so where its archive is, is too."""
+        self.sync()
+
+        self.assertEqual(WIS2Node.objects.get(centre_id="cg-met").base_url, "")
+        self.assertIsNone(self.api_source("cg-met"))
+
+    def test_nothing_has_been_asked_of_it_yet(self):
+        self.sync()
+
+        source = self.api_source("ke-meteo")
+
+        self.assertIsNone(source.is_reachable)
+        self.assertIsNone(source.last_connected_at)
+
+    def test_it_sits_beside_the_node_own_broker_rather_than_replacing_it(self):
+        self.sync()
+
+        node = WIS2Node.objects.get(centre_id="tg-anamet")
+        MessageSource.objects.create(
+            name="tg-anamet origin broker",
+            source_type=MessageSource.ORIGIN_BROKER,
+            node=node,
+            centre_id="tg-anamet",
+            host="wis.anamet.tg",
+        )
+
+        self.sync()
+
+        self.assertEqual(node.message_sources.count(), 2)
+        self.assertEqual(
+            node.message_sources.get(source_type=MessageSource.ORIGIN_BROKER).host,
+            "wis.anamet.tg",
+        )
+
+    def test_a_corrected_address_survives_the_next_sync(self):
+        self.sync()
+
+        source = self.api_source("ke-meteo")
+        source.api_url = "https://api.meteo.go.ke/oapi/collections/messages"
+        source.save()
+
+        self.sync()
+        source.refresh_from_db()
+
+        self.assertEqual(
+            source.api_url, "https://api.meteo.go.ke/oapi/collections/messages"
+        )
+
+    def test_re_running_the_sync_leaves_one_archive_per_node(self):
+        self.sync()
+        self.sync()
+
+        self.assertEqual(
+            MessageSource.objects.filter(
+                source_type=MessageSource.ORIGIN_API
+            ).count(),
+            2,
+        )
+
+    def test_a_node_whose_address_arrives_later_gains_one_then(self):
+        """A centre nobody could place is offered an archive once somebody can."""
+        self.sync()
+
+        self.assertIsNone(self.api_source("cg-met"))
+
+        node = WIS2Node.objects.get(centre_id="cg-met")
+        node.base_url = "https://wis.dirmet.cg"
+        node.save()
+
+        self.sync()
+
+        self.assertEqual(
+            self.api_source("cg-met").api_url,
+            "https://wis.dirmet.cg/oapi/collections/messages",
+        )
+
+    def test_a_trailing_slash_on_the_node_address_is_not_doubled(self):
+        self.sync()
+
+        node = WIS2Node.objects.get(centre_id="cg-met")
+        node.base_url = "https://wis.dirmet.cg/"
+        node.save()
+
+        self.sync()
+
+        self.assertEqual(
+            self.api_source("cg-met").api_url,
+            "https://wis.dirmet.cg/oapi/collections/messages",
+        )
 
 
 class ManuallyManagedNodeTests(CatalogueSyncTestCase):
@@ -315,6 +437,19 @@ class ManuallyManagedNodeTests(CatalogueSyncTestCase):
         source.refresh_from_db()
 
         self.assertEqual(source.host, "broker.dirmet.cg")
+
+    def test_it_is_still_offered_a_vantage_on_its_own_archive(self):
+        """The address is derived from the operator's own base URL, not the
+        catalogue's, and offering it overwrites nothing they have said."""
+        self.sync()
+
+        source = MessageSource.objects.get(
+            node=self.node, source_type=MessageSource.ORIGIN_API
+        )
+
+        self.assertEqual(
+            source.api_url, "https://wis.dirmet.cg/oapi/collections/messages"
+        )
 
     def test_its_datasets_still_sync(self):
         """The manual flag protects the node's own fields, not its datasets."""
@@ -364,7 +499,10 @@ class IdempotenceTests(CatalogueSyncTestCase):
 
         self.assertEqual(WIS2Node.objects.count(), len(MONITORED_CENTRE_IDS))
         self.assertEqual(Dataset.objects.count(), len(MONITORED_CENTRE_IDS))
-        self.assertEqual(MessageSource.objects.count(), 1)
+
+        # One advertised broker, and an archive apiece for the two centres
+        # whose records say where they answer.
+        self.assertEqual(MessageSource.objects.count(), 3)
 
     def test_the_second_run_updates_rather_than_creates(self):
         self.sync()

--- a/wis2watch/src/wis2watch/core/tests/test_models.py
+++ b/wis2watch/src/wis2watch/core/tests/test_models.py
@@ -1,3 +1,4 @@
+from django.core.exceptions import ValidationError
 from django.db import IntegrityError
 from django.test import TestCase, override_settings
 from django.utils import timezone as dj_timezone
@@ -12,6 +13,7 @@ from wis2watch.core.models import (
     SyncLog,
     WIS2Node,
 )
+from wis2watch.core.tests.support import origin_api
 
 
 def make_node(centre_id="ke-kmd", **kwargs):
@@ -110,6 +112,152 @@ class MessageSourceTests(TestCase):
 
         self.assertEqual(node.message_sources.count(), 2)
         self.assertEqual(node.origin_source.host, "broker.kmd.test")
+
+
+class OriginApiSourceTests(TestCase):
+    """A centre's own notification archive, as a vantage point of its own."""
+
+    def test_a_node_has_at_most_one_origin_api(self):
+        node = make_node()
+        origin_api(node)
+
+        with self.assertRaises(IntegrityError):
+            origin_api(node, name="KMD archive duplicate")
+
+    def test_it_sits_beside_the_node_own_broker(self):
+        node = make_node()
+        make_source(
+            name="KMD origin",
+            source_type=MessageSource.ORIGIN_BROKER,
+            host="broker.kmd.test",
+            node=node,
+        )
+
+        source = origin_api(node)
+
+        self.assertEqual(node.message_sources.count(), 2)
+        self.assertEqual(
+            source.api_url, "https://example.test/oapi/collections/messages"
+        )
+
+    def test_it_carries_no_reachability_until_something_has_asked(self):
+        self.assertIsNone(origin_api(make_node()).is_reachable)
+
+    def test_the_node_own_broker_is_still_the_node_origin_source(self):
+        """``origin_source`` names the broker, which is what dials the centre."""
+        node = make_node()
+        origin_api(node)
+        make_source(
+            name="KMD origin",
+            source_type=MessageSource.ORIGIN_BROKER,
+            host="broker.kmd.test",
+            node=node,
+        )
+
+        self.assertEqual(node.origin_source.host, "broker.kmd.test")
+
+    def test_it_belongs_to_the_centre_its_node_names(self):
+        self.assertEqual(origin_api(make_node("ke-kmd")).owning_centre_id, "ke-kmd")
+
+
+class OriginVantageQuerySetTests(TestCase):
+    """Which vantage points may be judged against the Global Broker.
+
+    Both origin transports answer here, so that the evaluation recording a
+    centre's gaps and the report listing them are asking one question.
+    """
+
+    def setUp(self):
+        self.node = make_node("ke-kmd")
+        self.broker = make_source(
+            name="KMD origin",
+            source_type=MessageSource.ORIGIN_BROKER,
+            host="broker.kmd.test",
+            node=self.node,
+        )
+        self.archive = origin_api(self.node)
+
+    def test_both_origin_transports_are_origin_vantages(self):
+        self.assertEqual(
+            {source.pk for source in MessageSource.objects.origin_vantages()},
+            {self.broker.pk, self.archive.pk},
+        )
+
+    def test_a_global_broker_is_not_an_origin_vantage(self):
+        make_source()
+
+        self.assertNotIn(
+            MessageSource.GLOBAL_BROKER,
+            {source.source_type for source in MessageSource.objects.origin_vantages()},
+        )
+
+    def test_a_vantage_switched_off_is_not_one(self):
+        self.archive.is_active = False
+        self.archive.save()
+
+        self.assertEqual(
+            [source.pk for source in MessageSource.objects.origin_vantages()],
+            [self.broker.pk],
+        )
+
+    def test_only_the_vantages_that_answered_may_be_judged_on(self):
+        self.broker.is_reachable = True
+        self.broker.save()
+
+        self.assertEqual(
+            [source.pk for source in MessageSource.objects.watched_origins()],
+            [self.broker.pk],
+        )
+
+    def test_a_reachable_archive_may_be_judged_on_too(self):
+        self.archive.is_reachable = True
+        self.archive.save()
+
+        self.assertEqual(
+            [source.pk for source in MessageSource.objects.watched_origins()],
+            [self.archive.pk],
+        )
+
+    def test_nothing_is_dialled_at_an_archive(self):
+        """The status panel reports connections; nothing connects to an archive."""
+        self.assertEqual(
+            {source.pk for source in MessageSource.objects.dialled()},
+            {self.broker.pk},
+        )
+
+
+class MessageSourceAddressTests(TestCase):
+    """What an operator has to give a vantage point before it will save."""
+
+    def test_a_broker_needs_a_host(self):
+        source = MessageSource(name="Nowhere", source_type=MessageSource.GLOBAL_BROKER)
+
+        with self.assertRaises(ValidationError) as raised:
+            source.full_clean()
+
+        self.assertIn("host", raised.exception.error_dict)
+
+    def test_an_origin_api_needs_an_archive_address(self):
+        source = MessageSource(
+            name="ke-kmd origin API",
+            source_type=MessageSource.ORIGIN_API,
+            node=make_node("ke-kmd"),
+        )
+
+        with self.assertRaises(ValidationError) as raised:
+            source.full_clean()
+
+        self.assertIn("api_url", raised.exception.error_dict)
+
+    def test_an_origin_api_needs_no_host(self):
+        source = MessageSource(
+            name="ke-kmd origin API",
+            source_type=MessageSource.ORIGIN_API,
+            node=make_node("ke-kmd"),
+            api_url="https://example.test/oapi/collections/messages",
+        )
+
+        source.full_clean()
 
 
 class NotificationMessageTests(TestCase):

--- a/wis2watch/src/wis2watch/core/tests/test_propagation.py
+++ b/wis2watch/src/wis2watch/core/tests/test_propagation.py
@@ -26,7 +26,7 @@ from wis2watch.core.models import (
 )
 from wis2watch.core.propagation import evaluate_propagation
 from wis2watch.core.retention import raw_retention_cutoff
-from wis2watch.core.tests.support import at, origin_broker
+from wis2watch.core.tests.support import at, origin_api, origin_broker
 
 
 NOW = at("2026-08-11T12:00:00")
@@ -404,6 +404,25 @@ class SuppressionTests(PropagationTestCase):
         self.assertEqual(self.missing(), ["kenyan"])
         self.assertEqual(counts.nodes_evaluated, 1)
         self.assertEqual(counts.nodes_suppressed, 1)
+
+    def test_a_second_vantage_on_one_centre_is_still_one_centre_suppressed(self):
+        """The count is of centres passed over, not of rows behind them."""
+        self.kenya_origin.is_reachable = False
+        self.kenya_origin.save()
+        origin_api(self.kenya)
+
+        counts = self.evaluate()
+
+        self.assertEqual(counts.nodes_evaluated, 0)
+        self.assertEqual(counts.nodes_suppressed, 1)
+
+    def test_a_centre_watched_through_one_vantage_is_not_also_suppressed(self):
+        origin_api(self.kenya)
+
+        counts = self.evaluate()
+
+        self.assertEqual(counts.nodes_evaluated, 1)
+        self.assertEqual(counts.nodes_suppressed, 0)
 
     def test_what_the_connection_record_says_now_does_not_unjudge_past_hours(self):
         """Blindness is read off the traffic, not off a side record.

--- a/wis2watch/src/wis2watch/core/viewsets.py
+++ b/wis2watch/src/wis2watch/core/viewsets.py
@@ -59,14 +59,18 @@ class WIS2NodeViewSet(ModelViewSet):
 
 
 class MessageSourceIndexView(generic.IndexView):
-    """The broker list, showing what is actually connected to.
+    """The vantage points that carry an address of their own.
 
-    A Global Cache pickup is a vantage point read off a Global Broker
-    connection's ``cache/`` topics rather than a broker of its own, so it has
-    no address to correct, no credential to set and nothing that deactivating
-    it would stop. Listed here it would offer an operator three controls that
-    do nothing. What it is carrying is on the node overview instead, per
-    centre, which is the question anyone actually has about it.
+    A Global Cache pickup is read off a Global Broker connection's ``cache/``
+    topics rather than reached at an address, so it has nothing to correct, no
+    credential to set and nothing that deactivating it would stop. Listed here
+    it would offer an operator three controls that do nothing. What it is
+    carrying is on the node overview instead, per centre, which is the
+    question anyone actually has about it.
+
+    A centre's own message archive is listed, though nothing dials it: its
+    address is a guess that only an operator can correct, and this is where
+    they correct it.
     """
 
     def get_base_queryset(self):

--- a/wis2watch/src/wis2watch/core/viewsets.py
+++ b/wis2watch/src/wis2watch/core/viewsets.py
@@ -78,14 +78,21 @@ class MessageSourceIndexView(generic.IndexView):
 
 
 class MessageSourceViewSet(ModelViewSet):
+    """Where every vantage point's address is set, brokers and archives alike.
+
+    Listed by address rather than by host and port, because the two kinds are
+    not reached the same way and a column of ports would be inventing one for
+    the kind that has none.
+    """
+
     model = MessageSource
     index_view_class = MessageSourceIndexView
     base_url_path = "message-sources"
     icon = "site"
-    menu_label = "Brokers"
+    menu_label = "Message sources"
     add_to_admin_menu = True
     menu_order = 110
-    list_display = ["name", "source_type", "host", "port", "is_active"]
+    list_display = ["name", "source_type", "address", "is_active"]
 
 
 class GlobalDiscoveryCatalogueViewSet(ModelViewSet):

--- a/wis2watch/src/wis2watch/ingest/subscriptions.py
+++ b/wis2watch/src/wis2watch/ingest/subscriptions.py
@@ -83,6 +83,11 @@ def active_origin_broker_sources():
     to be unreachable is still knocked on -- it may come back, and until it
     does its silence is the answer. Deactivating the source in the admin is
     the one way to stop attempting it.
+
+    Brokers alone, deliberately. A centre also offers its own notifications
+    over HTTP, and that vantage point stands beside this one everywhere a
+    centre is judged on what it published -- but there is no connection to
+    hold open to an archive, so it has no business in a list of what to dial.
     """
     return (
         MessageSource.objects.filter(

--- a/wis2watch/src/wis2watch/ingest/tests/test_subscriptions.py
+++ b/wis2watch/src/wis2watch/ingest/tests/test_subscriptions.py
@@ -9,7 +9,7 @@ confidently wrong answer rather than an exception.
 from django.test import TestCase
 
 from wis2watch.core.models import MessageSource, WIS2Node
-from wis2watch.core.tests.support import origin_broker
+from wis2watch.core.tests.support import origin_api, origin_broker
 from wis2watch.ingest.subscriptions import (
     active_global_broker_sources,
     active_origin_broker_sources,
@@ -195,6 +195,11 @@ def broker_for(centre_id, **kwargs):
     return origin_broker(node(centre_id), **kwargs)
 
 
+def origin_api_for(centre_id, *, on=None, **kwargs):
+    """A new node with a message archive of its own, as a sync leaves it."""
+    return origin_api(on or node(centre_id), **kwargs)
+
+
 class OriginBrokerSourceTests(TestCase):
     """Every monitored node's own broker is attempted, reachable or not."""
 
@@ -235,6 +240,20 @@ class OriginBrokerSourceTests(TestCase):
         )
 
         self.assertEqual(list(active_origin_broker_sources()), [])
+
+    def test_a_centre_own_message_archive_is_never_dialled(self):
+        """It is a vantage point read over HTTP; there is nothing to connect to."""
+        origin_api_for("ke-meteo")
+
+        self.assertEqual(list(active_origin_broker_sources()), [])
+
+    def test_an_archive_beside_a_broker_leaves_the_broker_dialled_alone(self):
+        broker = broker_for("ke-meteo")
+        origin_api_for("ke-meteo", on=broker.node)
+
+        self.assertEqual(
+            [source.pk for source in active_origin_broker_sources()], [broker.pk]
+        )
 
 
 class OriginBrokerSubscriptionTests(TestCase):

--- a/wis2watch/src/wis2watch/ingest/tests/test_supervisor.py
+++ b/wis2watch/src/wis2watch/ingest/tests/test_supervisor.py
@@ -22,7 +22,12 @@ from wis2watch.core.models import (
     NotificationMessage,
     WIS2Node,
 )
-from wis2watch.core.tests.support import in_region, load_jsonl_fixture, origin_broker
+from wis2watch.core.tests.support import (
+    in_region,
+    load_jsonl_fixture,
+    origin_api,
+    origin_broker,
+)
 from wis2watch.ingest.client import RECONNECT_MAX_DELAY
 from wis2watch.ingest.store import store_notifications
 from wis2watch.ingest.supervisor import Supervisor
@@ -471,6 +476,24 @@ class OriginBrokersFollowTheRegistryTests(SupervisorTestCase):
         self.assertTrue(self.is_connected(dj))
         self.assertTrue(self.listeners[ke].started)
         self.assertTrue(self.listeners[dj].started)
+
+    def test_a_centre_own_message_archive_is_never_connected_to(self):
+        """A vantage point read over HTTP has nothing for this loop to dial."""
+        archive = origin_api(self.node("ke-meteo"))
+
+        self.supervisor.start_listeners()
+        self.supervisor.refresh_from_registry()
+
+        self.assertFalse(self.is_connected(archive))
+
+    def test_an_archive_beside_a_broker_leaves_the_broker_connected(self):
+        broker = self.origin_broker("ke-meteo")
+        archive = origin_api(broker.node)
+
+        self.supervisor.start_listeners()
+
+        self.assertTrue(self.is_connected(broker))
+        self.assertFalse(self.is_connected(archive))
 
     def test_a_node_broker_is_asked_for_its_own_centre_only(self):
         origin = self.origin_broker("ke-meteo")

--- a/wis2watch/src/wis2watch/ws/consumers.py
+++ b/wis2watch/src/wis2watch/ws/consumers.py
@@ -78,10 +78,12 @@ class IngestFeedConsumer(AsyncWebsocketConsumer):
         """How each broker connection is faring, as the supervisor last left it."""
         from wis2watch.core.models import MessageSource
 
-        # Connections only. A carried vantage point has no reachability of its
-        # own to report, and would show here as one that never came up.
+        # Connections only. A vantage point nothing dials -- one carried by
+        # another connection, or an archive read over HTTP -- has no
+        # reachability of its own to report here, and would show as one that
+        # never came up.
         sources = (
-            MessageSource.objects.connections()
+            MessageSource.objects.dialled()
             .filter(is_active=True)
             .select_related("node")
         )


### PR DESCRIPTION
Closes #53.

A centre's own OGC API message archive becomes a vantage point the tool knows about, one per node, created beside the origin broker a catalogue sync already creates. **Nothing polls it.** Reachability stays null, because "never attempted" and "does not answer" are different findings and only a poll can tell them apart — the way dialling settles a broker.

## What changed

**Model** — `MessageSource` gains an `ORIGIN_API` type and an editable `api_url`. The existing `(node, source_type)` unique constraint already gives at most one per node. `host` becomes optional, and `clean()` now asks for the address the *kind* needs — a host for brokers, an archive URL for an origin API — so the admin refuses the field that is actually missing rather than demanding a broker host from someone correcting a URL.

**Catalogue sync** — the row is created from the node's base URL plus `/oapi/collections/messages`, via `get_or_create`, so an operator's correction is never written over. A node with no base URL gets nothing: there is nowhere to guess from.

Where the archive lives is a guess twice removed. No WCMP2 link relation names it, serving one at all is a wis2box convention rather than a WIS2 requirement, and the address is derived from a base URL that is itself inferred from a canonical link — so a centre publishing those into separate object storage yields a base URL the archive does not live under. That is why the address is offered once and corrected by hand.

**Querysets** — `origin_brokers()` becomes `origin_vantages()` and covers both origin transports, so `watched_origins()` — asked by both the propagation evaluation and the report listing its gaps — keeps giving one answer to one question. `dialled()` is new: `connections()` minus archives, for the ingest-status panel. The supervisor's dial list is untouched and still brokers only; there is no connection to hold open to an archive.

**Ingestion-stall alert** — stops counting origin-API rows. It is the only thing standing between the single-replica ingest dying and nobody noticing, and it works by reading a clock only that process winds. A poller running elsewhere on a schedule of its own would hold that clock up indefinitely and silently disable the alert.

**Admin** — the listing an operator reaches an archive through was still the broker list, printing a blank host and a default port of 1883 against something reached over HTTP, with no sign of the one field the row exists to expose. It now shows one address column that says where each kind actually points.

## Two judgement calls worth a look

**Manually managed nodes get an archive row too.** The ticket says "every node that has a base URL"; the repo's sync convention says the manual flag protects a node's own vantage points. I create it anyway, because the address derives from the node's own `base_url` — which for a manually managed node is the operator's correction rather than the catalogue's — and the row is never overwritten. One line to change if the flag should block it.

**`nodes_suppressed` moves on the first sync after deploy.** It now counts centres (distinct nodes) with an unjudgeable origin vantage rather than origin-broker rows, which follows from the ticket's requirement that this queryset cover both transports. It is log-only; nothing on screen or in mail reads it.

## Testing

929 tests pass. New coverage: the archive as a vantage point and the querysets that include it, the sync creating and never overwriting it, an operator correcting `api_url` through the admin form and the correction surviving a later sync, the supervisor never connecting to one, and a stall still reported when the only fresh arrivals are polled.