### PR TITLE
Ask a centre for the messages it published

### DIFF
--- a/wis2watch/src/wis2watch/core/analysis/silence.py
+++ b/wis2watch/src/wis2watch/core/analysis/silence.py
@@ -33,8 +33,11 @@ and a yearly dataset can never be found quiet, because its absence never
 exceeds what was looked at. So the last hour a dataset published in is asked
 of the whole history, which the index on the rollups makes one backwards walk
 per dataset, and a dataset never seen publishing at all is quiet only as far
-back as this tool holds records of anything -- absence before that is not
-evidence, it is the tool not having existed yet.
+back as this tool can show it was listening -- absence before that is not
+evidence, it is the tool not having existed yet. Which is why that floor is
+read off the vantage points it listens to live: a centre's own archive can be
+pulled months deep, and those are hours it holds one centre's word for rather
+than hours it was hearing the region.
 """
 
 from dataclasses import dataclass
@@ -44,7 +47,7 @@ from django.db.models import F, Min, OuterRef, Subquery
 from django.utils import timezone as dj_timezone
 from django.utils.translation import gettext_lazy as _
 
-from ..models import Dataset, HourlyRollup
+from ..models import Dataset, HourlyRollup, MessageSource
 from ..rollups import floor_to_hour
 
 #: Sorts before any real last-seen time, so whatever nothing has ever been
@@ -297,14 +300,32 @@ def _last_active_hour(now):
 
 
 def _records_begin(now):
-    """The earliest moment this tool holds any record of the region publishing.
+    """The earliest hour this tool can show it was listening to the region.
 
     What a dataset never seen publishing is measured against. Absence before
     this is not evidence of silence -- there was nothing here to have seen it
     -- and treating it as evidence would greet every new deployment with a
     region-wide outage that never happened.
+
+    Read off the vantage points this tool listens to live, and off those only.
+    A centre's own message archive can be pulled months deep, which is what it
+    is for; counting those hours here would move the floor for the whole
+    region back to a stretch nobody was watching, and every dataset never seen
+    publishing -- at every other centre, whose archive was never asked --
+    would be reported quiet for months that only one centre has any record of.
+    A pull of one centre's history is evidence about that centre, and the hours
+    it reaches back through are not hours this tool was hearing anyone else.
+
+    The centre that was pulled loses nothing by it. Its datasets that did
+    publish are judged on the hours their own messages landed in, archive and
+    all; this floor is only ever reached for a dataset never seen at all, where
+    measuring from when the tool arrived understates the quiet rather than
+    inventing it.
     """
-    earliest = HourlyRollup.objects.aggregate(earliest=Min("hour"))["earliest"]
+    earliest = (
+        HourlyRollup.objects.exclude(source__source_type=MessageSource.ORIGIN_API)
+        .aggregate(earliest=Min("hour"))["earliest"]
+    )
 
     return earliest or now
 

--- a/wis2watch/src/wis2watch/core/interpretation/__init__.py
+++ b/wis2watch/src/wis2watch/core/interpretation/__init__.py
@@ -18,6 +18,7 @@ from ..countries import (
     is_monitored_centre_id,
     monitored_country_code_for_centre_id,
 )
+from .archive import archived_notifications
 from .brokers import DEFAULT_PORTS, BrokerConnection, parse_broker_url
 from .discovery import (
     DiscoveredDataset,
@@ -64,6 +65,7 @@ __all__ = [
     "OscarStation",
     "ParsedNotification",
     "ParsedTopic",
+    "archived_notifications",
     "canonical_link",
     "centre_id_from_identifier",
     "centre_id_prefix",

--- a/wis2watch/src/wis2watch/core/interpretation/archive.py
+++ b/wis2watch/src/wis2watch/core/interpretation/archive.py
@@ -1,0 +1,29 @@
+"""Reading a centre's own archive of the notifications it published.
+
+A wis2box serves the notifications it has published as an OGC API Features
+collection, and each feature in it *is* a WIS2 Notification Message -- the same
+JSON the broker carries, envelope and all. So there is nothing to normalise
+here: what the page offers is handed to :func:`parse_notification` as it
+stands, which is what lets one store path serve both vantage points on a
+centre.
+
+What the page does not carry is a topic. On the broker, the topic is what says
+which centre published, whether the message is the centre's own publication or
+a Global Cache's copy of it, and which dataset it belongs to. None of that is
+in the archive, and none of it is invented here: the centre is known because
+the poller chose the address, and everything else is read off the message or
+left absent.
+"""
+
+
+def archived_notifications(payload):
+    """The notification messages a page of a centre's archive carries.
+
+    Returned as captured. Whether one of them can be identified in time --
+    and so stored at all -- is :func:`parse_notification`'s question, asked
+    once for both vantage points rather than answered again here.
+    """
+    if not payload:
+        return []
+
+    return payload.get("features") or []

--- a/wis2watch/src/wis2watch/core/migrations/0017_ask_a_centre_for_the_messages_it_published.py
+++ b/wis2watch/src/wis2watch/core/migrations/0017_ask_a_centre_for_the_messages_it_published.py
@@ -1,0 +1,34 @@
+"""Name the run that asks a centre for the notifications it published.
+
+A poll of a centre's own message archive is reported the way every other run
+against a node is -- one sync log, with what it found and what it could not
+store -- so that "was this centre's archive read, and what came back" is
+answered on the node's page beside its station sync rather than in a log file.
+"""
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("wis2watchcore", "0016_a_centres_own_archive_as_a_vantage_point"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="synclog",
+            name="sync_type",
+            field=models.CharField(
+                choices=[
+                    ("catalogue", "Global Discovery Catalogue"),
+                    ("discovery_metadata", "Discovery Metadata"),
+                    ("link_probes", "Canonical Link Probes"),
+                    ("message_archive", "Centre Message Archive"),
+                    ("node_stations", "Node Stations"),
+                    ("oscar_stations", "OSCAR Stations"),
+                    ("wildcard_sweep", "Wildcard Sweep"),
+                ],
+                max_length=50,
+            ),
+        ),
+    ]

--- a/wis2watch/src/wis2watch/core/models.py
+++ b/wis2watch/src/wis2watch/core/models.py
@@ -1442,6 +1442,7 @@ class SyncLog(models.Model):
     CATALOGUE = "catalogue"
     DISCOVERY_METADATA = "discovery_metadata"
     LINK_PROBES = "link_probes"
+    MESSAGE_ARCHIVE = "message_archive"
     NODE_STATIONS = "node_stations"
     OSCAR_STATIONS = "oscar_stations"
     WILDCARD_SWEEP = "wildcard_sweep"
@@ -1450,6 +1451,7 @@ class SyncLog(models.Model):
         (CATALOGUE, _("Global Discovery Catalogue")),
         (DISCOVERY_METADATA, _("Discovery Metadata")),
         (LINK_PROBES, _("Canonical Link Probes")),
+        (MESSAGE_ARCHIVE, _("Centre Message Archive")),
         (NODE_STATIONS, _("Node Stations")),
         (OSCAR_STATIONS, _("OSCAR Stations")),
         (WILDCARD_SWEEP, _("Wildcard Sweep")),

--- a/wis2watch/src/wis2watch/core/sync.py
+++ b/wis2watch/src/wis2watch/core/sync.py
@@ -32,6 +32,11 @@ UPDATED = "updated"
 ERRORED = "errored"
 
 #: A ceiling on paging, so a collection whose ``next`` links cycle cannot spin.
+#: Sized for the collections a schedule reads, which are registries of a few
+#: hundred records. A caller reading something that is legitimately longer --
+#: a centre's archive of months of notifications -- says so rather than having
+#: this raised for everybody, since the ceiling is only useful while it is
+#: lower than anything a healthy source would return.
 MAX_PAGES = 50
 
 FETCH_TIMEOUT = 60
@@ -47,17 +52,29 @@ class PagingDidNotTerminate(Exception):
     """
 
 
-def fetch_pages(url, params=None, verify=True, timeout=FETCH_TIMEOUT, read_from=""):
+def fetch_pages(
+    url,
+    params=None,
+    verify=True,
+    timeout=FETCH_TIMEOUT,
+    read_from="",
+    max_pages=MAX_PAGES,
+):
     """Every page of an OGC API Features collection, exactly as returned.
 
     Paging follows the server's own ``next`` link rather than an offset we
     compute, since that link already carries whatever query it needs to resume.
-    Only the first request supplies parameters.
+    Only the first request supplies parameters -- which is also why the link
+    has to carry the query forward: a filtered read that resumed without its
+    filter would page on through the whole collection believing it was still
+    reading the window it asked for.
 
     ``read_from`` names what is being read, for the failure raised when the
-    collection never stops offering another page.
+    collection never stops offering another page. ``max_pages`` is how many it
+    is given to stop, and is worth raising only where the collection really is
+    longer than a registry.
     """
-    for _ in range(MAX_PAGES):
+    for _ in range(max_pages):
         response = requests.get(
             url,
             params=params,
@@ -77,7 +94,7 @@ def fetch_pages(url, params=None, verify=True, timeout=FETCH_TIMEOUT, read_from=
         params = None
 
     raise PagingDidNotTerminate(
-        f"stopped paging {read_from} after {MAX_PAGES} pages; "
+        f"stopped paging {read_from} after {max_pages} pages; "
         "its next links do not terminate"
     )
 

--- a/wis2watch/src/wis2watch/core/tests/fixtures/README.md
+++ b/wis2watch/src/wis2watch/core/tests/fixtures/README.md
@@ -6,7 +6,7 @@ what these sources actually return, which is repeatedly not what their schemas
 suggest.
 
 The first three were captured on **2026-08-11**, the node station registry on
-**2026-08-12**.
+**2026-08-12**, and the two node message archives on **2026-08-13**.
 
 ## `global_broker_notifications.jsonl`
 
@@ -102,6 +102,65 @@ A registry longer than the page size links to its next page under `rel: next`,
 the same as a Global Discovery Catalogue does; this capture fits on one page
 and so carries no such link. The default page size of a station endpoint is
 routinely ten, which is why the fetch asks for more.
+
+## `node_messages_sc_seychelles_met.json` and `node_messages_gh_gmet.json`
+
+Two centres' own archives of the notifications they published, which a wis2box
+serves at `/oapi/collections/messages/items`. Both are unedited pages, exactly
+as the node returned them — envelope, links and all.
+
+**What makes these different from the captured broker traffic: there is no
+topic.** Not omitted from the property the parser reads, but absent from the
+payload entirely — nothing in a feature, at any level, says what topic the
+message went out on. Everything the ingest reads off a topic therefore has to
+come from somewhere else here: the centre from the address that was polled, the
+vantage point because the archive is one, and the dataset from the
+`metadata_id` the message carries. What is stored carries an empty topic,
+because none was observed. Synthesising the dataset's declared topic would read
+better and would destroy the evidence for a centre transmitting data no dataset
+of its own claims — a message no topic would ever have named.
+
+**Both carry a metadata notification mixed in with the data ones**, which is
+what a centre publishing its own discovery metadata looks like from the
+archive. It carries the WCMP2 record inline as base64, names **no**
+`metadata_id` (the record it announces is the one that would be named), carries
+no `wigos_station_identifier`, and advertises only a `rel: update` link — no
+canonical link at all. So it resolves to no dataset and no station, and is
+stored for all that, as the MQTT path stores one.
+
+| Capture | Retention at capture | The window asked for | Match count |
+| --- | --- | --- | --- |
+| `node_messages_sc_seychelles_met.json` | 451 messages, about 36 hours | `2026-08-12T14:30:00Z/2026-08-12T16:00:00Z` | 14 matched, 14 returned |
+| `node_messages_gh_gmet.json` | 57,170 messages, back to 2026-05-06 | `2026-08-09T00:00:00Z/2026-08-11T23:59:59Z` | 1,757 matched, 10 returned |
+
+Retention depth is a per-node property and it drifts, which is why both the
+match count and the capture date are recorded here: Seychelles
+(`https://wis2.meteo.sc`) holds barely a day and its whole archive fits on one
+page at the page size the poll asks for, while Ghana
+(`https://wis2.meteo.gov.gh`) holds three months and pages genuinely.
+
+What each covers:
+
+- **The shallow one** is a single page: no `rel: next` link, and
+  `numberMatched` equal to `numberReturned`. Thirteen data notifications, one
+  per station, and the metadata notification.
+- **The deep one** is a page from the *middle* of a paging run —
+  `offset=386&limit=10` of 1,757 — captured that way so that one page could
+  carry both a metadata notification and a real `next` link. Its `next` link
+  carries the `datetime` interval forward, which is why paging follows the
+  server's own link rather than an offset we compute: a resumed page that
+  dropped the interval would read on through the whole archive believing it was
+  still inside the window.
+- **Neither page is in publication order.** The deep capture's ten
+  notifications run 17:09, 15:00, 17:09, … as returned. Anything reading the
+  first or last row of a page as the edge of the window would be wrong on this
+  very capture.
+
+The `datetime` parameter matches on **`pubtime`**, not on the observation time
+in `properties.datetime`: at capture, a window of `10:00Z/11:00Z` returned
+notifications published between 10:09 and 10:24 whose observation times were
+all 09:00. That is what makes the reply comparable with what the Global Broker
+carried — the same claim, by the same publisher, about the same moment.
 
 ## Refreshing a fixture
 

--- a/wis2watch/src/wis2watch/core/tests/fixtures/node_messages_gh_gmet.json
+++ b/wis2watch/src/wis2watch/core/tests/fixtures/node_messages_gh_gmet.json
@@ -1,0 +1,509 @@
+{
+ "type": "FeatureCollection",
+ "features": [
+  {
+   "id": "edc1e42c-0641-48ee-b9bd-41129432be10",
+   "type": "Feature",
+   "conformsTo": [
+    "http://wis.wmo.int/spec/wnm/1/conf/core"
+   ],
+   "geometry": {
+    "coordinates": [
+     -2.8054,
+     7.2153
+    ],
+    "type": "Point"
+   },
+   "properties": {
+    "data_id": "gh-gmet:core.surface-based-observations.synop/WIGOS_0-288-0-65492_20260809T160000",
+    "datetime": "2026-08-09T16:00:00Z",
+    "pubtime": "2026-08-09T17:09:20Z",
+    "integrity": {
+     "method": "sha512",
+     "value": "qqxmpPiwR3Rd1I4jDeXSUvtVQ2ONA6FXt6wQ339rUaTtK4W1jWyQRB9atp75/lMpNoqpRgyOEJaCf4X2WOxmLw=="
+    },
+    "metadata_id": "urn:wmo:md:gh-gmet:core.surface-based-observations.synop",
+    "content": {
+     "encoding": "base64",
+     "value": "QlVGUgABgAQAABYA/////wAAAAJuHgAH6ggJEAAAAAALAAABgMGWx2AAAVMAABIAAANjU0OTIAAAAAAAAAAAAAAP////////////////////////////+P1QTABKK10hzBSBKO//////////////////////////////+YZ////////////////3Q3///J////////////////////////////////////////////////////////////////Af////gP//////////////////////////////////////////////////////////////////+L/9NgG/f2///74n///dM//////////////////////////////////////////////////f/AAX/f/9/r//f0//36P//////////////////////////////////////////////////////////////////////////////////////8A3Nzc3",
+     "size": 384
+    },
+    "wigos_station_identifier": "0-288-0-65492",
+    "id": "edc1e42c-0641-48ee-b9bd-41129432be10"
+   },
+   "links": [
+    {
+     "rel": "canonical",
+     "type": "application/bufr",
+     "href": "https://wis2.meteo.gov.gh/data/2026-08-09/wis/urn:wmo:md:gh-gmet:core.surface-based-observations.synop/WIGOS_0-288-0-65492_20260809T160000.bufr4",
+     "length": 384
+    },
+    {
+     "rel": "via",
+     "type": "text/html",
+     "href": "https://oscar.wmo.int/surface/#/search/station/stationReportDetails/0-288-0-65492"
+    }
+   ],
+   "generated_by": "wis2box 1.2.0"
+  },
+  {
+   "id": "28babf6b-1020-443c-ab4f-eb369c4f3990",
+   "type": "Feature",
+   "conformsTo": [
+    "http://wis.wmo.int/spec/wnm/1/conf/core"
+   ],
+   "geometry": {
+    "coordinates": [
+     -0.6862854,
+     7.7296587
+    ],
+    "type": "Point"
+   },
+   "properties": {
+    "data_id": "gh-gmet:core.surface-based-observations.synop/WIGOS_0-288-0-65462_20260809T160000",
+    "datetime": "2026-08-09T16:00:00Z",
+    "pubtime": "2026-08-09T17:09:21Z",
+    "integrity": {
+     "method": "sha512",
+     "value": "EP+BCsLPjhB3jVSaQNhIRd2iW6j7lf/0Wjr+z2oVA4L9yrF1U3/PiagSXgi3gOY5XMEoGlUHqvJAd5k2Ru/9GA=="
+    },
+    "metadata_id": "urn:wmo:md:gh-gmet:core.surface-based-observations.synop",
+    "content": {
+     "encoding": "base64",
+     "value": "QlVGUgABgAQAABYA/////wAAAAJuHgAH6ggJEAAAAAALAAABgMGWx2AAAVMAABIAAANjU0NjIAAAAAAAAAAAAAAP////////////////////////////+P1QTABKj9MiM41hZE//////////////////////////////+bC////////////////3Ve//+t////////////////////////////////////////////////////////////////Af////gP//////////////////////////////////////////////////////////////////+L/9mAV/f2///74n///dM//////////////////////////////////////////////////f/AAX/f/9/r//f0//36P//////////////////////////////////////////////////////////////////////////////////////8A3Nzc3",
+     "size": 384
+    },
+    "wigos_station_identifier": "0-288-0-65462",
+    "id": "28babf6b-1020-443c-ab4f-eb369c4f3990"
+   },
+   "links": [
+    {
+     "rel": "canonical",
+     "type": "application/bufr",
+     "href": "https://wis2.meteo.gov.gh/data/2026-08-09/wis/urn:wmo:md:gh-gmet:core.surface-based-observations.synop/WIGOS_0-288-0-65462_20260809T160000.bufr4",
+     "length": 384
+    },
+    {
+     "rel": "via",
+     "type": "text/html",
+     "href": "https://oscar.wmo.int/surface/#/search/station/stationReportDetails/0-288-0-65462"
+    }
+   ],
+   "generated_by": "wis2box 1.2.0"
+  },
+  {
+   "id": "73a97fb2-f3d6-4eb2-9dd4-2b0b10ba961b",
+   "type": "Feature",
+   "conformsTo": [
+    "http://wis.wmo.int/spec/wnm/1/conf/core"
+   ],
+   "geometry": {
+    "coordinates": [
+     -2.7762858,
+     7.5883323
+    ],
+    "type": "Point"
+   },
+   "properties": {
+    "data_id": "gh-gmet:core.surface-based-observations.synop/WIGOS_0-288-0-65468_20260809T160000",
+    "datetime": "2026-08-09T16:00:00Z",
+    "pubtime": "2026-08-09T17:09:22Z",
+    "integrity": {
+     "method": "sha512",
+     "value": "MK0HKqVAHJ7I91F2pnZLaxfPnilQkLMAHE5aMCTRUdG+QqqmDq8RkGcerqBPV7mSeo1bK2j5Slrhpqp/DZ7lvQ=="
+    },
+    "metadata_id": "urn:wmo:md:gh-gmet:core.surface-based-observations.synop",
+    "content": {
+     "encoding": "base64",
+     "value": "QlVGUgABgAQAABYA/////wAAAAJuHgAH6ggJEAAAAAALAAABgMGWx2AAAVMAABIAAANjU0NjgAAAAAAAAAAAAAAP////////////////////////////+P1QTABKdDihzYBhr0//////////////////////////////+ZO////////////////3UY//+r////////////////////////////////////////////////////////////////Af////gP//////////////////////////////////////////////////////////////////+L/8Agh/f2///74n///dM//////////////////////////////////////////////////f/AAX/f/9/r//f0//36P//////////////////////////////////////////////////////////////////////////////////////8A3Nzc3",
+     "size": 384
+    },
+    "wigos_station_identifier": "0-288-0-65468",
+    "id": "73a97fb2-f3d6-4eb2-9dd4-2b0b10ba961b"
+   },
+   "links": [
+    {
+     "rel": "canonical",
+     "type": "application/bufr",
+     "href": "https://wis2.meteo.gov.gh/data/2026-08-09/wis/urn:wmo:md:gh-gmet:core.surface-based-observations.synop/WIGOS_0-288-0-65468_20260809T160000.bufr4",
+     "length": 384
+    },
+    {
+     "rel": "via",
+     "type": "text/html",
+     "href": "https://oscar.wmo.int/surface/#/search/station/stationReportDetails/0-288-0-65468"
+    }
+   ],
+   "generated_by": "wis2box 1.2.0"
+  },
+  {
+   "id": "db6a1921-a6fc-4610-a7c6-f5175c1c47d6",
+   "type": "Feature",
+   "conformsTo": [
+    "http://wis.wmo.int/spec/wnm/1/conf/core"
+   ],
+   "geometry": {
+    "coordinates": [
+     -0.0364,
+     8.412
+    ],
+    "type": "Point"
+   },
+   "properties": {
+    "data_id": "gh-gmet:core.surface-based-observations.synop/WIGOS_0-288-0-65483_20260809T160000",
+    "datetime": "2026-08-09T16:00:00Z",
+    "pubtime": "2026-08-09T17:09:23Z",
+    "integrity": {
+     "method": "sha512",
+     "value": "xuNDpShExSLXUlUL12BmTwUuaqq5QuKoUDvfpIpEyrtvOxr7OO2yhPrM3YuECpc1AsbAgs6/dekCuIEj8dYhLg=="
+    },
+    "metadata_id": "urn:wmo:md:gh-gmet:core.surface-based-observations.synop",
+    "content": {
+     "encoding": "base64",
+     "value": "QlVGUgABgAQAABYA/////wAAAAJuHgAH6ggJEAAAAAALAAABgMGWx2AAAVMAABIAAANjU0ODMAAAAAAAAAAAAAAP////////////////////////////+P1QTABLFRgiU0kBYm//////////////////////////////+RL///////////////////////////////////////////////////////////////////////////////////////Af////gP//////////////////////////////////////////////////////////////////+L//////f2///74n///dM//////////////////////////////////////////////////f/AAX/f/9/r//f0//36P//////////////////////////////////////////////////////////////////////////////////////8A3Nzc3",
+     "size": 384
+    },
+    "wigos_station_identifier": "0-288-0-65483",
+    "id": "db6a1921-a6fc-4610-a7c6-f5175c1c47d6"
+   },
+   "links": [
+    {
+     "rel": "canonical",
+     "type": "application/bufr",
+     "href": "https://wis2.meteo.gov.gh/data/2026-08-09/wis/urn:wmo:md:gh-gmet:core.surface-based-observations.synop/WIGOS_0-288-0-65483_20260809T160000.bufr4",
+     "length": 384
+    },
+    {
+     "rel": "via",
+     "type": "text/html",
+     "href": "https://oscar.wmo.int/surface/#/search/station/stationReportDetails/0-288-0-65483"
+    }
+   ],
+   "generated_by": "wis2box 1.2.0"
+  },
+  {
+   "id": "b318097a-4400-4213-8977-e3a2b6b7a416",
+   "type": "Feature",
+   "conformsTo": [
+    "http://wis.wmo.int/spec/wnm/1/conf/core"
+   ],
+   "geometry": {
+    "coordinates": [
+     -2.4167,
+     9.2833
+    ],
+    "type": "Point"
+   },
+   "properties": {
+    "data_id": "gh-gmet:core.surface-based-observations.synop/WIGOS_0-288-0-65481_20260809T160000",
+    "datetime": "2026-08-09T16:00:00Z",
+    "pubtime": "2026-08-09T17:09:27Z",
+    "integrity": {
+     "method": "sha512",
+     "value": "B9reM06jzDLyFz0shhE24g2gQgf1xNO/30r6evQyk7QJTvUe0Qw/1pAklzKNS7g0yihu7aIUPNyV6d9eDFvlUA=="
+    },
+    "metadata_id": "urn:wmo:md:gh-gmet:core.surface-based-observations.synop",
+    "content": {
+     "encoding": "base64",
+     "value": "QlVGUgABgAQAABYA/////wAAAAJuHgAH6ggJEAAAAAALAAABgMGWx2AAAVMAABIAAANjU0ODEAAAAAAAAAAAAAAP////////////////////////////+P1QTABLv0Uh3w9BRk//////////////////////////////+Yu////////////////3SZ///J////////////////////////////////////////////////////////////////Af////gP//////////////////////////////////////////////////////////////////+L//////f2///74n///dM//////////////////////////////////////////////////f/AAX/f/9/r//f0//36P//////////////////////////////////////////////////////////////////////////////////////8A3Nzc3",
+     "size": 384
+    },
+    "wigos_station_identifier": "0-288-0-65481",
+    "id": "b318097a-4400-4213-8977-e3a2b6b7a416"
+   },
+   "links": [
+    {
+     "rel": "canonical",
+     "type": "application/bufr",
+     "href": "https://wis2.meteo.gov.gh/data/2026-08-09/wis/urn:wmo:md:gh-gmet:core.surface-based-observations.synop/WIGOS_0-288-0-65481_20260809T160000.bufr4",
+     "length": 384
+    },
+    {
+     "rel": "via",
+     "type": "text/html",
+     "href": "https://oscar.wmo.int/surface/#/search/station/stationReportDetails/0-288-0-65481"
+    }
+   ],
+   "generated_by": "wis2box 1.2.0"
+  },
+  {
+   "id": "7c55b342-88b5-4454-a740-688e6cea7b12",
+   "type": "Feature",
+   "conformsTo": [
+    "http://wis.wmo.int/spec/wnm/1/conf/core"
+   ],
+   "geometry": {
+    "type": "Polygon",
+    "coordinates": [
+     [
+      [
+       -3.244370083011262,
+       11.098340969278722
+      ],
+      [
+       1.0601216976049272,
+       11.098340969278722
+      ],
+      [
+       1.0601216976049272,
+       4.710462144383371
+      ],
+      [
+       -3.244370083011262,
+       4.710462144383371
+      ],
+      [
+       -3.244370083011262,
+       11.098340969278722
+      ]
+     ]
+    ]
+   },
+   "properties": {
+    "data_id": "gh-gmet/metadata/urn:wmo:md:gh-gmet:core.surface-based-observations.synop",
+    "datetime": "2026-01-30T13:33:29Z",
+    "pubtime": "2026-08-09T15:00:01Z",
+    "integrity": {
+     "method": "sha512",
+     "value": "f29trXH8YJE4+c85eGDKdRRf5Jpq0yrVcZPY7v+b5t8Vz6UGG1hRCyMVf2OM+kXZMYqEtqH4a+AbrqX80/5P9Q=="
+    },
+    "content": {
+     "encoding": "base64",
+     "value": "eyJpZCI6ICJ1cm46d21vOm1kOmdoLWdtZXQ6Y29yZS5zdXJmYWNlLWJhc2VkLW9ic2VydmF0aW9ucy5zeW5vcCIsICJjb25mb3Jtc1RvIjogWyJodHRwOi8vd2lzLndtby5pbnQvc3BlYy93Y21wLzIvY29uZi9jb3JlIl0sICJ0eXBlIjogIkZlYXR1cmUiLCAidGltZSI6IHsiaW50ZXJ2YWwiOiBbIjIwMjYtMDEtMzAiLCAiLi4iXSwgInJlc29sdXRpb24iOiAiUFQxSCJ9LCAiZ2VvbWV0cnkiOiB7InR5cGUiOiAiUG9seWdvbiIsICJjb29yZGluYXRlcyI6IFtbWy0zLjI0NDM3MDA4MzAxMTI2MiwgMTEuMDk4MzQwOTY5Mjc4NzIyXSwgWzEuMDYwMTIxNjk3NjA0OTI3MiwgMTEuMDk4MzQwOTY5Mjc4NzIyXSwgWzEuMDYwMTIxNjk3NjA0OTI3MiwgNC43MTA0NjIxNDQzODMzNzFdLCBbLTMuMjQ0MzcwMDgzMDExMjYyLCA0LjcxMDQ2MjE0NDM4MzM3MV0sIFstMy4yNDQzNzAwODMwMTEyNjIsIDExLjA5ODM0MDk2OTI3ODcyMl1dXX0sICJwcm9wZXJ0aWVzIjogeyJ0eXBlIjogImRhdGFzZXQiLCAiaWRlbnRpZmllciI6ICJ1cm46d21vOm1kOmdoLWdtZXQ6Y29yZS5zdXJmYWNlLWJhc2VkLW9ic2VydmF0aW9ucy5zeW5vcCIsICJ0aXRsZSI6ICJIb3VybHkgc3lub3B0aWMgb2JzZXJ2YXRpb25zIGZyb20gZml4ZWQtbGFuZCBzdGF0aW9ucyAoU1lOT1ApIChnaC1nbWV0KSIsICJkZXNjcmlwdGlvbiI6ICJvYnNlcnZhdGlvbiBkYXRhIGZvciBnaGFuYSIsICJrZXl3b3JkcyI6IFsib2JzZXJ2YXRpb25zIiwgInRlbXBlcmF0dXJlIiwgInZpc2liaWxpdHkiLCAicHJlY2lwaXRhdGlvbiIsICJwcmVzc3VyZSIsICJjbG91ZHMiLCAic25vdyBkZXB0aCIsICJldmFwb3JhdGlvbiIsICJyYWRpYXRpb24iLCAid2luZCIsICJ0b3RhbCBzdW5zaGluZSIsICJodW1pZGl0eSJdLCAidGhlbWVzIjogW3siY29uY2VwdHMiOiBbeyJpZCI6ICJ3ZWF0aGVyIiwgInRpdGxlIjogIldlYXRoZXIifV0sICJzY2hlbWUiOiAiaHR0cDovL2NvZGVzLndtby5pbnQvd2lzL3RvcGljLWhpZXJhcmNoeS9lYXJ0aC1zeXN0ZW0tZGlzY2lwbGluZSJ9XSwgImNvbnRhY3RzIjogW3sib3JnYW5pemF0aW9uIjogIkdoYW5hIE1ldGVvcm9sb2dpY2FsIEFnZW5jeSAoR01ldCkiLCAiZW1haWxzIjogW3sidmFsdWUiOiAiaW5mb0BtZXRlby5nb3YuZ2gifV0sICJhZGRyZXNzZXMiOiBbeyJjb3VudHJ5IjogIkdIQSJ9XSwgImxpbmtzIjogW3sicmVsIjogImFib3V0IiwgImhyZWYiOiAiaHR0cHM6Ly93d3cubWV0ZW8uZ292LmdoLyIsICJ0eXBlIjogInRleHQvaHRtbCJ9XSwgInJvbGVzIjogWyJob3N0Il19XSwgImNyZWF0ZWQiOiAiMjAyNi0wMS0zMFQxMzozMzoyOVoiLCAidXBkYXRlZCI6ICIyMDI2LTAxLTMwVDEzOjMzOjI5WiIsICJ3bW86ZGF0YVBvbGljeSI6ICJjb3JlIiwgImlkIjogInVybjp3bW86bWQ6Z2gtZ21ldDpjb3JlLnN1cmZhY2UtYmFzZWQtb2JzZXJ2YXRpb25zLnN5bm9wIn0sICJsaW5rcyI6IFt7ImhyZWYiOiAibXF0dHM6Ly9ldmVyeW9uZTpldmVyeW9uZUB3aXMyLm1ldGVvLmdvdi5naDo4ODgzIiwgInR5cGUiOiAiYXBwbGljYXRpb24vanNvbiIsICJuYW1lIjogIm9yaWdpbi9hL3dpczIvZ2gtZ21ldC9kYXRhL2NvcmUvd2VhdGhlci9zdXJmYWNlLWJhc2VkLW9ic2VydmF0aW9ucy9zeW5vcCIsICJyZWwiOiAiaXRlbXMiLCAiY2hhbm5lbCI6ICJvcmlnaW4vYS93aXMyL2doLWdtZXQvZGF0YS9jb3JlL3dlYXRoZXIvc3VyZmFjZS1iYXNlZC1vYnNlcnZhdGlvbnMvc3lub3AiLCAiZmlsdGVycyI6IHsid2lnb3Nfc3RhdGlvbl9pZGVudGlmaWVyIjogeyJ0eXBlIjogInN0cmluZyIsICJ0aXRsZSI6ICJXSUdPUyBTdGF0aW9uIElkZW50aWZpZXIiLCAiZGVzY3JpcHRpb24iOiAiRmlsdGVyIGJ5IFdJR09TIFN0YXRpb24gSWRlbnRpZmllciJ9fSwgInRpdGxlIjogIk5vdGlmaWNhdGlvbnMifSwgeyJocmVmIjogImh0dHBzOi8vd2lzMi5tZXRlby5nb3YuZ2gvbWV0YWRhdGEvZGF0YS91cm46d21vOm1kOmdoLWdtZXQ6Y29yZS5zdXJmYWNlLWJhc2VkLW9ic2VydmF0aW9ucy5zeW5vcC5qc29uIiwgInR5cGUiOiAiYXBwbGljYXRpb24vZ2VvK2pzb24iLCAibmFtZSI6ICJ1cm46d21vOm1kOmdoLWdtZXQ6Y29yZS5zdXJmYWNlLWJhc2VkLW9ic2VydmF0aW9ucy5zeW5vcCIsICJyZWwiOiAiY2Fub25pY2FsIiwgInRpdGxlIjogInVybjp3bW86bWQ6Z2gtZ21ldDpjb3JlLnN1cmZhY2UtYmFzZWQtb2JzZXJ2YXRpb25zLnN5bm9wIn1dfQ==",
+     "size": 2218
+    },
+    "id": "7c55b342-88b5-4454-a740-688e6cea7b12"
+   },
+   "links": [
+    {
+     "rel": "update",
+     "type": "application/geo+json",
+     "href": "https://wis2.meteo.gov.gh/data/metadata/urn:wmo:md:gh-gmet:core.surface-based-observations.synop.json",
+     "length": 2218
+    }
+   ],
+   "generated_by": "wis2box 1.2.0"
+  },
+  {
+   "id": "5c479de7-9b4c-478b-b7f8-84acd38cb390",
+   "type": "Feature",
+   "conformsTo": [
+    "http://wis.wmo.int/spec/wnm/1/conf/core"
+   ],
+   "geometry": {
+    "coordinates": [
+     -0.9833333333,
+     5.9333333333
+    ],
+    "type": "Point"
+   },
+   "properties": {
+    "data_id": "gh-gmet:core.surface-based-observations.synop/WIGOS_0-20000-0-65457_20260809T140000",
+    "datetime": "2026-08-09T14:00:00Z",
+    "pubtime": "2026-08-09T15:09:05Z",
+    "integrity": {
+     "method": "sha512",
+     "value": "du/YVhEXRfHprmjRRtCAo4MLwEblaqgrqyCqMx7wrHL9V3XAs29kUL7JzZWEUxEwXxyXy4MObidJ47miNpPs5w=="
+    },
+    "metadata_id": "urn:wmo:md:gh-gmet:core.surface-based-observations.synop",
+    "content": {
+     "encoding": "base64",
+     "value": "QlVGUgABgAQAABYA/////wAAAAJuHgAH6ggJDgAAAAALAAABgMGWx2AAAVMABOIAAANjU0NTcAAAAAAAAAAAAAAILk//////////////////////////+P1QS4BJMPqiJQxhUS////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////Af////gP//////////////////////////////////////////////////////////////////+L//////f2///74n///dM//////////////////////////////////////////////////f/AAX/f/9/r//f0//36P//////////////////////////////////////////////////////////////////////////////////////8A3Nzc3",
+     "size": 384
+    },
+    "wigos_station_identifier": "0-20000-0-65457",
+    "id": "5c479de7-9b4c-478b-b7f8-84acd38cb390"
+   },
+   "links": [
+    {
+     "rel": "canonical",
+     "type": "application/bufr",
+     "href": "https://wis2.meteo.gov.gh/data/2026-08-09/wis/urn:wmo:md:gh-gmet:core.surface-based-observations.synop/WIGOS_0-20000-0-65457_20260809T140000.bufr4",
+     "length": 384
+    },
+    {
+     "rel": "via",
+     "type": "text/html",
+     "href": "https://oscar.wmo.int/surface/#/search/station/stationReportDetails/0-20000-0-65457"
+    }
+   ],
+   "generated_by": "wis2box 1.2.0"
+  },
+  {
+   "id": "4d90a052-5054-48f3-9e7c-f3207443afdf",
+   "type": "Feature",
+   "conformsTo": [
+    "http://wis.wmo.int/spec/wnm/1/conf/core"
+   ],
+   "geometry": {
+    "coordinates": [
+     0.1166666667,
+     6.1
+    ],
+    "type": "Point"
+   },
+   "properties": {
+    "data_id": "gh-gmet:core.surface-based-observations.synop/WIGOS_0-20000-0-65460_20260809T140000",
+    "datetime": "2026-08-09T14:00:00Z",
+    "pubtime": "2026-08-09T15:09:00Z",
+    "integrity": {
+     "method": "sha512",
+     "value": "TQABJOmjNccRYiP+5eToxluMazbsjLCyB0+iMr+H0ANNpkB/It94CtqQMCgW22lUp07BwTm2C/spOYkZcmNp+Q=="
+    },
+    "metadata_id": "urn:wmo:md:gh-gmet:core.surface-based-observations.synop",
+    "content": {
+     "encoding": "base64",
+     "value": "QlVGUgABgAQAABYA/////wAAAAJuHgAH6ggJDgAAAAALAAABgMGWx2AAAVMABOIAAANjU0NjAAAAAAAAAAAAAAAILmf/////////////////////////+P1QS4BJUYgiWsJhBO//////////////////////////////+dd///////////////////////////////////////////////////////////////////////////////////////Af////gP//////////////////////////////////////////////////////////////////+L/92gO/f2///74n///dM//////////////////////////////////////////////////f/AAX/f/9/r//f0//36P//////////////////////////////////////////////////////////////////////////////////////8A3Nzc3",
+     "size": 384
+    },
+    "wigos_station_identifier": "0-20000-0-65460",
+    "id": "4d90a052-5054-48f3-9e7c-f3207443afdf"
+   },
+   "links": [
+    {
+     "rel": "canonical",
+     "type": "application/bufr",
+     "href": "https://wis2.meteo.gov.gh/data/2026-08-09/wis/urn:wmo:md:gh-gmet:core.surface-based-observations.synop/WIGOS_0-20000-0-65460_20260809T140000.bufr4",
+     "length": 384
+    },
+    {
+     "rel": "via",
+     "type": "text/html",
+     "href": "https://oscar.wmo.int/surface/#/search/station/stationReportDetails/0-20000-0-65460"
+    }
+   ],
+   "generated_by": "wis2box 1.2.0"
+  },
+  {
+   "id": "d7971f64-eebc-4092-96de-f11efae25d5a",
+   "type": "Feature",
+   "conformsTo": [
+    "http://wis.wmo.int/spec/wnm/1/conf/core"
+   ],
+   "geometry": {
+    "coordinates": [
+     -2.2333333333,
+     4.8666666667
+    ],
+    "type": "Point"
+   },
+   "properties": {
+    "data_id": "gh-gmet:core.surface-based-observations.synop/WIGOS_0-20000-0-65465_20260809T140000",
+    "datetime": "2026-08-09T14:00:00Z",
+    "pubtime": "2026-08-09T15:09:07Z",
+    "integrity": {
+     "method": "sha512",
+     "value": "aSZsz7hyKcFyyaqJV4MdDSdHbt/C3NfVAKQ2XE+BMKDu07BFtiB/YKrNIlVUPkN/x6hbH7PNdmrysSFIqYEVVA=="
+    },
+    "metadata_id": "urn:wmo:md:gh-gmet:core.surface-based-observations.synop",
+    "content": {
+     "encoding": "base64",
+     "value": "QlVGUgABgAQAABYA/////wAAAAJuHgAH6ggJDgAAAAALAAABgMGWx2AAAVMABOIAAANjU0NjUAAAAAAAAAAAAAAILo//////////////////////////+P1QS4BIYKWh6ANhEa//////////////////////////////+dM///////////////////////////////////////////////////////////////////////////////////////Af////gP//////////////////////////////////////////////////////////////////+L//////f2///74n///dM//////////////////////////////////////////////////f/AAX/f/9/r//f0//36P//////////////////////////////////////////////////////////////////////////////////////8A3Nzc3",
+     "size": 384
+    },
+    "wigos_station_identifier": "0-20000-0-65465",
+    "id": "d7971f64-eebc-4092-96de-f11efae25d5a"
+   },
+   "links": [
+    {
+     "rel": "canonical",
+     "type": "application/bufr",
+     "href": "https://wis2.meteo.gov.gh/data/2026-08-09/wis/urn:wmo:md:gh-gmet:core.surface-based-observations.synop/WIGOS_0-20000-0-65465_20260809T140000.bufr4",
+     "length": 384
+    },
+    {
+     "rel": "via",
+     "type": "text/html",
+     "href": "https://oscar.wmo.int/surface/#/search/station/stationReportDetails/0-20000-0-65465"
+    }
+   ],
+   "generated_by": "wis2box 1.2.0"
+  },
+  {
+   "id": "c3c18a4d-442e-49bd-ba5f-c3dc15d8063b",
+   "type": "Feature",
+   "conformsTo": [
+    "http://wis.wmo.int/spec/wnm/1/conf/core"
+   ],
+   "geometry": {
+    "coordinates": [
+     -0.0740417,
+     6.0155254
+    ],
+    "type": "Point"
+   },
+   "properties": {
+    "data_id": "gh-gmet:core.surface-based-observations.synop/WIGOS_0-288-0-65469_20260809T140000",
+    "datetime": "2026-08-09T14:00:00Z",
+    "pubtime": "2026-08-09T15:09:04Z",
+    "integrity": {
+     "method": "sha512",
+     "value": "vDcNU28+9LkqDCFZnXfQR4PLiQ/Dl89fC5ib2w+qsAYww75acAK+8XTmEpnsn3wbSNOldUn4ySh1aR56ZwXHCg=="
+    },
+    "metadata_id": "urn:wmo:md:gh-gmet:core.surface-based-observations.synop",
+    "content": {
+     "encoding": "base64",
+     "value": "QlVGUgABgAQAABYA/////wAAAAJuHgAH6ggJDgAAAAALAAABgMGWx2AAAVMAABIAAANjU0NjkAAAAAAAAAAAAAAP////////////////////////////+P1QS4BJQQiiUXKCAI//////////////////////////////+W1////////////////3M6///J////////////////////////////////////////////////////////////////Af////gP//////////////////////////////////////////////////////////////////+L/8AgAff2///74n///dM//////////////////////////////////////////////////f/AAX/f/9/r//f0//36P//////////////////////////////////////////////////////////////////////////////////////8A3Nzc3",
+     "size": 384
+    },
+    "wigos_station_identifier": "0-288-0-65469",
+    "id": "c3c18a4d-442e-49bd-ba5f-c3dc15d8063b"
+   },
+   "links": [
+    {
+     "rel": "canonical",
+     "type": "application/bufr",
+     "href": "https://wis2.meteo.gov.gh/data/2026-08-09/wis/urn:wmo:md:gh-gmet:core.surface-based-observations.synop/WIGOS_0-288-0-65469_20260809T140000.bufr4",
+     "length": 384
+    },
+    {
+     "rel": "via",
+     "type": "text/html",
+     "href": "https://oscar.wmo.int/surface/#/search/station/stationReportDetails/0-288-0-65469"
+    }
+   ],
+   "generated_by": "wis2box 1.2.0"
+  }
+ ],
+ "numberMatched": 1757,
+ "numberReturned": 10,
+ "links": [
+  {
+   "type": "application/geo+json",
+   "rel": "self",
+   "title": "This document as GeoJSON",
+   "href": "https://wis2.meteo.gov.gh/oapi/collections/messages/items?f=json&limit=10&datetime=2026-08-09T00%3A00%3A00Z%2F2026-08-11T23%3A59%3A59Z"
+  },
+  {
+   "rel": "alternate",
+   "type": "application/ld+json",
+   "title": "This document as RDF (JSON-LD)",
+   "href": "https://wis2.meteo.gov.gh/oapi/collections/messages/items?f=jsonld&limit=10&datetime=2026-08-09T00%3A00%3A00Z%2F2026-08-11T23%3A59%3A59Z"
+  },
+  {
+   "type": "text/html",
+   "rel": "alternate",
+   "title": "This document as HTML",
+   "href": "https://wis2.meteo.gov.gh/oapi/collections/messages/items?f=html&limit=10&datetime=2026-08-09T00%3A00%3A00Z%2F2026-08-11T23%3A59%3A59Z"
+  },
+  {
+   "type": "application/geo+json",
+   "rel": "prev",
+   "title": "Items (prev)",
+   "href": "https://wis2.meteo.gov.gh/oapi/collections/messages/items?offset=376&limit=10&datetime=2026-08-09T00%3A00%3A00Z%2F2026-08-11T23%3A59%3A59Z"
+  },
+  {
+   "type": "application/geo+json",
+   "rel": "next",
+   "title": "Items (next)",
+   "href": "https://wis2.meteo.gov.gh/oapi/collections/messages/items?offset=396&limit=10&datetime=2026-08-09T00%3A00%3A00Z%2F2026-08-11T23%3A59%3A59Z"
+  },
+  {
+   "type": "application/json",
+   "title": "Data notifications",
+   "rel": "collection",
+   "href": "https://wis2.meteo.gov.gh/oapi/collections/messages"
+  }
+ ],
+ "timeStamp": "2026-08-13T10:44:48.175510Z"
+}

--- a/wis2watch/src/wis2watch/core/tests/fixtures/node_messages_sc_seychelles_met.json
+++ b/wis2watch/src/wis2watch/core/tests/fixtures/node_messages_sc_seychelles_met.json
@@ -1,0 +1,683 @@
+{
+ "type": "FeatureCollection",
+ "features": [
+  {
+   "id": "d11c819f-9dd7-463c-b2f3-8c1fecde76ed",
+   "type": "Feature",
+   "conformsTo": [
+    "http://wis.wmo.int/spec/wnm/1/conf/core"
+   ],
+   "geometry": {
+    "type": "Polygon",
+    "coordinates": [
+     [
+      [
+       46.203567505,
+       -3.714232206
+      ],
+      [
+       56.294338226,
+       -3.714232206
+      ],
+      [
+       56.294338226,
+       -10.206198692
+      ],
+      [
+       46.203567505,
+       -10.206198692
+      ],
+      [
+       46.203567505,
+       -3.714232206
+      ]
+     ]
+    ]
+   },
+   "properties": {
+    "data_id": "sc-seychelles-met/metadata/urn:wmo:md:sc-seychelles-met:core.surface-based-observations.synop",
+    "datetime": "2024-09-20T14:16:16Z",
+    "pubtime": "2026-08-12T15:00:00Z",
+    "integrity": {
+     "method": "sha512",
+     "value": "krxd/HF0CihFGR6swsVKne437FtPaAjfjrwGANWfrgiemUgjV8zP4rg8yknBdRaVv2kWwsccXisJf/Xa/LoCrw=="
+    },
+    "content": {
+     "encoding": "base64",
+     "value": "eyJpZCI6ICJ1cm46d21vOm1kOnNjLXNleWNoZWxsZXMtbWV0OmNvcmUuc3VyZmFjZS1iYXNlZC1vYnNlcnZhdGlvbnMuc3lub3AiLCAiY29uZm9ybXNUbyI6IFsiaHR0cDovL3dpcy53bW8uaW50L3NwZWMvd2NtcC8yL2NvbmYvY29yZSJdLCAidHlwZSI6ICJGZWF0dXJlIiwgInRpbWUiOiB7ImludGVydmFsIjogWyIyMDI0LTA5LTIwIiwgIi4uIl0sICJyZXNvbHV0aW9uIjogIlBUMUgifSwgImdlb21ldHJ5IjogeyJ0eXBlIjogIlBvbHlnb24iLCAiY29vcmRpbmF0ZXMiOiBbW1s0Ni4yMDM1Njc1MDUsIC0zLjcxNDIzMjIwNl0sIFs1Ni4yOTQzMzgyMjYsIC0zLjcxNDIzMjIwNl0sIFs1Ni4yOTQzMzgyMjYsIC0xMC4yMDYxOTg2OTJdLCBbNDYuMjAzNTY3NTA1LCAtMTAuMjA2MTk4NjkyXSwgWzQ2LjIwMzU2NzUwNSwgLTMuNzE0MjMyMjA2XV1dfSwgInByb3BlcnRpZXMiOiB7InR5cGUiOiAiZGF0YXNldCIsICJpZGVudGlmaWVyIjogInVybjp3bW86bWQ6c2Mtc2V5Y2hlbGxlcy1tZXQ6Y29yZS5zdXJmYWNlLWJhc2VkLW9ic2VydmF0aW9ucy5zeW5vcCIsICJ0aXRsZSI6ICJIb3VybHkgc3lub3B0aWMgb2JzZXJ2YXRpb25zIGZyb20gZml4ZWQtbGFuZCBzdGF0aW9ucyAoU1lOT1ApIChzYy1zZXljaGVsbGVzLW1ldCkiLCAiZGVzY3JpcHRpb24iOiAiT2JzZXJ2YXRpb24gZGF0YSBmcm9tIFNleWNoZWxsZXMgbWV0ZW9yb2xvZ2ljYWwgYXV0aG9yaXR5IiwgImtleXdvcmRzIjogWyJvYnNlcnZhdGlvbnMiLCAidGVtcGVyYXR1cmUiLCAidmlzaWJpbGl0eSIsICJwcmVjaXBpdGF0aW9uIiwgInByZXNzdXJlIiwgImNsb3VkcyIsICJzbm93IGRlcHRoIiwgImV2YXBvcmF0aW9uIiwgInJhZGlhdGlvbiIsICJ3aW5kIiwgInRvdGFsIHN1bnNoaW5lIiwgImh1bWlkaXR5Il0sICJ0aGVtZXMiOiBbeyJjb25jZXB0cyI6IFt7ImlkIjogIndlYXRoZXIiLCAidGl0bGUiOiAiV2VhdGhlciJ9XSwgInNjaGVtZSI6ICJodHRwOi8vY29kZXMud21vLmludC93aXMvdG9waWMtaGllcmFyY2h5L2VhcnRoLXN5c3RlbS1kaXNjaXBsaW5lIn1dLCAiY29udGFjdHMiOiBbeyJvcmdhbml6YXRpb24iOiAiU2V5Y2hlbGxlcyBNZXRlb3JvbG9naWNhbCBBdXRob3JpdHkiLCAiZW1haWxzIjogW3sidmFsdWUiOiAiaW5mb0BtZXRlby5zYyJ9XSwgImFkZHJlc3NlcyI6IFt7ImNvdW50cnkiOiAiU1lDIn1dLCAibGlua3MiOiBbeyJyZWwiOiAiYWJvdXQiLCAiaHJlZiI6ICJodHRwczovL3d3dy5tZXRlby5zYy8iLCAidHlwZSI6ICJ0ZXh0L2h0bWwifV0sICJyb2xlcyI6IFsiaG9zdCJdLCAicGhvbmVzIjogW3sidmFsdWUiOiAiKzI0ODQ5NzA3MDAifV19XSwgImNyZWF0ZWQiOiAiMjAyNC0wOS0yMFQxNDoxNjoxNloiLCAidXBkYXRlZCI6ICIyMDI0LTA5LTIwVDE0OjE2OjE2WiIsICJ3bW86ZGF0YVBvbGljeSI6ICJjb3JlIiwgImlkIjogInVybjp3bW86bWQ6c2Mtc2V5Y2hlbGxlcy1tZXQ6Y29yZS5zdXJmYWNlLWJhc2VkLW9ic2VydmF0aW9ucy5zeW5vcCJ9LCAibGlua3MiOiBbeyJocmVmIjogIm1xdHRzOi8vZXZlcnlvbmU6ZXZlcnlvbmVAd2lzMi5tZXRlby5zYzo4ODgzIiwgInR5cGUiOiAiYXBwbGljYXRpb24vanNvbiIsICJuYW1lIjogIm9yaWdpbi9hL3dpczIvc2Mtc2V5Y2hlbGxlcy1tZXQvZGF0YS9jb3JlL3dlYXRoZXIvc3VyZmFjZS1iYXNlZC1vYnNlcnZhdGlvbnMvc3lub3AiLCAicmVsIjogIml0ZW1zIiwgImNoYW5uZWwiOiAib3JpZ2luL2Evd2lzMi9zYy1zZXljaGVsbGVzLW1ldC9kYXRhL2NvcmUvd2VhdGhlci9zdXJmYWNlLWJhc2VkLW9ic2VydmF0aW9ucy9zeW5vcCIsICJmaWx0ZXJzIjogeyJ3aWdvc19zdGF0aW9uX2lkZW50aWZpZXIiOiB7InR5cGUiOiAic3RyaW5nIiwgInRpdGxlIjogIldJR09TIFN0YXRpb24gSWRlbnRpZmllciIsICJkZXNjcmlwdGlvbiI6ICJGaWx0ZXIgYnkgV0lHT1MgU3RhdGlvbiBJZGVudGlmaWVyIn19LCAidGl0bGUiOiAiTm90aWZpY2F0aW9ucyJ9LCB7ImhyZWYiOiAiaHR0cHM6Ly93aXMyLm1ldGVvLnNjL2RhdGEvbWV0YWRhdGEvdXJuOndtbzptZDpzYy1zZXljaGVsbGVzLW1ldDpjb3JlLnN1cmZhY2UtYmFzZWQtb2JzZXJ2YXRpb25zLnN5bm9wLmpzb24iLCAidHlwZSI6ICJhcHBsaWNhdGlvbi9nZW8ranNvbiIsICJuYW1lIjogInVybjp3bW86bWQ6c2Mtc2V5Y2hlbGxlcy1tZXQ6Y29yZS5zdXJmYWNlLWJhc2VkLW9ic2VydmF0aW9ucy5zeW5vcCIsICJyZWwiOiAiY2Fub25pY2FsIiwgInRpdGxlIjogInVybjp3bW86bWQ6c2Mtc2V5Y2hlbGxlcy1tZXQ6Y29yZS5zdXJmYWNlLWJhc2VkLW9ic2VydmF0aW9ucy5zeW5vcCJ9XX0=",
+     "size": 2306
+    },
+    "id": "d11c819f-9dd7-463c-b2f3-8c1fecde76ed"
+   },
+   "links": [
+    {
+     "rel": "update",
+     "type": "application/geo+json",
+     "href": "https://wis2.meteo.sc/data/metadata/urn:wmo:md:sc-seychelles-met:core.surface-based-observations.synop.json",
+     "length": 2306
+    }
+   ],
+   "generated_by": "wis2box 1.3.0"
+  },
+  {
+   "id": "579401fe-4a11-4ea7-9369-34cb79c48964",
+   "type": "Feature",
+   "conformsTo": [
+    "http://wis.wmo.int/spec/wnm/1/conf/core"
+   ],
+   "geometry": {
+    "coordinates": [
+     53.31338,
+     -5.11496
+    ],
+    "type": "Point"
+   },
+   "properties": {
+    "data_id": "sc-seychelles-met:core.surface-based-observations.synop/WIGOS_0-690-0-63056RI_20260812T140000",
+    "datetime": "2026-08-12T14:00:00Z",
+    "pubtime": "2026-08-12T15:02:13Z",
+    "integrity": {
+     "method": "sha512",
+     "value": "DQbKfSKqmsN8ANoV4B67T6Dwd0JWASt4YL1Qv2ae9zMXVJaP5E/qL9CMpFQg28bieUrvCSkVDaJgJToOv0SbRQ=="
+    },
+    "metadata_id": "urn:wmo:md:sc-seychelles-met:core.surface-based-observations.synop",
+    "content": {
+     "encoding": "base64",
+     "value": "QlVGUgABgAQAABYA/////wAAAAJuHgAH6ggMDgAAAAALAAABgMGWx2AAAVMAACsgAANjMwNTZSSQAAAAAAAAAAAP////////////////////////////+P1QY4BAwxwsgEFBEl//////////////////////////////+er////////////////3eK//9v////////////////////////////////////////////////////////////////Af////gP//////////////////////////////////////////////////////////////////+L/93AO/f2///74n///dM//////////////////////////////////////////////////f/AAX/f/9/r//f0//36P//////////////////////////////////////////////////////////////////////////////////////8A3Nzc3",
+     "size": 384
+    },
+    "wigos_station_identifier": "0-690-0-63056RI",
+    "id": "579401fe-4a11-4ea7-9369-34cb79c48964"
+   },
+   "links": [
+    {
+     "rel": "canonical",
+     "type": "application/bufr",
+     "href": "https://wis2.meteo.sc/data/2026-08-12/wis/urn:wmo:md:sc-seychelles-met:core.surface-based-observations.synop/WIGOS_0-690-0-63056RI_20260812T140000.bufr4",
+     "length": 384
+    },
+    {
+     "rel": "via",
+     "type": "text/html",
+     "href": "https://oscar.wmo.int/surface/#/search/station/stationReportDetails/0-690-0-63056RI"
+    }
+   ],
+   "generated_by": "wis2box 1.3.0"
+  },
+  {
+   "id": "98521604-38ff-44ea-baf5-8bd81175c7b6",
+   "type": "Feature",
+   "conformsTo": [
+    "http://wis.wmo.int/spec/wnm/1/conf/core"
+   ],
+   "geometry": {
+    "coordinates": [
+     46.4988,
+     -9.7351
+    ],
+    "type": "Point"
+   },
+   "properties": {
+    "data_id": "sc-seychelles-met:core.surface-based-observations.synop/WIGOS_0-690-0-63057AI_20260812T140000",
+    "datetime": "2026-08-12T14:00:00Z",
+    "pubtime": "2026-08-12T15:02:13Z",
+    "integrity": {
+     "method": "sha512",
+     "value": "7TR5NmmpamNt3/Ls8Myap01p4aaevy5TXTzOtUY3nmWbMMtWmcKFgoa2VAC0AA8M0htqCobNFabw2pXSBRE8Zw=="
+    },
+    "metadata_id": "urn:wmo:md:sc-seychelles-met:core.surface-based-observations.synop",
+    "content": {
+     "encoding": "base64",
+     "value": "QlVGUgABgAQAABYA/////wAAAAJuHgAH6ggMDgAAAAALAAABgMGWx2AAAVMAACsgAANjMwNTdBSQAAAAAAAAAAAP////////////////////////////+P1QY4A9PL0rM4MBvN//////////////////////////////+fV////////////////3Zl//9v////////////////////////////////////////////////////////////////Af////gP//////////////////////////////////////////////////////////////////+L/9XARff2///74n///dM//////////////////////////////////////////////////f/AAX/f/9/r//f0//36P//////////////////////////////////////////////////////////////////////////////////////8A3Nzc3",
+     "size": 384
+    },
+    "wigos_station_identifier": "0-690-0-63057AI",
+    "id": "98521604-38ff-44ea-baf5-8bd81175c7b6"
+   },
+   "links": [
+    {
+     "rel": "canonical",
+     "type": "application/bufr",
+     "href": "https://wis2.meteo.sc/data/2026-08-12/wis/urn:wmo:md:sc-seychelles-met:core.surface-based-observations.synop/WIGOS_0-690-0-63057AI_20260812T140000.bufr4",
+     "length": 384
+    },
+    {
+     "rel": "via",
+     "type": "text/html",
+     "href": "https://oscar.wmo.int/surface/#/search/station/stationReportDetails/0-690-0-63057AI"
+    }
+   ],
+   "generated_by": "wis2box 1.3.0"
+  },
+  {
+   "id": "aa14c1de-b6f7-44ff-b8d3-c0ead4ccc397",
+   "type": "Feature",
+   "conformsTo": [
+    "http://wis.wmo.int/spec/wnm/1/conf/core"
+   ],
+   "geometry": {
+    "coordinates": [
+     53.309,
+     -5.7472
+    ],
+    "type": "Point"
+   },
+   "properties": {
+    "data_id": "sc-seychelles-met:core.surface-based-observations.synop/WIGOS_0-690-0-63058PI_20260812T140000",
+    "datetime": "2026-08-12T14:00:00Z",
+    "pubtime": "2026-08-12T15:02:13Z",
+    "integrity": {
+     "method": "sha512",
+     "value": "KrLpTh3OQ4XAoCjLSmwGIAvm76gNsQq82e9kKo/8njXNc/8yS6V/b2GVmYjegnCW/obIt/gIA98Wg71rJMNvvw=="
+    },
+    "metadata_id": "urn:wmo:md:sc-seychelles-met:core.surface-based-observations.synop",
+    "content": {
+     "encoding": "base64",
+     "value": "QlVGUgABgAQAABYA/////wAAAAJuHgAH6ggMDgAAAAALAAABgMGWx2AAAVMAACsgAANjMwNThQSQAAAAAAAAAAAP////////////////////////////+P1QY4BAR6AsgAqBEb//////////////////////////////+ex////////////////3QT//9Z////////////////////////////////////////////////////////////////Af////gP//////////////////////////////////////////////////////////////////+L/9OAnff2///74n///dM//////////////////////////////////////////////////f/AAX/f/9/r//f0//36P//////////////////////////////////////////////////////////////////////////////////////8A3Nzc3",
+     "size": 384
+    },
+    "wigos_station_identifier": "0-690-0-63058PI",
+    "id": "aa14c1de-b6f7-44ff-b8d3-c0ead4ccc397"
+   },
+   "links": [
+    {
+     "rel": "canonical",
+     "type": "application/bufr",
+     "href": "https://wis2.meteo.sc/data/2026-08-12/wis/urn:wmo:md:sc-seychelles-met:core.surface-based-observations.synop/WIGOS_0-690-0-63058PI_20260812T140000.bufr4",
+     "length": 384
+    },
+    {
+     "rel": "via",
+     "type": "text/html",
+     "href": "https://oscar.wmo.int/surface/#/search/station/stationReportDetails/0-690-0-63058PI"
+    }
+   ],
+   "generated_by": "wis2box 1.3.0"
+  },
+  {
+   "id": "33e50be8-1429-4c81-98f8-d5542e48a91a",
+   "type": "Feature",
+   "conformsTo": [
+    "http://wis.wmo.int/spec/wnm/1/conf/core"
+   ],
+   "geometry": {
+    "coordinates": [
+     55.4821,
+     -4.7152
+    ],
+    "type": "Point"
+   },
+   "properties": {
+    "data_id": "sc-seychelles-met:core.surface-based-observations.synop/WIGOS_0-690-0-63001AB_20260812T140000",
+    "datetime": "2026-08-12T14:00:00Z",
+    "pubtime": "2026-08-12T15:03:44Z",
+    "integrity": {
+     "method": "sha512",
+     "value": "57Hp7m0rfrruB33eNISHkU7D3+gwYnog13QreTzO43tSgtCbCKq/nZ3pNgu12GBmQntHNIwYCA6URqCG7i1sZg=="
+    },
+    "metadata_id": "urn:wmo:md:sc-seychelles-met:core.surface-based-observations.synop",
+    "content": {
+     "encoding": "base64",
+     "value": "QlVGUgABgAQAABYA/////wAAAAJuHgAH6ggMDgAAAAALAAABgMGWx2AAAVMAACsgAANjMwMDFBQgAAAAAAAAAAAP////////////////////////////+P1QY4BBETAs6iZA/I//////////////////////////////+ec////////////////3VS//+1////////////////////////////////////////////////////////////////Af////gP//////////////////////////////////////////////////////////////////+L/96ACff2///74n///dM//////////////////////////////////////////////////f/AAX/f/9/r//f0//36P//////////////////////////////////////////////////////////////////////////////////////8A3Nzc3",
+     "size": 384
+    },
+    "wigos_station_identifier": "0-690-0-63001AB",
+    "id": "33e50be8-1429-4c81-98f8-d5542e48a91a"
+   },
+   "links": [
+    {
+     "rel": "canonical",
+     "type": "application/bufr",
+     "href": "https://wis2.meteo.sc/data/2026-08-12/wis/urn:wmo:md:sc-seychelles-met:core.surface-based-observations.synop/WIGOS_0-690-0-63001AB_20260812T140000.bufr4",
+     "length": 384
+    },
+    {
+     "rel": "via",
+     "type": "text/html",
+     "href": "https://oscar.wmo.int/surface/#/search/station/stationReportDetails/0-690-0-63001AB"
+    }
+   ],
+   "generated_by": "wis2box 1.3.0"
+  },
+  {
+   "id": "6cb7c9bf-8f29-4a11-b75c-89f26fec44e8",
+   "type": "Feature",
+   "conformsTo": [
+    "http://wis.wmo.int/spec/wnm/1/conf/core"
+   ],
+   "geometry": {
+    "coordinates": [
+     55.4808,
+     -4.7516
+    ],
+    "type": "Point"
+   },
+   "properties": {
+    "data_id": "sc-seychelles-met:core.surface-based-observations.synop/WIGOS_0-690-0-63009BL_20260812T140000",
+    "datetime": "2026-08-12T14:00:00Z",
+    "pubtime": "2026-08-12T15:03:44Z",
+    "integrity": {
+     "method": "sha512",
+     "value": "+KJgH3f1Cvyz/EijiAAigX9qM3KjGRuOGOvuGKzZ/CUJ/af0UY70oqu7EP29Q+Q4m06r4JK4iW6aJQL3tPAu9g=="
+    },
+    "metadata_id": "urn:wmo:md:sc-seychelles-met:core.surface-based-observations.synop",
+    "content": {
+     "encoding": "base64",
+     "value": "QlVGUgABgAQAABYA/////wAAAAJuHgAH6ggMDgAAAAALAAABgMGWx2AAAVMAACsgAANjMwMDlCTAAAAAAAAAAAAP////////////////////////////+P1QY4BBChQs6hYf////////////////////////////////+dZ////////////////3VS//+j////////////////////////////////////////////////////////////////Af////gP//////////////////////////////////////////////////////////////////+L/8AAAff2///74n///dM//////////////////////////////////////////////////f/AAX/f/9/r//f0//36P//////////////////////////////////////////////////////////////////////////////////////8A3Nzc3",
+     "size": 384
+    },
+    "wigos_station_identifier": "0-690-0-63009BL",
+    "id": "6cb7c9bf-8f29-4a11-b75c-89f26fec44e8"
+   },
+   "links": [
+    {
+     "rel": "canonical",
+     "type": "application/bufr",
+     "href": "https://wis2.meteo.sc/data/2026-08-12/wis/urn:wmo:md:sc-seychelles-met:core.surface-based-observations.synop/WIGOS_0-690-0-63009BL_20260812T140000.bufr4",
+     "length": 384
+    },
+    {
+     "rel": "via",
+     "type": "text/html",
+     "href": "https://oscar.wmo.int/surface/#/search/station/stationReportDetails/0-690-0-63009BL"
+    }
+   ],
+   "generated_by": "wis2box 1.3.0"
+  },
+  {
+   "id": "d6b4681c-b953-495d-bc77-4debb1973211",
+   "type": "Feature",
+   "conformsTo": [
+    "http://wis.wmo.int/spec/wnm/1/conf/core"
+   ],
+   "geometry": {
+    "coordinates": [
+     55.4094,
+     -4.6173
+    ],
+    "type": "Point"
+   },
+   "properties": {
+    "data_id": "sc-seychelles-met:core.surface-based-observations.synop/WIGOS_0-690-0-63003BO_20260812T140000",
+    "datetime": "2026-08-12T14:00:00Z",
+    "pubtime": "2026-08-12T15:03:45Z",
+    "integrity": {
+     "method": "sha512",
+     "value": "FtO5yzpNxPrtPByz6YzGiaOMsTbP+tloCn0jP7gLn1w9ZbL+rv4tr2U7LJVSyOKp6hahB3/J/E6mCMTA6RGF8w=="
+    },
+    "metadata_id": "urn:wmo:md:sc-seychelles-met:core.surface-based-observations.synop",
+    "content": {
+     "encoding": "base64",
+     "value": "QlVGUgABgAQAABYA/////wAAAAJuHgAH6ggMDgAAAAALAAABgMGWx2AAAVMAACsgAANjMwMDNCTwAAAAAAAAAAAP////////////////////////////+P1QY4BBJE8s5pmf////////////////////////////////+eI////////////////3VH//+n////////////////////////////////////////////////////////////////Af////gP//////////////////////////////////////////////////////////////////+L/9LAR/f2///74n///dM//////////////////////////////////////////////////f/AAX/f/9/r//f0//36P//////////////////////////////////////////////////////////////////////////////////////8A3Nzc3",
+     "size": 384
+    },
+    "wigos_station_identifier": "0-690-0-63003BO",
+    "id": "d6b4681c-b953-495d-bc77-4debb1973211"
+   },
+   "links": [
+    {
+     "rel": "canonical",
+     "type": "application/bufr",
+     "href": "https://wis2.meteo.sc/data/2026-08-12/wis/urn:wmo:md:sc-seychelles-met:core.surface-based-observations.synop/WIGOS_0-690-0-63003BO_20260812T140000.bufr4",
+     "length": 384
+    },
+    {
+     "rel": "via",
+     "type": "text/html",
+     "href": "https://oscar.wmo.int/surface/#/search/station/stationReportDetails/0-690-0-63003BO"
+    }
+   ],
+   "generated_by": "wis2box 1.3.0"
+  },
+  {
+   "id": "d1f867ba-43f1-4da2-8805-e6312526fe2a",
+   "type": "Feature",
+   "conformsTo": [
+    "http://wis.wmo.int/spec/wnm/1/conf/core"
+   ],
+   "geometry": {
+    "coordinates": [
+     55.5199,
+     -4.7067
+    ],
+    "type": "Point"
+   },
+   "properties": {
+    "data_id": "sc-seychelles-met:core.surface-based-observations.synop/WIGOS_0-690-0-63002AC_20260812T140000",
+    "datetime": "2026-08-12T14:00:00Z",
+    "pubtime": "2026-08-12T15:03:45Z",
+    "integrity": {
+     "method": "sha512",
+     "value": "Dd9YBHP5CmUIXRGD22Y/Pz4f3LIXMjIZ0o6ZdzIkZdcn82O/o1OZpjEh1DcqEbCHT226zDzBe4SLBIPyQNJVJQ=="
+    },
+    "metadata_id": "urn:wmo:md:sc-seychelles-met:core.surface-based-observations.synop",
+    "content": {
+     "encoding": "base64",
+     "value": "QlVGUgABgAQAABYA/////wAAAAJuHgAH6ggMDgAAAAALAAABgMGWx2AAAVMAACsgAANjMwMDJBQwAAAAAAAAAAAP////////////////////////////+P1QY4BBEtks6/7f////////////////////////////////+ea////////////////3VR//+b////////////////////////////////////////////////////////////////Af////gP//////////////////////////////////////////////////////////////////+L/97gIff2///74n///dM//////////////////////////////////////////////////f/AAX/f/9/r//f0//36P//////////////////////////////////////////////////////////////////////////////////////8A3Nzc3",
+     "size": 384
+    },
+    "wigos_station_identifier": "0-690-0-63002AC",
+    "id": "d1f867ba-43f1-4da2-8805-e6312526fe2a"
+   },
+   "links": [
+    {
+     "rel": "canonical",
+     "type": "application/bufr",
+     "href": "https://wis2.meteo.sc/data/2026-08-12/wis/urn:wmo:md:sc-seychelles-met:core.surface-based-observations.synop/WIGOS_0-690-0-63002AC_20260812T140000.bufr4",
+     "length": 384
+    },
+    {
+     "rel": "via",
+     "type": "text/html",
+     "href": "https://oscar.wmo.int/surface/#/search/station/stationReportDetails/0-690-0-63002AC"
+    }
+   ],
+   "generated_by": "wis2box 1.3.0"
+  },
+  {
+   "id": "95664add-3373-4286-987d-3578f9cec310",
+   "type": "Feature",
+   "conformsTo": [
+    "http://wis.wmo.int/spec/wnm/1/conf/core"
+   ],
+   "geometry": {
+    "coordinates": [
+     55.5225,
+     -4.7813
+    ],
+    "type": "Point"
+   },
+   "properties": {
+    "data_id": "sc-seychelles-met:core.surface-based-observations.synop/WIGOS_0-690-0-63008AF_20260812T140000",
+    "datetime": "2026-08-12T14:00:00Z",
+    "pubtime": "2026-08-12T15:03:45Z",
+    "integrity": {
+     "method": "sha512",
+     "value": "uJzAsN3raUMJWX3P5FIKyUTwLDVI50+oHZiSB2JIu0beWssmQVZE3PDsSHosuyRef6tdOb93ZBwEGv9hVs07iw=="
+    },
+    "metadata_id": "urn:wmo:md:sc-seychelles-met:core.surface-based-observations.synop",
+    "content": {
+     "encoding": "base64",
+     "value": "QlVGUgABgAQAABYA/////wAAAAJuHgAH6ggMDgAAAAALAAABgMGWx2AAAVMAACsgAANjMwMDhBRgAAAAAAAAAAAP////////////////////////////+P1QY4BBBEcs7B9f////////////////////////////////+eg////////////////3VA//+j////////////////////////////////////////////////////////////////Af////gP//////////////////////////////////////////////////////////////////+L/8vgE/f2///74n///dM//////////////////////////////////////////////////f/AAX/f/9/r//f0//36P//////////////////////////////////////////////////////////////////////////////////////8A3Nzc3",
+     "size": 384
+    },
+    "wigos_station_identifier": "0-690-0-63008AF",
+    "id": "95664add-3373-4286-987d-3578f9cec310"
+   },
+   "links": [
+    {
+     "rel": "canonical",
+     "type": "application/bufr",
+     "href": "https://wis2.meteo.sc/data/2026-08-12/wis/urn:wmo:md:sc-seychelles-met:core.surface-based-observations.synop/WIGOS_0-690-0-63008AF_20260812T140000.bufr4",
+     "length": 384
+    },
+    {
+     "rel": "via",
+     "type": "text/html",
+     "href": "https://oscar.wmo.int/surface/#/search/station/stationReportDetails/0-690-0-63008AF"
+    }
+   ],
+   "generated_by": "wis2box 1.3.0"
+  },
+  {
+   "id": "6e8f0766-5614-4493-bea1-60482d5f5799",
+   "type": "Feature",
+   "conformsTo": [
+    "http://wis.wmo.int/spec/wnm/1/conf/core"
+   ],
+   "geometry": {
+    "coordinates": [
+     55.3834,
+     -4.6443
+    ],
+    "type": "Point"
+   },
+   "properties": {
+    "data_id": "sc-seychelles-met:core.surface-based-observations.synop/WIGOS_0-690-0-63010CT_20260812T140000",
+    "datetime": "2026-08-12T14:00:00Z",
+    "pubtime": "2026-08-12T15:03:45Z",
+    "integrity": {
+     "method": "sha512",
+     "value": "mtgyC1Eg+mieZRToHpWkLr5IP6FE9G6LIb3fFKurcnpBNJ1FuajT+BR8CJJrkdhNtuqADu/ABZuTKfiPsi1pAw=="
+    },
+    "metadata_id": "urn:wmo:md:sc-seychelles-met:core.surface-based-observations.synop",
+    "content": {
+     "encoding": "base64",
+     "value": "QlVGUgABgAQAABYA/////wAAAAJuHgAH6ggMDgAAAAALAAABgMGWx2AAAVMAACsgAANjMwMTBDVAAAAAAAAAAAAP////////////////////////////+P1QY4BBHwks5VSf////////////////////////////////+eS////////////////3Un//+x////////////////////////////////////////////////////////////////Af////gP//////////////////////////////////////////////////////////////////+L/+LgD/f2///74n///dM//////////////////////////////////////////////////f/AAX/f/9/r//f0//36P//////////////////////////////////////////////////////////////////////////////////////8A3Nzc3",
+     "size": 384
+    },
+    "wigos_station_identifier": "0-690-0-63010CT",
+    "id": "6e8f0766-5614-4493-bea1-60482d5f5799"
+   },
+   "links": [
+    {
+     "rel": "canonical",
+     "type": "application/bufr",
+     "href": "https://wis2.meteo.sc/data/2026-08-12/wis/urn:wmo:md:sc-seychelles-met:core.surface-based-observations.synop/WIGOS_0-690-0-63010CT_20260812T140000.bufr4",
+     "length": 384
+    },
+    {
+     "rel": "via",
+     "type": "text/html",
+     "href": "https://oscar.wmo.int/surface/#/search/station/stationReportDetails/0-690-0-63010CT"
+    }
+   ],
+   "generated_by": "wis2box 1.3.0"
+  },
+  {
+   "id": "24ba4a7b-0ce4-4648-95c0-310e77b7cfdc",
+   "type": "Feature",
+   "conformsTo": [
+    "http://wis.wmo.int/spec/wnm/1/conf/core"
+   ],
+   "geometry": {
+    "coordinates": [
+     55.4709,
+     -4.6665
+    ],
+    "type": "Point"
+   },
+   "properties": {
+    "data_id": "sc-seychelles-met:core.surface-based-observations.synop/WIGOS_0-690-0-63011LM_20260812T140000",
+    "datetime": "2026-08-12T14:00:00Z",
+    "pubtime": "2026-08-12T15:03:45Z",
+    "integrity": {
+     "method": "sha512",
+     "value": "r7GfwIcdQkHA/3RYC8XAUnmU843BOJnC36xCN3dGYAtK0q2A6xeXgeSAjCyeHb9xjZrZdr4szc6IDmUUixB8yg=="
+    },
+    "metadata_id": "urn:wmo:md:sc-seychelles-met:core.surface-based-observations.synop",
+    "content": {
+     "encoding": "base64",
+     "value": "QlVGUgABgAQAABYA/////wAAAAJuHgAH6ggMDgAAAAALAAABgMGWx2AAAVMAACsgAANjMwMTFMTQAAAAAAAAAAAP////////////////////////////+P1QY4BBGrMs6Zpf////////////////////////////////+Wb////////////////3OD//+/////////////////////////////////////////////////////////////////Af////gP//////////////////////////////////////////////////////////////////+L/9ZgB/f2///74n///dM//////////////////////////////////////////////////f/AAX/f/9/r//f0//36P//////////////////////////////////////////////////////////////////////////////////////8A3Nzc3",
+     "size": 384
+    },
+    "wigos_station_identifier": "0-690-0-63011LM",
+    "id": "24ba4a7b-0ce4-4648-95c0-310e77b7cfdc"
+   },
+   "links": [
+    {
+     "rel": "canonical",
+     "type": "application/bufr",
+     "href": "https://wis2.meteo.sc/data/2026-08-12/wis/urn:wmo:md:sc-seychelles-met:core.surface-based-observations.synop/WIGOS_0-690-0-63011LM_20260812T140000.bufr4",
+     "length": 384
+    },
+    {
+     "rel": "via",
+     "type": "text/html",
+     "href": "https://oscar.wmo.int/surface/#/search/station/stationReportDetails/0-690-0-63011LM"
+    }
+   ],
+   "generated_by": "wis2box 1.3.0"
+  },
+  {
+   "id": "46bc7109-e266-478c-9440-4f460483b3d7",
+   "type": "Feature",
+   "conformsTo": [
+    "http://wis.wmo.int/spec/wnm/1/conf/core"
+   ],
+   "geometry": {
+    "coordinates": [
+     55.4224,
+     -4.6209
+    ],
+    "type": "Point"
+   },
+   "properties": {
+    "data_id": "sc-seychelles-met:core.surface-based-observations.synop/WIGOS_0-690-0-63005LN_20260812T140000",
+    "datetime": "2026-08-12T14:00:00Z",
+    "pubtime": "2026-08-12T15:03:45Z",
+    "integrity": {
+     "method": "sha512",
+     "value": "zFESM/ATfJzCoYftx1mUoU+FztNpDeKCxXTFw2t7QPdsV+p9jVDwCfMq6tIavm8V8wSqf79+BRIwz7Wbia5y/g=="
+    },
+    "metadata_id": "urn:wmo:md:sc-seychelles-met:core.surface-based-observations.synop",
+    "content": {
+     "encoding": "base64",
+     "value": "QlVGUgABgAQAABYA/////wAAAAJuHgAH6ggMDgAAAAALAAABgMGWx2AAAVMAACsgAANjMwMDVMTgAAAAAAAAAAAP////////////////////////////+P1QY4BBI5ss5zwf////////////////////////////////+a1////////////////3SP//+v////////////////////////////////////////////////////////////////Af////gP//////////////////////////////////////////////////////////////////+L/8AAAff2///74n///dM//////////////////////////////////////////////////f/AAX/f/9/r//f0//36P//////////////////////////////////////////////////////////////////////////////////////8A3Nzc3",
+     "size": 384
+    },
+    "wigos_station_identifier": "0-690-0-63005LN",
+    "id": "46bc7109-e266-478c-9440-4f460483b3d7"
+   },
+   "links": [
+    {
+     "rel": "canonical",
+     "type": "application/bufr",
+     "href": "https://wis2.meteo.sc/data/2026-08-12/wis/urn:wmo:md:sc-seychelles-met:core.surface-based-observations.synop/WIGOS_0-690-0-63005LN_20260812T140000.bufr4",
+     "length": 384
+    },
+    {
+     "rel": "via",
+     "type": "text/html",
+     "href": "https://oscar.wmo.int/surface/#/search/station/stationReportDetails/0-690-0-63005LN"
+    }
+   ],
+   "generated_by": "wis2box 1.3.0"
+  },
+  {
+   "id": "b36fe309-6bc2-42e0-baa9-b14152d6b331",
+   "type": "Feature",
+   "conformsTo": [
+    "http://wis.wmo.int/spec/wnm/1/conf/core"
+   ],
+   "geometry": {
+    "coordinates": [
+     55.4698,
+     -4.6546
+    ],
+    "type": "Point"
+   },
+   "properties": {
+    "data_id": "sc-seychelles-met:core.surface-based-observations.synop/WIGOS_0-690-0-63006MJ_20260812T140000",
+    "datetime": "2026-08-12T14:00:00Z",
+    "pubtime": "2026-08-12T15:03:46Z",
+    "integrity": {
+     "method": "sha512",
+     "value": "eMLdwxequD8RN3jXcHjBobCIeocD7Y2+BKQ1iiyPclWaYu0CHbS0evicaU49kGN2qq/v/D4NAV7NudRX4SAbuw=="
+    },
+    "metadata_id": "urn:wmo:md:sc-seychelles-met:core.surface-based-observations.synop",
+    "content": {
+     "encoding": "base64",
+     "value": "QlVGUgABgAQAABYA/////wAAAAJuHgAH6ggMDgAAAAALAAABgMGWx2AAAVMAACsgAANjMwMDZNSgAAAAAAAAAAAP////////////////////////////+P1QY4BBHQYs6Yyf////////////////////////////////+X/////////////////3Pe//+3////////////////////////////////////////////////////////////////Af////gP//////////////////////////////////////////////////////////////////+L/9lgKff2///74n///dM//////////////////////////////////////////////////f/AAX/f/9/r//f0//36P//////////////////////////////////////////////////////////////////////////////////////8A3Nzc3",
+     "size": 384
+    },
+    "wigos_station_identifier": "0-690-0-63006MJ",
+    "id": "b36fe309-6bc2-42e0-baa9-b14152d6b331"
+   },
+   "links": [
+    {
+     "rel": "canonical",
+     "type": "application/bufr",
+     "href": "https://wis2.meteo.sc/data/2026-08-12/wis/urn:wmo:md:sc-seychelles-met:core.surface-based-observations.synop/WIGOS_0-690-0-63006MJ_20260812T140000.bufr4",
+     "length": 384
+    },
+    {
+     "rel": "via",
+     "type": "text/html",
+     "href": "https://oscar.wmo.int/surface/#/search/station/stationReportDetails/0-690-0-63006MJ"
+    }
+   ],
+   "generated_by": "wis2box 1.3.0"
+  },
+  {
+   "id": "283f0919-ed9b-457c-a1be-dd48f0d91fe4",
+   "type": "Feature",
+   "conformsTo": [
+    "http://wis.wmo.int/spec/wnm/1/conf/core"
+   ],
+   "geometry": {
+    "coordinates": [
+     55.4691,
+     -4.6094
+    ],
+    "type": "Point"
+   },
+   "properties": {
+    "data_id": "sc-seychelles-met:core.surface-based-observations.synop/WIGOS_0-690-0-63015PD_20260812T140000",
+    "datetime": "2026-08-12T14:00:00Z",
+    "pubtime": "2026-08-12T15:03:46Z",
+    "integrity": {
+     "method": "sha512",
+     "value": "F8+i0AU2pllF48Qi92LxEZBu0F3va9jqOVNXKEhIdIS7RpnR/+2nWmVydttfO8OGyen6zYkOeoyHnOeVrQkZfg=="
+    },
+    "metadata_id": "urn:wmo:md:sc-seychelles-met:core.surface-based-observations.synop",
+    "content": {
+     "encoding": "base64",
+     "value": "QlVGUgABgAQAABYA/////wAAAAJuHgAH6ggMDgAAAAALAAABgMGWx2AAAVMAACsgAANjMwMTVQRAAAAAAAAAAAAP////////////////////////////+P1QY4BBJdos6YPf////////////////////////////////+eF////////////////3VX//+r////////////////////////////////////////////////////////////////Af////gP//////////////////////////////////////////////////////////////////+L/9DgP/f2///74n///dM//////////////////////////////////////////////////f/AAX/f/9/r//f0//36P//////////////////////////////////////////////////////////////////////////////////////8A3Nzc3",
+     "size": 384
+    },
+    "wigos_station_identifier": "0-690-0-63015PD",
+    "id": "283f0919-ed9b-457c-a1be-dd48f0d91fe4"
+   },
+   "links": [
+    {
+     "rel": "canonical",
+     "type": "application/bufr",
+     "href": "https://wis2.meteo.sc/data/2026-08-12/wis/urn:wmo:md:sc-seychelles-met:core.surface-based-observations.synop/WIGOS_0-690-0-63015PD_20260812T140000.bufr4",
+     "length": 384
+    },
+    {
+     "rel": "via",
+     "type": "text/html",
+     "href": "https://oscar.wmo.int/surface/#/search/station/stationReportDetails/0-690-0-63015PD"
+    }
+   ],
+   "generated_by": "wis2box 1.3.0"
+  }
+ ],
+ "numberMatched": 14,
+ "numberReturned": 14,
+ "links": [
+  {
+   "type": "application/geo+json",
+   "rel": "self",
+   "title": "This document as GeoJSON",
+   "href": "https://wis2.meteo.sc/oapi/collections/messages/items?f=json&limit=500&datetime=2026-08-12T14%3A30%3A00Z%2F2026-08-12T16%3A00%3A00Z"
+  },
+  {
+   "rel": "alternate",
+   "type": "application/ld+json",
+   "title": "This document as RDF (JSON-LD)",
+   "href": "https://wis2.meteo.sc/oapi/collections/messages/items?f=jsonld&limit=500&datetime=2026-08-12T14%3A30%3A00Z%2F2026-08-12T16%3A00%3A00Z"
+  },
+  {
+   "type": "text/html",
+   "rel": "alternate",
+   "title": "This document as HTML",
+   "href": "https://wis2.meteo.sc/oapi/collections/messages/items?f=html&limit=500&datetime=2026-08-12T14%3A30%3A00Z%2F2026-08-12T16%3A00%3A00Z"
+  },
+  {
+   "type": "text/csv; charset=utf-8",
+   "rel": "alternate",
+   "title": "This document as CSV",
+   "href": "https://wis2.meteo.sc/oapi/collections/messages/items?f=csv&limit=500&datetime=2026-08-12T14%3A30%3A00Z%2F2026-08-12T16%3A00%3A00Z"
+  },
+  {
+   "type": "application/json",
+   "title": "Data notifications",
+   "rel": "collection",
+   "href": "https://wis2.meteo.sc/oapi/collections/messages"
+  }
+ ],
+ "timeStamp": "2026-08-13T10:44:47.059681Z"
+}

--- a/wis2watch/src/wis2watch/core/tests/support.py
+++ b/wis2watch/src/wis2watch/core/tests/support.py
@@ -55,9 +55,12 @@ def pages(*payloads):
     Every sync takes its page fetch as an argument for exactly this reason, so
     the writing rules can be asserted against payloads the source really
     returned without anything opening a socket.
+
+    Whatever the fetch is asked for is ignored, so that one stand-in serves the
+    syncs that fetch a source whole and the poll that fetches a window of one.
     """
 
-    def fetch(_source):
+    def fetch(*_args, **_kwargs):
         yield from payloads
 
     return fetch
@@ -66,7 +69,7 @@ def pages(*payloads):
 def failing_fetch(message):
     """A page fetch that fails the way an unreachable source would."""
 
-    def fetch(_source):
+    def fetch(*_args, **_kwargs):
         raise OSError(message)
         yield  # pragma: no cover - never reached, keeps this a generator
 

--- a/wis2watch/src/wis2watch/core/tests/test_interpretation_archive.py
+++ b/wis2watch/src/wis2watch/core/tests/test_interpretation_archive.py
@@ -1,0 +1,192 @@
+"""Reading a page of a centre's own notification archive, against captures.
+
+The two fixtures are real pages from two centres' archives, and the assertions
+here are mostly about what those pages do *not* carry. No topic, above all:
+every attribution the broker path derives from one has to come from somewhere
+else, and a test that let a topic creep in would be testing something the
+archive never returns.
+"""
+
+from wis2watch.core.interpretation import (
+    archived_notifications,
+    next_page_url,
+    parse_notification,
+    parse_topic,
+)
+
+from .support import NoNetworkTestCase, load_json_fixture
+
+SHALLOW = "node_messages_sc_seychelles_met.json"
+DEEP = "node_messages_gh_gmet.json"
+
+#: The metadata notification each capture carries. A centre announces its own
+#: discovery metadata on the same archive as its data, and names no dataset
+#: when it does: the record it announces *is* the dataset description.
+SC_METADATA_NOTIFICATION = (
+    "sc-seychelles-met/metadata/"
+    "urn:wmo:md:sc-seychelles-met:core.surface-based-observations.synop"
+)
+GH_METADATA_NOTIFICATION = (
+    "gh-gmet/metadata/urn:wmo:md:gh-gmet:core.surface-based-observations.synop"
+)
+
+
+class ArchivedNotificationsTests(NoNetworkTestCase):
+    """What a page of an archive offers, read off the two captures."""
+
+    def test_a_shallow_archive_offers_every_notification_on_its_one_page(self):
+        payload = load_json_fixture(SHALLOW)
+
+        self.assertEqual(len(archived_notifications(payload)), 14)
+
+    def test_a_deep_archive_offers_the_page_it_was_asked_for(self):
+        payload = load_json_fixture(DEEP)
+
+        self.assertEqual(len(archived_notifications(payload)), 10)
+
+    def test_a_page_of_nothing_offers_nothing(self):
+        self.assertEqual(archived_notifications({"features": []}), [])
+        self.assertEqual(archived_notifications({}), [])
+        self.assertEqual(archived_notifications(None), [])
+
+
+class NoTopicTests(NoNetworkTestCase):
+    """The archive carries no topic, which is the whole of its difference.
+
+    The broker path reads the centre, the vantage point and the dataset off the
+    topic a message arrived on. An archived notification is the same JSON with
+    that one thing missing, and it is missing from every level of the payload
+    rather than merely from the property the parser reads.
+    """
+
+    def test_no_archived_notification_names_a_topic(self):
+        for fixture in (SHALLOW, DEEP):
+            for notification in archived_notifications(load_json_fixture(fixture)):
+                with self.subTest(fixture=fixture, id=notification["id"]):
+                    self.assertNotIn("topic", notification)
+                    self.assertNotIn("topic", notification["properties"])
+
+    def test_the_absent_topic_names_no_centre(self):
+        """What the store would resolve from a topic, had it one to resolve."""
+        self.assertIsNone(parse_topic(""))
+
+
+class ParsingTests(NoNetworkTestCase):
+    """A feature of the collection is a notification, not a wrapper round one.
+
+    The archive returns the WIS2 Notification Message itself -- the same JSON
+    the broker carries -- so the parser the ingest already has reads it as it
+    stands. That is what lets one store path serve both vantage points.
+    """
+
+    def test_every_captured_notification_parses(self):
+        for fixture in (SHALLOW, DEEP):
+            for notification in archived_notifications(load_json_fixture(fixture)):
+                with self.subTest(fixture=fixture, id=notification["id"]):
+                    self.assertIsNotNone(parse_notification(notification))
+
+    def test_a_data_notification_keeps_its_uuid_time_and_station(self):
+        first = archived_notifications(load_json_fixture(DEEP))[0]
+
+        parsed = parse_notification(first)
+
+        self.assertEqual(parsed.notification_id, first["id"])
+        self.assertEqual(
+            parsed.publication_time.isoformat(), "2026-08-09T17:09:20+00:00"
+        )
+        self.assertEqual(parsed.wigos_station_id, "0-288-0-65492")
+        self.assertEqual(
+            parsed.metadata_id,
+            "urn:wmo:md:gh-gmet:core.surface-based-observations.synop",
+        )
+        self.assertTrue(
+            parsed.canonical_link.startswith("https://wis2.meteo.gov.gh/data/")
+        )
+
+    def test_a_metadata_notification_names_no_dataset_and_no_station(self):
+        """Both captures carry one, and neither is a data publication.
+
+        A centre announcing its own discovery metadata carries the record
+        inline and names no ``metadata_id`` -- the record it announces is the
+        one that would be named. Nothing resolves it to a dataset, and nothing
+        should: the alternative is inventing an attribution the message never
+        made.
+        """
+        for fixture, data_id in (
+            (SHALLOW, SC_METADATA_NOTIFICATION),
+            (DEEP, GH_METADATA_NOTIFICATION),
+        ):
+            with self.subTest(fixture=fixture):
+                page = load_json_fixture(fixture)
+                announcements = [
+                    parse_notification(notification)
+                    for notification in archived_notifications(page)
+                    if notification["properties"]["data_id"] == data_id
+                ]
+
+                self.assertEqual(len(announcements), 1)
+                self.assertEqual(announcements[0].metadata_id, "")
+                self.assertEqual(announcements[0].wigos_station_id, "")
+                self.assertFalse(announcements[0].is_attributed)
+
+    def test_a_metadata_notification_advertises_no_canonical_link(self):
+        """It carries the record itself, and offers only an ``update`` link."""
+        announcement = next(
+            notification
+            for notification in archived_notifications(load_json_fixture(SHALLOW))
+            if notification["properties"]["data_id"] == SC_METADATA_NOTIFICATION
+        )
+
+        self.assertEqual(parse_notification(announcement).canonical_link, "")
+        self.assertEqual(
+            [link["rel"] for link in announcement["links"]],
+            ["update"],
+        )
+
+
+class PagingTests(NoNetworkTestCase):
+    """An archive pages the way every other collection this tool reads does."""
+
+    def test_a_shallow_archive_offers_no_next_page(self):
+        self.assertIsNone(next_page_url(load_json_fixture(SHALLOW)))
+
+    def test_a_deep_archive_links_to_the_next_page(self):
+        self.assertEqual(
+            next_page_url(load_json_fixture(DEEP)),
+            "https://wis2.meteo.gov.gh/oapi/collections/messages/items"
+            "?offset=396&limit=10"
+            "&datetime=2026-08-09T00%3A00%3A00Z%2F2026-08-11T23%3A59%3A59Z",
+        )
+
+    def test_the_next_page_link_carries_the_window_forward(self):
+        """Which is why paging follows the link rather than rebuilding it.
+
+        A resumed page that dropped the interval would quietly widen the
+        window: the run would page on through the whole archive believing it
+        was reading the window it asked for.
+        """
+        self.assertIn("datetime=", next_page_url(load_json_fixture(DEEP)))
+
+    def test_a_page_reports_how_many_the_window_really_matched(self):
+        """The count is exact, and is what a partial read can be judged against."""
+        self.assertEqual(load_json_fixture(DEEP)["numberMatched"], 1757)
+        self.assertEqual(load_json_fixture(DEEP)["numberReturned"], 10)
+        self.assertEqual(load_json_fixture(SHALLOW)["numberMatched"], 14)
+
+
+class OrderingTests(NoNetworkTestCase):
+    """Nothing may be assumed about the order a page arrives in.
+
+    The deep capture is a real page from the middle of a paging run, and its
+    notifications are not in publication order. Anything that read the first or
+    last row of a page as the edge of the window would be wrong on this very
+    capture.
+    """
+
+    def test_a_page_is_not_in_publication_order(self):
+        published = [
+            parse_notification(notification).publication_time
+            for notification in archived_notifications(load_json_fixture(DEEP))
+        ]
+
+        self.assertNotEqual(published, sorted(published))

--- a/wis2watch/src/wis2watch/core/tests/test_silence.py
+++ b/wis2watch/src/wis2watch/core/tests/test_silence.py
@@ -275,6 +275,67 @@ class NeverHeardFromTests(SilenceTestCase):
         self.assertFalse(self.row().is_silent)
 
 
+class PulledHistoryTests(SilenceTestCase):
+    """One centre's archive, pulled deep, says nothing about anyone else.
+
+    A centre's own message archive can be asked for months of its history, and
+    those hours are that centre's word for itself rather than hours this tool
+    was hearing the region. Counted as the region's floor they would report
+    every dataset never seen publishing -- at every other centre, whose archive
+    was never asked -- as quiet for months.
+    """
+
+    def setUp(self):
+        super().setUp()
+
+        self.ghana = self.node("gh-gmet")
+        self.archive = MessageSource.objects.create(
+            name="gh-gmet origin API",
+            source_type=MessageSource.ORIGIN_API,
+            node=self.ghana,
+            centre_id="gh-gmet",
+            api_url="https://wis2.meteo.gov.gh/oapi/collections/messages",
+        )
+
+    def pulled(self, dataset, hour):
+        """A rollup from a pull of the centre's own archive."""
+        return HourlyRollup.objects.create(
+            hour=hour,
+            source=self.archive,
+            node=dataset.node,
+            dataset=dataset,
+            message_count=1,
+        )
+
+    def test_a_deep_pull_does_not_backdate_what_the_region_was_watched_from(self):
+        pulled = self.dataset("pulled", node=self.ghana)
+        self.pulled(pulled, NOW - timedelta(days=90))
+        self.last_published(self.dataset("something-else"), NOW - timedelta(hours=40))
+
+        self.learned(self.dataset(), 6)
+
+        self.assertEqual(self.row().hours_quiet, 40)
+
+    def test_a_pull_alone_leaves_a_dataset_never_seen_unjudged_on_it(self):
+        """Nothing but a pulled archive is no record of watching the region."""
+        pulled = self.dataset("pulled", node=self.ghana)
+        self.pulled(pulled, NOW - timedelta(days=90))
+
+        self.learned(self.dataset(), 6)
+
+        self.assertEqual(self.row().hours_quiet, 0)
+        self.assertFalse(self.row().is_silent)
+
+    def test_the_pulled_centre_is_still_judged_on_the_hours_it_published_in(self):
+        """The floor is only ever reached for a dataset never seen at all."""
+        pulled = self.dataset("pulled", node=self.ghana)
+        self.pulled(pulled, NOW - timedelta(hours=30))
+        self.learned(pulled, 6)
+
+        self.assertEqual(self.row("pulled").hours_quiet, 29)
+        self.assertTrue(self.row("pulled").is_silent)
+
+
 class LongMemoryTests(SilenceTestCase):
     """How far back the last publication is looked for: all the way.
 

--- a/wis2watch/src/wis2watch/ingest/archive.py
+++ b/wis2watch/src/wis2watch/ingest/archive.py
@@ -48,7 +48,7 @@ from django.utils import timezone as dj_timezone
 from ..core.interpretation import archived_notifications
 from ..core.models import SyncLog
 from ..core.rollups import window_start
-from ..core.sync import SyncCounts, fetch_pages
+from ..core.sync import PagingDidNotTerminate, SyncCounts, fetch_pages
 from .store import store_notifications
 
 logger = logging.getLogger(__name__)
@@ -63,17 +63,14 @@ ITEMS_PATH = "/items"
 #: a pull is a hundred requests or fifty thousand.
 PAGE_SIZE = 500
 
-#: How long a centre is given to answer one page. As generous as a catalogue's,
-#: because this is asked of one centre at a time by somebody waiting for it,
-#: rather than of every centre on a schedule.
-FETCH_TIMEOUT = 60
-
 #: A ceiling on paging, far above the one the scheduled syncs use. Those read
 #: registries of a few hundred records, where fifty pages already means the
 #: links are cycling; an archive of a year of a busy centre's traffic is
 #: legitimately hundreds of pages, and a ceiling that stopped it would report a
-#: half-read archive as a failure every time.
-MAX_PAGES = 2000
+#: half-read archive as a failure every time. Named for the archive, because a
+#: bare ``MAX_PAGES`` beside the one every other read uses would be two rules
+#: with one name.
+MAX_ARCHIVE_PAGES = 2000
 
 
 def archive_items_url(source):
@@ -88,10 +85,10 @@ def publication_interval(since, until):
     archive are, and an interval offered in a local offset would silently ask
     for a different few hours than the one that was meant.
     """
-    return f"{_rfc3339(since)}/{_rfc3339(until)}"
+    return f"{_utc_instant(since)}/{_utc_instant(until)}"
 
 
-def _rfc3339(moment):
+def _utc_instant(moment):
     """An instant as the archive spells one."""
     return moment.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
@@ -110,7 +107,7 @@ def trailing_window(hours, now=None):
     return window_start(now, hours), now
 
 
-def fetch_archive_pages(source, since, until, max_pages=MAX_PAGES):
+def fetch_archive_pages(source, since, until, max_pages=MAX_ARCHIVE_PAGES):
     """Every page of a centre's archive for a window, exactly as returned.
 
     The interval matches on publication time, which is what makes the reply
@@ -129,8 +126,7 @@ def fetch_archive_pages(source, since, until, max_pages=MAX_PAGES):
             "datetime": publication_interval(since, until),
         },
         verify=source.node.verify_ssl,
-        timeout=FETCH_TIMEOUT,
-        read_from=f"{source.node.centre_id}'s message archive",
+        read_from=f"{source.owning_centre_id}'s message archive",
         max_pages=max_pages,
     )
 
@@ -163,6 +159,12 @@ def _store_page(source, payload):
     that would say. Everything else about a row -- the dataset, the station,
     what to do with one that cannot be identified in time -- is the store's,
     which is the point of writing through it.
+
+    Two of the store's outcomes are the only ones a poll can come back with:
+    accepted, and unstorable. Nothing here can be refused for belonging to
+    another region, since that is decided from the centre a message's topic
+    names and these name none -- which is why what the run reports adds up
+    without counting it.
     """
     notifications = archived_notifications(payload)
 
@@ -175,7 +177,9 @@ def _store_page(source, payload):
     return len(notifications), counts
 
 
-def poll_message_archive(source, *, since, until, max_pages=MAX_PAGES, fetch=None):
+def poll_message_archive(
+    source, *, since, until, max_pages=MAX_ARCHIVE_PAGES, fetch=None
+):
     """Pull a window of one centre's archive, returning the ``SyncLog``.
 
     Reported through a sync log like every other run against a node, so that
@@ -211,9 +215,22 @@ def poll_message_archive(source, *, since, until, max_pages=MAX_PAGES, fetch=Non
             counts.found += offered
             counts.created += stored.accepted
             counts.errored += stored.discarded
+    except PagingDidNotTerminate as exc:
+        # It answered -- too many times. A read this could not finish is a
+        # failed run, but recording the centre as unreachable would send
+        # somebody looking for a network fault at a centre that replied to
+        # every request, and would disqualify it from being judged at all.
+        logger.error(
+            "Could not read %s's message archive through: %s",
+            source.owning_centre_id,
+            exc,
+        )
+        _record_answer(source)
+
+        return counts.close(sync_log, SyncLog.FAILED, str(exc))
     except Exception as exc:
         logger.error(
-            "Could not read %s's message archive: %s", source.node.centre_id, exc
+            "Could not read %s's message archive: %s", source.owning_centre_id, exc
         )
         _record_answer(source, error=str(exc))
 
@@ -223,7 +240,7 @@ def poll_message_archive(source, *, since, until, max_pages=MAX_PAGES, fetch=Non
     counts.close(sync_log, counts.status)
 
     logger.info(
-        "Message archive poll for %s: %s", source.node.centre_id, sync_log.summary
+        "Message archive poll for %s: %s", source.owning_centre_id, sync_log.summary
     )
 
     return sync_log

--- a/wis2watch/src/wis2watch/ingest/archive.py
+++ b/wis2watch/src/wis2watch/ingest/archive.py
@@ -1,0 +1,229 @@
+"""Asking a centre for the notifications it says it published.
+
+A wis2box serves an archive of its own notification messages over HTTP, and
+this is where that archive is read and stored as origin evidence. It is the
+second way a centre can speak for itself: the first is the broker it publishes
+to, and a centre whose broker cannot be reached from outside -- which is a
+great many of them -- can still be asked here what it published.
+
+Four things about that reading are decisions rather than mechanics.
+
+**There is no topic.** The archive returns the WIS2 Notification Message
+itself, envelope and all, but nothing that says what topic it went out on.
+Every attribution the broker path derives from a topic -- which centre, which
+vantage point, which dataset -- therefore comes from somewhere else: the centre
+because the poll chose the address, the vantage point because the archive is
+one, and the dataset from the metadata identifier the message carries. The
+stored topic stays empty, because none was observed. Synthesising one from the
+dataset's declared topic would read better and would quietly destroy the
+evidence for a centre transmitting data no dataset of its own claims, which is
+a message no topic would ever have named.
+
+**The whole collection is asked for, not one dataset of it.** On the nodes
+surveyed it costs the same -- each declares a single dataset -- and a message
+whose metadata identifier names no registered dataset is the strongest evidence
+this tool can get that a centre is transmitting undeclared data, since it comes
+from the centre's own archive. Asking per dataset could only ever return the
+datasets already known. Metadata notifications come back mixed in with data
+ones and are stored, as the broker path stores them.
+
+**The window is a fixed trailing one, asked for again each time.** Publication
+time is the publisher's own claim, so a message stamped behind a watermark
+would be dropped permanently, with no later run that recovers it. Overlap is
+the only thing that absorbs stamp skew, and re-reading costs nothing: a
+notification already held is absorbed by the per-source uniqueness constraint.
+
+**Certificate verification follows the node's own setting**, as reading the
+same node's station registry does. A bad certificate is separately reported by
+link probing, which always verifies, so honouring the setting here suppresses
+no finding -- it only stops a certificate problem from also costing the origin
+evidence.
+"""
+
+import logging
+from datetime import timezone
+
+from django.utils import timezone as dj_timezone
+
+from ..core.interpretation import archived_notifications
+from ..core.models import SyncLog
+from ..core.rollups import window_start
+from ..core.sync import SyncCounts, fetch_pages
+from .store import store_notifications
+
+logger = logging.getLogger(__name__)
+
+#: Where the collection's items live, relative to the archive's address. The
+#: stored address names the collection, because that is the part an operator
+#: can check by opening it.
+ITEMS_PATH = "/items"
+
+#: Notifications requested per page. An archive holds a message per station per
+#: hour and is read months at a time, so the page size is what decides whether
+#: a pull is a hundred requests or fifty thousand.
+PAGE_SIZE = 500
+
+#: How long a centre is given to answer one page. As generous as a catalogue's,
+#: because this is asked of one centre at a time by somebody waiting for it,
+#: rather than of every centre on a schedule.
+FETCH_TIMEOUT = 60
+
+#: A ceiling on paging, far above the one the scheduled syncs use. Those read
+#: registries of a few hundred records, where fifty pages already means the
+#: links are cycling; an archive of a year of a busy centre's traffic is
+#: legitimately hundreds of pages, and a ceiling that stopped it would report a
+#: half-read archive as a failure every time.
+MAX_PAGES = 2000
+
+
+def archive_items_url(source):
+    """Where the notifications of a centre's archive are read from."""
+    return f"{source.api_url.rstrip('/')}{ITEMS_PATH}"
+
+
+def publication_interval(since, until):
+    """A window as the archive asks for one: two instants and a slash.
+
+    Stated in UTC and stamped as such, because that is what the times in the
+    archive are, and an interval offered in a local offset would silently ask
+    for a different few hours than the one that was meant.
+    """
+    return f"{_rfc3339(since)}/{_rfc3339(until)}"
+
+
+def _rfc3339(moment):
+    """An instant as the archive spells one."""
+    return moment.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def trailing_window(hours, now=None):
+    """The window a pull of this depth asks for: where it starts, and now.
+
+    It starts at the first whole hourly bucket the depth covers, because what
+    is pulled is afterwards counted into those buckets: a window beginning
+    mid-hour would leave its first bucket recomputed from a fraction of the
+    hour's messages, and a partial count overwrites a complete one with a
+    smaller number.
+    """
+    now = now or dj_timezone.now()
+
+    return window_start(now, hours), now
+
+
+def fetch_archive_pages(source, since, until, max_pages=MAX_PAGES):
+    """Every page of a centre's archive for a window, exactly as returned.
+
+    The interval matches on publication time, which is what makes the reply
+    comparable with what the Global Broker carried: both are the same claim by
+    the same publisher about the same moment.
+
+    Paging follows the server's own ``next`` link, which carries the interval
+    forward -- a resumed page that dropped it would read on through the whole
+    archive believing it was still inside the window.
+    """
+    return fetch_pages(
+        archive_items_url(source),
+        params={
+            "f": "json",
+            "limit": PAGE_SIZE,
+            "datetime": publication_interval(since, until),
+        },
+        verify=source.node.verify_ssl,
+        timeout=FETCH_TIMEOUT,
+        read_from=f"{source.node.centre_id}'s message archive",
+        max_pages=max_pages,
+    )
+
+
+def _record_answer(source, error=""):
+    """Write down what the centre did when it was asked.
+
+    Reachability here is not a claim that the centre is publishing, only that
+    it answered: an archive that returns an empty window has answered, and one
+    that 404s has not. Both are findings, which is why this is written after
+    every poll rather than only after a failure.
+    """
+    source.is_reachable = not error
+    source.last_error = error
+
+    updated = ["is_reachable", "last_error", "modified"]
+
+    if not error:
+        source.last_connected_at = dj_timezone.now()
+        updated.append("last_connected_at")
+
+    source.save(update_fields=updated)
+
+
+def _store_page(source, payload):
+    """Store one page of notifications, reporting what became of them.
+
+    The node is handed to the store rather than left to be read off a topic:
+    the poll knows whose archive it asked for, and the messages carry nothing
+    that would say. Everything else about a row -- the dataset, the station,
+    what to do with one that cannot be identified in time -- is the store's,
+    which is the point of writing through it.
+    """
+    notifications = archived_notifications(payload)
+
+    counts = store_notifications(
+        source,
+        [("", notification) for notification in notifications],
+        node=source.node,
+    )
+
+    return len(notifications), counts
+
+
+def poll_message_archive(source, *, since, until, max_pages=MAX_PAGES, fetch=None):
+    """Pull a window of one centre's archive, returning the ``SyncLog``.
+
+    Reported through a sync log like every other run against a node, so that
+    "was this centre's archive read, and what came back" is answered where its
+    station sync is answered.
+
+    ``items_created`` counts the notifications written through the store rather
+    than the rows that landed. A window is asked for again on every run, so
+    most of what it carries is already held and is absorbed by the uniqueness
+    constraint; asking the database how many were new would cost a scan of a
+    hypertable to learn something no one needs.
+
+    A run that fails part way keeps what it read before it failed. The pages
+    already stored are evidence about the centre whatever went wrong on the
+    next request, and re-reading the window is free.
+
+    ``fetch`` is how the archive's pages are read, defaulting to the network.
+    """
+    fetch = fetch or fetch_archive_pages
+
+    sync_log = SyncLog.objects.create(
+        node=source.node,
+        sync_type=SyncLog.MESSAGE_ARCHIVE,
+        status=SyncLog.FAILED,
+    )
+
+    counts = SyncCounts()
+
+    try:
+        for payload in fetch(source, since=since, until=until, max_pages=max_pages):
+            offered, stored = _store_page(source, payload)
+
+            counts.found += offered
+            counts.created += stored.accepted
+            counts.errored += stored.discarded
+    except Exception as exc:
+        logger.error(
+            "Could not read %s's message archive: %s", source.node.centre_id, exc
+        )
+        _record_answer(source, error=str(exc))
+
+        return counts.close(sync_log, SyncLog.FAILED, str(exc))
+
+    _record_answer(source)
+    counts.close(sync_log, counts.status)
+
+    logger.info(
+        "Message archive poll for %s: %s", source.node.centre_id, sync_log.summary
+    )
+
+    return sync_log

--- a/wis2watch/src/wis2watch/ingest/management/commands/pull_message_archive.py
+++ b/wis2watch/src/wis2watch/ingest/management/commands/pull_message_archive.py
@@ -1,0 +1,121 @@
+"""Ask one centre for the notifications it published, and count them.
+
+This is how a centre's own account of itself is recovered after the fact: for a
+node whose broker nothing outside can reach, and for a stretch this tool was
+not listening through -- its own downtime, or the weeks before it was installed.
+
+The rollups are rebuilt here rather than left to the schedule. The scheduled
+run recomputes the last two days, so a pull reaching further back would sit in
+the raw messages until the expiry job dropped them a fortnight later, and the
+history would materialise as a side effect of that -- correct by coincidence
+rather than by design.
+
+Beware what a deep pull means for propagation findings. Notifications recovered
+from a centre's archive across hours the Global Broker was never listened to
+will look, to anything comparing the two, like a Global Broker that failed to
+carry them. That is why the propagation evaluation judges only the hours it can
+prove it was listening through, and why this command can be pointed at any
+depth without manufacturing accusations.
+"""
+
+from django.core.management.base import BaseCommand, CommandError
+
+from wis2watch.core.models import MessageSource, WIS2Node
+from wis2watch.core.rollups import rollup_hours
+from wis2watch.ingest.archive import poll_message_archive, trailing_window
+
+#: How deep a pull goes when nobody says. A day is the overlap a daily run
+#: wants: long enough to absorb a publisher's stamp skew, short enough to be
+#: the thing somebody reaches for without thinking about it.
+DEFAULT_HOURS = 24
+
+
+class Command(BaseCommand):
+    help = "Pull one centre's own archive of the notifications it published"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "centre_id",
+            help="The WIS2 centre ID of the node to ask, e.g. sc-seychelles-met",
+        )
+        parser.add_argument(
+            "--hours",
+            type=int,
+            default=DEFAULT_HOURS,
+            help=(
+                "How many hours back to ask for. The window is asked for "
+                "outright each time rather than resumed, so overlapping an "
+                "earlier pull costs nothing"
+            ),
+        )
+
+    def handle(self, *args, **options):
+        source = self.archive_of(options["centre_id"])
+        hours = self.depth(options["hours"])
+
+        since, until = trailing_window(hours)
+
+        sync_log = poll_message_archive(source, since=since, until=until)
+
+        style = self.style.ERROR if sync_log.error_message else self.style.SUCCESS
+
+        self.stdout.write(
+            style(f"{source.node.centre_id} message archive: {sync_log.summary}")
+        )
+
+        if sync_log.error_message:
+            self.stdout.write(self.style.ERROR(f"  {sync_log.error_message}"))
+
+        self.rebuild_rollups(since, until)
+
+    def rebuild_rollups(self, since, until):
+        """Count the hours that were just pulled.
+
+        Run whatever the poll came to. A run that failed part way through still
+        stored the pages it read before it failed, and those hours are as much
+        in need of counting as a whole run's.
+        """
+        counts = rollup_hours(since=since, until=until)
+
+        self.stdout.write(
+            f"Rolled up {since:%Y-%m-%d %H:%M} to {until:%Y-%m-%d %H:%M} UTC: "
+            f"{counts.summary}"
+        )
+
+    def archive_of(self, centre_id):
+        """The vantage point on this centre's archive, or a refusal.
+
+        Both refusals are the operator's to act on rather than something to
+        guess past: a centre nothing has registered may be a typo, and one with
+        no archive registered needs an address nobody here can invent -- where a
+        centre serves its notifications is a wis2box convention rather than
+        anything WCMP2 advertises, and the admin is where it is corrected.
+        """
+        node = WIS2Node.objects.filter(centre_id=centre_id.strip().lower()).first()
+
+        if node is None:
+            raise CommandError(f"No node is registered under the centre ID {centre_id}")
+
+        source = node.message_sources.filter(
+            source_type=MessageSource.ORIGIN_API
+        ).first()
+
+        if source is None:
+            raise CommandError(
+                f"{node.centre_id} has no message archive registered. Add one "
+                "against the node under Message Sources, with the address it "
+                "serves its own notifications at."
+            )
+
+        return source
+
+    def depth(self, hours):
+        """How far back to ask, or a refusal.
+
+        A window of nothing would report a successful run that read an archive
+        and found it empty, which is a different finding entirely.
+        """
+        if hours < 1:
+            raise CommandError("A pull covers at least one hour")
+
+        return hours

--- a/wis2watch/src/wis2watch/ingest/store.py
+++ b/wis2watch/src/wis2watch/ingest/store.py
@@ -217,13 +217,19 @@ class RegistryLookup:
         return self._stations[wigos_id]
 
 
-def prepare_notification(source, topic, payload, lookup=None):
+def prepare_notification(source, topic, payload, lookup=None, node=None):
     """A received message as an unsaved ``NotificationMessage``, or None.
 
     ``source`` is the connection the message arrived on; which vantage point
     the row is stored against is read off the topic, since one connection
     carries both a centre's own publication and the caches' republication of
     it.
+
+    ``node`` is the centre whose traffic this is, for a vantage point that
+    knows without being told: a poller reading a centre's own archive chose the
+    address, so the answer the broker path reads off a topic is one the request
+    already settled. It is only ever consulted where there is no topic to read
+    -- a message that names its centre says so, and what it says stands.
 
     None means the message cannot be identified in time -- no UUID, or no
     usable publication time -- and so could not be de-duplicated or matched
@@ -248,7 +254,7 @@ def prepare_notification(source, topic, payload, lookup=None):
 
     return NotificationMessage(
         source=lookup.vantage(source, parsed),
-        node=lookup.node(parsed.centre_id) if parsed else None,
+        node=lookup.node(parsed.centre_id) if parsed else node,
         dataset=lookup.dataset(
             parsed.as_origin().raw if parsed else "", notification.metadata_id
         ),
@@ -380,7 +386,7 @@ def _record_observed_stations(records):
             )
 
 
-def store_notifications(source, received):
+def store_notifications(source, received, node=None):
     """Store a flush of received ``(topic, payload)`` pairs.
 
     A message the flush cannot prepare is counted and stepped over: one
@@ -392,6 +398,13 @@ def store_notifications(source, received):
     A registered node is kept whatever its centre ID begins with, since a node
     added by hand under a prefix that names no country is still one somebody
     asked to watch.
+
+    ``node`` is whose traffic the caller already knows this to be, and is what
+    a poll of a centre's own archive brings that a broker flush cannot: those
+    messages carry no topic, so without it every one of them would be stored
+    attributed to nobody. Passing it is not a licence to store another
+    region's traffic -- a message that names its own centre is still judged on
+    that -- it is the answer for messages that name none.
     """
     counts = StoreCounts()
     lookup = RegistryLookup()
@@ -399,7 +412,9 @@ def store_notifications(source, received):
 
     for topic, payload in received:
         try:
-            record = prepare_notification(source, topic, payload, lookup=lookup)
+            record = prepare_notification(
+                source, topic, payload, lookup=lookup, node=node
+            )
         except Exception as exc:
             logger.warning("Could not prepare a message on %s: %s", topic, exc)
             counts.discarded += 1

--- a/wis2watch/src/wis2watch/ingest/tests/test_archive.py
+++ b/wis2watch/src/wis2watch/ingest/tests/test_archive.py
@@ -1,0 +1,423 @@
+"""Polling a centre's own archive, against two captured archives.
+
+These are seeded-database tests for the same reason the broker store's are: a
+wrong lookup here writes a confidently mis-attributed row rather than raising.
+The risk is the other way round from the broker's, though. There, everything is
+read off a topic and the danger is reading it wrongly; here there is no topic at
+all, and the danger is inventing what it would have said -- a centre, a dataset,
+a vantage point -- from the request that happened to fetch the page.
+"""
+
+from datetime import timedelta
+from unittest import mock
+
+from django.test import TestCase
+from django.utils import timezone as dj_timezone
+
+from wis2watch.core.models import (
+    Dataset,
+    NodeLastSeen,
+    NotificationMessage,
+    Station,
+    StationSource,
+    SyncLog,
+    WIS2Node,
+)
+from wis2watch.core.sync import MAX_PAGES as SCHEDULED_MAX_PAGES
+from wis2watch.core.tests.support import (
+    at,
+    failing_fetch,
+    load_json_fixture,
+    origin_api,
+    pages,
+)
+from wis2watch.ingest.archive import (
+    MAX_PAGES,
+    PAGE_SIZE,
+    archive_items_url,
+    fetch_archive_pages,
+    poll_message_archive,
+    publication_interval,
+)
+
+SHALLOW = "node_messages_sc_seychelles_met.json"
+DEEP = "node_messages_gh_gmet.json"
+
+SC_DATASET = "urn:wmo:md:sc-seychelles-met:core.surface-based-observations.synop"
+SC_METADATA_NOTIFICATION = f"sc-seychelles-met/metadata/{SC_DATASET}"
+
+SINCE = at("2026-08-12T00:00:00")
+UNTIL = at("2026-08-13T00:00:00")
+
+
+class ArchiveTestCase(TestCase):
+    """A centre whose archive is registered as a vantage point on it."""
+
+    def setUp(self):
+        super().setUp()
+
+        self.node = WIS2Node.objects.create(
+            centre_id="sc-seychelles-met",
+            name="Seychelles Meteorological Authority",
+            base_url="https://wis2.meteo.sc",
+        )
+        self.source = origin_api(self.node)
+
+    def dataset(self, identifier=SC_DATASET, topic="a/wis2/sc-seychelles-met/data"):
+        return Dataset.objects.create(
+            node=self.node,
+            identifier=identifier,
+            title="Hourly synoptic observations",
+            wmo_data_policy="core",
+            wmo_topic_hierarchy=topic,
+            raw_json={},
+        )
+
+    def poll(self, *payloads):
+        """Poll the archive over payloads it is made to answer with."""
+        return poll_message_archive(
+            self.source, since=SINCE, until=UNTIL, fetch=pages(*payloads)
+        )
+
+    def poll_capture(self, fixture=SHALLOW):
+        return self.poll(load_json_fixture(fixture))
+
+
+class AttributionTests(ArchiveTestCase):
+    """Whose traffic this is, and what the row may claim about it."""
+
+    def test_every_notification_is_stored_against_the_centre_that_was_asked(self):
+        self.poll_capture()
+
+        self.assertEqual(NotificationMessage.objects.count(), 14)
+        self.assertEqual(
+            NotificationMessage.objects.filter(node=self.node).count(), 14
+        )
+
+    def test_no_stored_row_claims_a_topic(self):
+        """None was observed, and one that reads well would destroy evidence.
+
+        A topic synthesised from the dataset's declared one would make every
+        archived message look like a message on a declared topic -- which is
+        exactly the evidence ``transmitting-undeclared`` rests on being able to
+        find missing.
+        """
+        self.poll_capture()
+
+        self.assertEqual(
+            set(NotificationMessage.objects.values_list("topic", flat=True)), {""}
+        )
+
+    def test_the_archive_is_the_vantage_point_the_rows_are_stored_against(self):
+        self.poll_capture()
+
+        self.assertEqual(
+            NotificationMessage.objects.exclude(source=self.source).count(), 0
+        )
+
+    def test_a_notification_is_resolved_to_a_dataset_by_the_record_it_names(self):
+        """With no topic to ask first, the metadata identifier is all there is."""
+        dataset = self.dataset()
+
+        self.poll_capture()
+
+        self.assertEqual(
+            NotificationMessage.objects.filter(dataset=dataset).count(), 13
+        )
+
+    def test_a_notification_naming_a_record_nobody_registered_is_still_stored(self):
+        """The strongest evidence a centre is transmitting undeclared data.
+
+        It comes from the centre's own archive, and discarding it would leave
+        the finding resting on nothing.
+        """
+        self.dataset(identifier="urn:wmo:md:sc-seychelles-met:something-else")
+
+        self.poll_capture()
+
+        undeclared = NotificationMessage.objects.filter(dataset__isnull=True)
+
+        self.assertEqual(undeclared.count(), 14)
+        self.assertEqual(undeclared.exclude(node=self.node).count(), 0)
+
+    def test_a_metadata_notification_is_stored_as_the_broker_path_stores_one(self):
+        """It names no dataset and no station, and is kept for all that."""
+        self.dataset()
+
+        self.poll_capture()
+
+        announcement = NotificationMessage.objects.get(
+            data_id=SC_METADATA_NOTIFICATION
+        )
+
+        self.assertEqual(announcement.node, self.node)
+        self.assertIsNone(announcement.dataset)
+        self.assertIsNone(announcement.station)
+        self.assertEqual(announcement.metadata_id, "")
+
+    def test_a_station_seen_transmitting_is_written_down(self):
+        self.poll_capture()
+
+        self.assertEqual(Station.objects.count(), 13)
+        self.assertEqual(
+            StationSource.objects.filter(
+                source_type=StationSource.OBSERVED, node=self.node
+            ).count(),
+            13,
+        )
+
+    def test_a_polled_centre_is_not_a_silent_one(self):
+        """Which matters most for exactly these centres.
+
+        A centre reached only through its own archive is heard on no broker
+        this tool holds open, so nothing else would ever move its last-seen and
+        its silence would read as the centre having gone quiet.
+        """
+        self.poll_capture()
+
+        self.assertEqual(
+            NodeLastSeen.objects.get(node=self.node).last_message_at,
+            at("2026-08-12T15:03:46"),
+        )
+
+
+class RepeatedPollTests(ArchiveTestCase):
+    """Overlap is the point, so re-reading a window has to cost nothing."""
+
+    def test_pulling_an_overlapping_window_again_adds_no_rows(self):
+        self.poll_capture()
+        self.poll_capture()
+
+        self.assertEqual(NotificationMessage.objects.count(), 14)
+
+    def test_two_centres_archives_do_not_collide(self):
+        other = WIS2Node.objects.create(centre_id="gh-gmet", name="Ghana Met")
+        elsewhere = origin_api(other)
+
+        self.poll_capture()
+        poll_message_archive(
+            elsewhere,
+            since=SINCE,
+            until=UNTIL,
+            fetch=pages(load_json_fixture(DEEP)),
+        )
+
+        self.assertEqual(NotificationMessage.objects.filter(node=self.node).count(), 14)
+        self.assertEqual(NotificationMessage.objects.filter(node=other).count(), 10)
+
+
+class SyncLogTests(ArchiveTestCase):
+    """What the run reports, through the log every other run reports through."""
+
+    def test_a_run_is_logged_against_the_node_it_asked(self):
+        sync_log = self.poll_capture()
+
+        self.assertEqual(sync_log.node, self.node)
+        self.assertEqual(sync_log.sync_type, SyncLog.MESSAGE_ARCHIVE)
+        self.assertEqual(sync_log.status, SyncLog.SUCCESS)
+        self.assertIsNotNone(sync_log.completed_at)
+
+    def test_it_reports_what_the_archive_offered_and_what_was_stored(self):
+        sync_log = self.poll_capture()
+
+        self.assertEqual(sync_log.items_found, 14)
+        self.assertEqual(sync_log.items_created, 14)
+        self.assertEqual(sync_log.items_errored, 0)
+
+    def test_it_counts_every_page_it_read(self):
+        sync_log = self.poll(load_json_fixture(SHALLOW), load_json_fixture(DEEP))
+
+        self.assertEqual(sync_log.items_found, 24)
+        self.assertEqual(sync_log.items_created, 24)
+
+    def test_one_unusable_notification_does_not_cost_the_page_it_came_on(self):
+        payload = load_json_fixture(SHALLOW)
+        payload["features"].append({"id": "no-publication-time", "properties": {}})
+
+        sync_log = self.poll(payload)
+
+        self.assertEqual(sync_log.status, SyncLog.PARTIAL)
+        self.assertEqual(sync_log.items_found, 15)
+        self.assertEqual(sync_log.items_created, 14)
+        self.assertEqual(sync_log.items_errored, 1)
+        self.assertEqual(NotificationMessage.objects.count(), 14)
+
+
+class ReachabilityTests(ArchiveTestCase):
+    """Only a poll can settle whether a centre serves an archive at all."""
+
+    def test_a_centre_that_answers_is_recorded_as_reachable(self):
+        before = dj_timezone.now()
+
+        self.poll_capture()
+        self.source.refresh_from_db()
+
+        self.assertIs(self.source.is_reachable, True)
+        self.assertEqual(self.source.last_error, "")
+        self.assertGreaterEqual(self.source.last_connected_at, before)
+
+    def test_a_centre_with_no_archive_is_recorded_as_unreachable_with_the_reason(self):
+        """Most centres serve none: the path is a wis2box convention.
+
+        The run is a failed one and the reason is kept, but nothing raises --
+        a centre that does not answer is a finding, not an accident.
+        """
+        sync_log = poll_message_archive(
+            self.source,
+            since=SINCE,
+            until=UNTIL,
+            fetch=failing_fetch("404 Client Error: Not Found"),
+        )
+        self.source.refresh_from_db()
+
+        self.assertEqual(sync_log.status, SyncLog.FAILED)
+        self.assertIn("404", sync_log.error_message)
+        self.assertIs(self.source.is_reachable, False)
+        self.assertIn("404", self.source.last_error)
+
+    def test_a_centre_that_answers_again_stops_being_unreachable(self):
+        self.source.is_reachable = False
+        self.source.last_error = "404 Client Error: Not Found"
+        self.source.save(update_fields=["is_reachable", "last_error"])
+
+        self.poll_capture()
+        self.source.refresh_from_db()
+
+        self.assertIs(self.source.is_reachable, True)
+        self.assertEqual(self.source.last_error, "")
+
+    def test_what_a_failed_run_read_before_it_failed_is_kept(self):
+        def fetch(*args, **kwargs):
+            yield load_json_fixture(SHALLOW)
+            raise OSError("the connection dropped")
+
+        sync_log = poll_message_archive(
+            self.source, since=SINCE, until=UNTIL, fetch=fetch
+        )
+
+        self.assertEqual(sync_log.status, SyncLog.FAILED)
+        self.assertEqual(sync_log.items_found, 14)
+        self.assertEqual(NotificationMessage.objects.count(), 14)
+
+
+class FetchTests(ArchiveTestCase):
+    """What is actually asked of the centre, and how far it is followed."""
+
+    def response(self, payload):
+        return mock.Mock(
+            json=mock.Mock(return_value=payload), raise_for_status=mock.Mock()
+        )
+
+    def test_the_items_of_the_archive_are_what_is_read(self):
+        self.assertEqual(
+            archive_items_url(self.source),
+            "https://wis2.meteo.sc/oapi/collections/messages/items",
+        )
+
+    def test_a_trailing_slash_on_a_corrected_address_is_not_doubled(self):
+        self.source.api_url = "https://wis2.meteo.sc/oapi/collections/messages/"
+
+        self.assertEqual(
+            archive_items_url(self.source),
+            "https://wis2.meteo.sc/oapi/collections/messages/items",
+        )
+
+    def test_the_window_is_asked_for_as_a_closed_interval(self):
+        self.assertEqual(
+            publication_interval(SINCE, UNTIL),
+            "2026-08-12T00:00:00Z/2026-08-13T00:00:00Z",
+        )
+
+    def test_it_asks_the_centre_for_the_window_a_page_at_a_time(self):
+        with mock.patch("wis2watch.core.sync.requests.get") as get:
+            get.return_value = self.response({"features": []})
+
+            list(fetch_archive_pages(self.source, since=SINCE, until=UNTIL))
+
+        self.assertEqual(get.call_args.args[0], archive_items_url(self.source))
+        self.assertEqual(
+            get.call_args.kwargs["params"],
+            {
+                "f": "json",
+                "limit": PAGE_SIZE,
+                "datetime": publication_interval(SINCE, UNTIL),
+            },
+        )
+
+    def test_certificate_verification_follows_the_node_s_own_setting(self):
+        """As reading the same node's registry does.
+
+        A bad certificate is reported separately by link probing, which always
+        verifies, so honouring the setting here suppresses no finding -- it
+        only stops a certificate problem from also costing the origin evidence.
+        """
+        self.node.verify_ssl = False
+        self.node.save(update_fields=["verify_ssl"])
+        self.source.refresh_from_db()
+
+        with mock.patch("wis2watch.core.sync.requests.get") as get:
+            get.return_value = self.response({"features": []})
+
+            list(fetch_archive_pages(self.source, since=SINCE, until=UNTIL))
+
+        self.assertIs(get.call_args.kwargs["verify"], False)
+
+    def test_it_follows_the_next_link_the_capture_really_carries(self):
+        deep = load_json_fixture(DEEP)
+
+        with mock.patch("wis2watch.core.sync.requests.get") as get:
+            get.side_effect = [
+                self.response(deep),
+                self.response({"features": []}),
+            ]
+
+            list(fetch_archive_pages(self.source, since=SINCE, until=UNTIL))
+
+        self.assertEqual(
+            get.call_args_list[1].args[0],
+            "https://wis2.meteo.gov.gh/oapi/collections/messages/items"
+            "?offset=396&limit=10"
+            "&datetime=2026-08-09T00%3A00%3A00Z%2F2026-08-11T23%3A59%3A59Z",
+        )
+
+    def test_it_pages_far_beyond_what_a_scheduled_sync_is_given(self):
+        """A registry is a few hundred records; an archive is months of traffic."""
+        self.assertGreater(MAX_PAGES, SCHEDULED_MAX_PAGES)
+
+    def test_an_archive_that_never_stops_paging_fails_rather_than_half_reads(self):
+        forever = {
+            "features": [],
+            "links": [{"rel": "next", "href": "https://wis2.meteo.sc/on"}],
+        }
+
+        with mock.patch("wis2watch.core.sync.requests.get") as get:
+            get.return_value = self.response(forever)
+
+            sync_log = poll_message_archive(
+                self.source, since=SINCE, until=UNTIL, max_pages=3
+            )
+
+        self.assertEqual(sync_log.status, SyncLog.FAILED)
+        self.assertIn("do not terminate", sync_log.error_message)
+        self.assertEqual(get.call_count, 3)
+
+
+class WindowTests(ArchiveTestCase):
+    """The window is asked for outright, rather than resumed from a watermark."""
+
+    def test_the_interval_is_whatever_the_caller_asked_for(self):
+        since = UNTIL - timedelta(days=90)
+
+        self.assertEqual(
+            publication_interval(since, UNTIL),
+            "2026-05-15T00:00:00Z/2026-08-13T00:00:00Z",
+        )
+
+    def test_the_interval_is_stated_in_utc_whatever_it_is_given_in(self):
+        """Publication time is UTC in WIS2, and the request has to say so."""
+        elsewhere = SINCE.astimezone(dj_timezone.get_fixed_timezone(180))
+
+        self.assertEqual(
+            publication_interval(elsewhere, UNTIL),
+            "2026-08-12T00:00:00Z/2026-08-13T00:00:00Z",
+        )

--- a/wis2watch/src/wis2watch/ingest/tests/test_archive.py
+++ b/wis2watch/src/wis2watch/ingest/tests/test_archive.py
@@ -32,12 +32,13 @@ from wis2watch.core.tests.support import (
     pages,
 )
 from wis2watch.ingest.archive import (
-    MAX_PAGES,
+    MAX_ARCHIVE_PAGES,
     PAGE_SIZE,
     archive_items_url,
     fetch_archive_pages,
     poll_message_archive,
     publication_interval,
+    trailing_window,
 )
 
 SHALLOW = "node_messages_sc_seychelles_met.json"
@@ -382,7 +383,7 @@ class FetchTests(ArchiveTestCase):
 
     def test_it_pages_far_beyond_what_a_scheduled_sync_is_given(self):
         """A registry is a few hundred records; an archive is months of traffic."""
-        self.assertGreater(MAX_PAGES, SCHEDULED_MAX_PAGES)
+        self.assertGreater(MAX_ARCHIVE_PAGES, SCHEDULED_MAX_PAGES)
 
     def test_an_archive_that_never_stops_paging_fails_rather_than_half_reads(self):
         forever = {
@@ -401,6 +402,30 @@ class FetchTests(ArchiveTestCase):
         self.assertIn("do not terminate", sync_log.error_message)
         self.assertEqual(get.call_count, 3)
 
+    def test_an_archive_that_answered_too_often_is_not_called_unreachable(self):
+        """It replied to every request. The read is what failed, not the centre.
+
+        Recorded as unreachable it would send somebody looking for a network
+        fault that is not there, and would disqualify the centre from being
+        judged against the Global Broker at all.
+        """
+        forever = {
+            "features": [],
+            "links": [{"rel": "next", "href": "https://wis2.meteo.sc/on"}],
+        }
+
+        with mock.patch("wis2watch.core.sync.requests.get") as get:
+            get.return_value = self.response(forever)
+
+            poll_message_archive(
+                self.source, since=SINCE, until=UNTIL, max_pages=3
+            )
+
+        self.source.refresh_from_db()
+
+        self.assertIs(self.source.is_reachable, True)
+        self.assertEqual(self.source.last_error, "")
+
 
 class WindowTests(ArchiveTestCase):
     """The window is asked for outright, rather than resumed from a watermark."""
@@ -412,6 +437,18 @@ class WindowTests(ArchiveTestCase):
             publication_interval(since, UNTIL),
             "2026-05-15T00:00:00Z/2026-08-13T00:00:00Z",
         )
+
+    def test_a_pull_covers_whole_hourly_buckets_ending_with_this_one(self):
+        """Because what is pulled is afterwards counted into those buckets.
+
+        A window beginning mid-hour would have its first bucket recomputed from
+        a fraction of that hour's messages, and a partial count overwrites a
+        complete one with a smaller number.
+        """
+        since, until = trailing_window(6, now=at("2026-08-12T16:30:00"))
+
+        self.assertEqual(since, at("2026-08-12T11:00:00"))
+        self.assertEqual(until, at("2026-08-12T16:30:00"))
 
     def test_the_interval_is_stated_in_utc_whatever_it_is_given_in(self):
         """Publication time is UTC in WIS2, and the request has to say so."""

--- a/wis2watch/src/wis2watch/ingest/tests/test_pull_message_archive.py
+++ b/wis2watch/src/wis2watch/ingest/tests/test_pull_message_archive.py
@@ -1,0 +1,204 @@
+"""Pulling one centre's archive from the command line.
+
+The command is how a centre's own account of what it published is recovered
+after the fact -- for a node whose broker nothing can reach, or for a stretch
+this tool was not listening through. So the tests run it end to end against a
+captured archive, with only the network stood in for: what an operator needs to
+be able to trust is that the run left the rollups behind it, not that a
+function was called.
+"""
+
+from io import StringIO
+from unittest import mock
+
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.test import TestCase
+
+from wis2watch.core.models import (
+    HourlyRollup,
+    MessageSource,
+    NotificationMessage,
+    SyncLog,
+    WIS2Node,
+)
+from wis2watch.core.tests.support import at, load_json_fixture, origin_api
+from wis2watch.ingest.archive import PAGE_SIZE
+
+CAPTURE = "node_messages_sc_seychelles_met.json"
+
+#: An hour after the last notification the capture carries, so that a shallow
+#: pull covers it and the assertions do not depend on the day they are run.
+NOW = at("2026-08-12T16:30:00")
+
+
+class PullMessageArchiveTestCase(TestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.node = WIS2Node.objects.create(
+            centre_id="sc-seychelles-met",
+            name="Seychelles Meteorological Authority",
+            base_url="https://wis2.meteo.sc",
+        )
+        self.source = origin_api(self.node)
+
+    def run_command(self, *args, payload=None, **options):
+        """Run the command against a captured page, with the clock held still."""
+        answer = mock.Mock(
+            json=mock.Mock(return_value=payload or load_json_fixture(CAPTURE)),
+            raise_for_status=mock.Mock(),
+        )
+        out, err = StringIO(), StringIO()
+
+        with mock.patch("wis2watch.ingest.archive.dj_timezone.now", return_value=NOW):
+            with mock.patch("wis2watch.core.sync.requests.get", return_value=answer):
+                call_command(
+                    "pull_message_archive", *args, stdout=out, stderr=err, **options
+                )
+
+        return out.getvalue() + err.getvalue()
+
+
+class PullTests(PullMessageArchiveTestCase):
+    """What the run leaves behind it."""
+
+    def test_it_stores_the_named_centre_s_notifications_as_origin_evidence(self):
+        self.run_command("sc-seychelles-met", hours=2)
+
+        stored = NotificationMessage.objects.filter(node=self.node)
+
+        self.assertEqual(stored.count(), 14)
+        self.assertEqual(stored.exclude(source=self.source).count(), 0)
+        self.assertEqual(set(stored.values_list("topic", flat=True)), {""})
+
+    def test_it_asks_the_archive_for_the_depth_it_was_given(self):
+        with mock.patch("wis2watch.ingest.archive.fetch_archive_pages") as fetch:
+            fetch.return_value = iter([load_json_fixture(CAPTURE)])
+
+            with mock.patch(
+                "wis2watch.ingest.archive.dj_timezone.now", return_value=NOW
+            ):
+                call_command(
+                    "pull_message_archive",
+                    "sc-seychelles-met",
+                    hours=6,
+                    stdout=StringIO(),
+                )
+
+        self.assertEqual(fetch.call_args.kwargs["since"], at("2026-08-12T11:00:00"))
+        self.assertEqual(fetch.call_args.kwargs["until"], NOW)
+
+    def test_it_pages_beyond_the_bound_a_scheduled_sync_is_given(self):
+        """A scheduled sync reads a registry; this reads months of traffic."""
+        with mock.patch("wis2watch.ingest.archive.fetch_pages") as fetch_pages:
+            fetch_pages.return_value = iter([load_json_fixture(CAPTURE)])
+
+            self.run_command("sc-seychelles-met", hours=2)
+
+        self.assertEqual(fetch_pages.call_args.kwargs["max_pages"], 2000)
+        self.assertEqual(fetch_pages.call_args.kwargs["params"]["limit"], PAGE_SIZE)
+
+    def test_it_reports_what_it_fetched_through_the_usual_sync_log(self):
+        output = self.run_command("sc-seychelles-met", hours=2)
+
+        sync_log = SyncLog.objects.get(sync_type=SyncLog.MESSAGE_ARCHIVE)
+
+        self.assertEqual(sync_log.node, self.node)
+        self.assertEqual(sync_log.status, SyncLog.SUCCESS)
+        self.assertEqual(sync_log.items_found, 14)
+        self.assertIn("sc-seychelles-met", output)
+        self.assertIn("found=14", output)
+
+
+class RollupTests(PullMessageArchiveTestCase):
+    """The pulled range is counted before the run is over.
+
+    Without this the scheduled rollup only recomputes the last two days, and
+    everything older materialises a fortnight later as a side effect of the
+    expiry job -- correct by coincidence rather than by design.
+    """
+
+    def test_the_hours_that_were_pulled_are_rolled_up(self):
+        self.run_command("sc-seychelles-met", hours=2)
+
+        rollups = HourlyRollup.objects.filter(node=self.node)
+
+        # One row per station the hour carried, and one for the metadata
+        # notification, which names none.
+        self.assertEqual(rollups.count(), 14)
+        self.assertEqual(
+            set(rollups.values_list("hour", flat=True)),
+            {NOW.replace(hour=15, minute=0)},
+        )
+        self.assertEqual(sum(rollups.values_list("message_count", flat=True)), 14)
+
+    def test_a_pull_reaching_back_past_the_scheduled_window_is_counted_too(self):
+        """The whole depth asked for, not the trailing two days of it."""
+        self.run_command("sc-seychelles-met", hours=24 * 60)
+
+        self.assertEqual(HourlyRollup.objects.filter(node=self.node).count(), 14)
+
+    def test_a_second_pull_of_the_same_window_does_not_double_the_counts(self):
+        self.run_command("sc-seychelles-met", hours=2)
+        self.run_command("sc-seychelles-met", hours=2)
+
+        self.assertEqual(
+            sum(
+                HourlyRollup.objects.filter(node=self.node).values_list(
+                    "message_count", flat=True
+                )
+            ),
+            14,
+        )
+
+
+class RefusalTests(PullMessageArchiveTestCase):
+    """What the command will not guess at."""
+
+    def test_a_centre_nobody_has_registered_is_refused(self):
+        with self.assertRaisesMessage(CommandError, "xx-nowhere"):
+            call_command("pull_message_archive", "xx-nowhere", stdout=StringIO())
+
+    def test_a_centre_with_no_known_archive_is_refused(self):
+        MessageSource.objects.filter(pk=self.source.pk).delete()
+
+        with self.assertRaisesMessage(CommandError, "no message archive"):
+            call_command(
+                "pull_message_archive", "sc-seychelles-met", stdout=StringIO()
+            )
+
+    def test_a_depth_of_no_hours_is_refused(self):
+        with self.assertRaisesMessage(CommandError, "at least one hour"):
+            call_command(
+                "pull_message_archive", "sc-seychelles-met", hours=0, stdout=StringIO()
+            )
+
+
+class UnreachableTests(PullMessageArchiveTestCase):
+    """A centre serving no archive is a finding, not a broken run."""
+
+    def test_a_centre_that_does_not_answer_is_reported_rather_than_raised(self):
+        answer = mock.Mock()
+        answer.raise_for_status.side_effect = OSError("404 Client Error: Not Found")
+
+        with mock.patch("wis2watch.ingest.archive.dj_timezone.now", return_value=NOW):
+            with mock.patch("wis2watch.core.sync.requests.get", return_value=answer):
+                out, err = StringIO(), StringIO()
+                call_command(
+                    "pull_message_archive",
+                    "sc-seychelles-met",
+                    hours=2,
+                    stdout=out,
+                    stderr=err,
+                )
+
+        self.source.refresh_from_db()
+
+        self.assertIs(self.source.is_reachable, False)
+        self.assertIn("404", self.source.last_error)
+        self.assertIn("404", out.getvalue() + err.getvalue())
+        self.assertEqual(
+            SyncLog.objects.get(sync_type=SyncLog.MESSAGE_ARCHIVE).status,
+            SyncLog.FAILED,
+        )

--- a/wis2watch/src/wis2watch/ingest/tests/test_store.py
+++ b/wis2watch/src/wis2watch/ingest/tests/test_store.py
@@ -779,3 +779,45 @@ class LastSeenTests(StoreTestCase):
         store_notifications(self.source, [(KE_TOPIC, {"id": None})])
 
         self.assertEqual(NodeLastSeen.objects.count(), 0)
+
+
+class KnownNodeTests(StoreTestCase):
+    """Whose traffic a flush is, when the caller already knows.
+
+    A poll of a centre's own archive fetches messages that carry no topic, so
+    the answer the broker path reads off one has to come from the request. What
+    the store must not do with that answer is let it stand in for a topic that
+    is there.
+    """
+
+    def test_a_message_with_no_topic_is_attributed_to_the_node_that_was_asked(self):
+        payload = message_on(KE_TOPIC)["payload"]
+
+        store_notifications(self.source, [("", payload)], node=self.node)
+
+        record = NotificationMessage.objects.get()
+
+        self.assertEqual(record.node, self.node)
+        self.assertEqual(record.topic, "")
+
+    def test_a_message_that_names_its_own_centre_is_attributed_by_the_topic(self):
+        """The topic is what was observed, and observation wins."""
+        other = WIS2Node.objects.create(centre_id="dj-anm", name="Djibouti Met")
+        message = message_on(KE_TOPIC)
+
+        store_notifications(
+            self.source, [(message["topic"], message["payload"])], node=other
+        )
+
+        self.assertEqual(NotificationMessage.objects.get().node, self.node)
+
+    def test_another_region_s_traffic_is_still_refused(self):
+        """Knowing whose flush this is licenses nothing about what it carries."""
+        message = message_on(BR_TOPIC)
+
+        counts = store_notifications(
+            self.source, [(message["topic"], message["payload"])], node=self.node
+        )
+
+        self.assertEqual(counts.out_of_region, 1)
+        self.assertEqual(NotificationMessage.objects.count(), 0)


### PR DESCRIPTION
Closes #54

A centre's own archive of its notifications becomes something this tool can read. `pull_message_archive <centre-id> [--hours N]` pulls one node over a chosen depth, stores what comes back as origin evidence, and rebuilds the hourly rollups across what it pulled.

## The decisions worth arguing with

**There is no topic.** The archive returns the notification itself, envelope and all, but nothing saying what topic it went out on. So every attribution the broker path reads off a topic comes from elsewhere: the centre because the poll chose the address, the vantage point because the archive is one, the dataset from the metadata identifier the message carries. The stored topic stays empty. Synthesising the dataset's declared topic would read better and would destroy the evidence for a centre transmitting data no dataset of its own claims — a message no topic would ever have named.

**The whole collection, not one dataset of it.** Filtering by dataset can only ever return the datasets already known, and a message whose metadata identifier names no registered dataset is the strongest witness available for `transmitting-undeclared`. Metadata notifications come back mixed in and are stored, as the MQTT path stores them.

**A fixed trailing window, asked for outright each time.** Publication time is the publisher's own claim, so a message stamped behind a watermark would be dropped permanently. Overlap absorbs stamp skew, and re-reading is free — a notification already held is absorbed by the per-source uniqueness constraint.

**Written through the existing store path**, so a polled node still moves its last-seen forward — which matters most for exactly these nodes, whose broker silence would otherwise read as the centre having gone quiet — still records the stations it observed transmitting, and still tolerates one malformed notification without losing the batch.

Certificate verification follows the node's own setting, as reading its registry does. Paging gets a ceiling of its own: the one sized for registries of a few hundred records would report every deep pull as a half-read failure.

## A defect this turned up, and fixed

A deep pull backdated the floor the silence report measures a never-seen dataset against — that floor was the earliest hour *any* rollup covered, so pulling one centre back to May would have reported datasets at every other centre, whose archive nobody asked for, quiet for months nobody was watching. It is the hazard #52 taught the propagation evaluation to refuse, arriving in a report nothing had checked. The floor now counts only vantage points this tool listens to live; the pulled centre loses nothing, since the floor is only ever reached for a dataset never seen at all.

Also: an archive whose paging never terminates is no longer recorded as unreachable. It answered every request — the read is what failed, and calling it unreachable would send somebody after a network fault that is not there.

## Fixtures

Two unedited live pages, captured 2026-08-13, each carrying a metadata notification:

| Capture | Retention at capture | Match count |
| --- | --- | --- |
| `node_messages_sc_seychelles_met.json` | 451 messages, ~36 hours | 14 matched, 14 returned, one page |
| `node_messages_gh_gmet.json` | 57,170 messages, back to 2026-05-06 | 1,757 matched, 10 returned, live `next` link |

Two things the captures settled, both written up in the fixtures README: the `datetime` parameter matches `pubtime` rather than the observation time, and a page is **not** in publication order — anything reading the first or last row as the edge of the window would be wrong on this very capture.

## Verification

Beyond the offline tests, the real command was run against Seychelles' live archive in a throwaway database: 78 notifications pulled, every one with an empty topic and attributed, 78 rollup rows, and a second run over the same window added nothing. A node whose archive does not answer was recorded unreachable with the reason, and the run finished.

1002 tests pass.

## Two judgement calls, flagged for review

- The paging bound is a module constant rather than a `--max-pages` flag. The AC asks that the command page beyond the scheduled bound, which it does; a flag looked like surface area nobody asked for.
- A node with no archive *registered* raises rather than being recorded unreachable — there is no source row to record it on. A node whose registered archive 404s is recorded unreachable, as asked.