### PR TITLE
Watch the centres whose broker will not answer

### DIFF
--- a/wis2watch/src/wis2watch/config/settings/base.py
+++ b/wis2watch/src/wis2watch/config/settings/base.py
@@ -467,7 +467,10 @@ VUE_FRONTEND_STATIC_PATH = 'vue'
 
 # Scheduled work is sync, rollup, cleanup and mail only. Broker connections are
 # stateful and long-lived, and belong to the ingestion supervisor rather than to
-# a task queue -- see wis2watch.ingest.supervisor.
+# a task queue -- see wis2watch.ingest.supervisor. Reading a centre's own
+# archive is scheduled work for exactly that reason: it is an HTTP fetch with
+# nothing to hold open, and it is how a centre whose broker the supervisor
+# cannot dial is heard at all.
 CELERY_BEAT_SCHEDULE = {
     'sync-catalogues': {
         'task': 'wis2watch.core.tasks.run_sync_catalogues',
@@ -476,6 +479,14 @@ CELERY_BEAT_SCHEDULE = {
     'sync-node-stations': {
         'task': 'wis2watch.core.tasks.run_sync_all_node_stations',
         'schedule': 3600.0,  # Every hour
+    },
+    # Hourly, and only for the centres whose own broker will not answer -- see
+    # wis2watch.ingest.tasks for why an hour is soon enough and why the centres
+    # that can be heard live are left alone. Off the hour, so the region's
+    # archives are not asked in the same minute as its station registries.
+    'poll-message-archives': {
+        'task': 'wis2watch.ingest.tasks.run_poll_all_message_archives',
+        'schedule': crontab(minute=20),
     },
     # OSCAR changes slowly: a country's declared set moves in months, and the
     # whole monitored region is read territory by territory in one run.

--- a/wis2watch/src/wis2watch/core/models.py
+++ b/wis2watch/src/wis2watch/core/models.py
@@ -271,6 +271,53 @@ class MessageSourceQuerySet(models.QuerySet):
         """
         return self.origin_vantages().filter(is_reachable=True)
 
+    def archives_to_poll(self):
+        """The centres' own archives worth asking on a schedule.
+
+        The ones whose own broker will not answer, which are the shakiest
+        centres in the region and the ones most worth watching. Until something
+        polls them they have no origin witness at all, and the comparison this
+        tool exists to make cannot be made for them.
+
+        Confirmed reachable is the only thing that keeps a centre out. A broker
+        never attempted is null rather than fine; a broker switched off carries
+        an answer that has since gone stale; and a centre with no broker
+        registered has never been heard from at all. None of those three can be
+        judged on propagation until its archive is asked, which is precisely
+        what makes them worth asking.
+
+        A centre whose broker does answer is left alone. Its archive and its
+        broker are the same witness -- the same notifications published by the
+        same centre -- so polling it would buy a second copy of what is already
+        held rather than any further evidence. The cost of that is accepted
+        deliberately: a healthy centre gets no protection from this tool's own
+        downtime, and recovering such a window is the management command's job
+        rather than the schedule's.
+
+        An archive with no address is not asked either. Where a centre serves
+        its notifications is inferred rather than advertised, so a poll of one
+        this tool has nowhere to ask would record the centre as unreachable
+        over a hole in our own registry.
+
+        The broker is looked for through the manager rather than through
+        ``self``, because what it asks is a different question of the same
+        table: whichever archives this queryset has been narrowed to, the
+        broker that speaks for one of their centres is not among them.
+        """
+        broker_that_answers = MessageSource.objects.filter(
+            node_id=models.OuterRef("node_id"),
+            source_type=MessageSource.ORIGIN_BROKER,
+            is_active=True,
+            is_reachable=True,
+        )
+
+        return (
+            self.origin_vantages()
+            .filter(source_type=MessageSource.ORIGIN_API)
+            .exclude(api_url="")
+            .exclude(models.Exists(broker_that_answers))
+        )
+
 
 class MessageSource(TimeStampedModel):
     """

--- a/wis2watch/src/wis2watch/core/tests/test_models.py
+++ b/wis2watch/src/wis2watch/core/tests/test_models.py
@@ -13,7 +13,7 @@ from wis2watch.core.models import (
     SyncLog,
     WIS2Node,
 )
-from wis2watch.core.tests.support import origin_api
+from wis2watch.core.tests.support import origin_api, origin_broker
 
 
 def make_node(centre_id="ke-kmd", **kwargs):
@@ -223,6 +223,80 @@ class OriginVantageQuerySetTests(TestCase):
         self.assertEqual(
             {source.pk for source in MessageSource.objects.dialled()},
             {self.broker.pk},
+        )
+
+
+class ArchivesToPollTests(TestCase):
+    """Which centres are asked for their own notifications on a schedule.
+
+    The choosing is the whole of it, and it goes wrong in two directions. A
+    centre left out has no origin witness at all, so nothing this tool exists
+    to say about it can be said. A centre asked needlessly is a second copy of
+    traffic already held, fetched off a small national server every hour.
+    """
+
+    def setUp(self):
+        self.node = make_node("ke-kmd")
+        self.archive = origin_api(self.node)
+
+    def polled(self):
+        return [source.pk for source in MessageSource.objects.archives_to_poll()]
+
+    def test_a_centre_whose_broker_has_never_been_dialled_is_polled(self):
+        """Null is unprobed rather than fine, and unprobed cannot be judged."""
+        origin_broker(self.node)
+
+        self.assertEqual(self.polled(), [self.archive.pk])
+
+    def test_a_centre_whose_broker_will_not_answer_is_polled(self):
+        origin_broker(self.node, is_reachable=False)
+
+        self.assertEqual(self.polled(), [self.archive.pk])
+
+    def test_a_centre_with_no_broker_registered_at_all_is_polled(self):
+        self.assertEqual(self.polled(), [self.archive.pk])
+
+    def test_a_centre_whose_broker_answers_is_left_alone(self):
+        """The archive and the broker are the same witness."""
+        origin_broker(self.node, is_reachable=True)
+
+        self.assertEqual(self.polled(), [])
+
+    def test_a_broker_switched_off_is_not_an_answer(self):
+        """Nothing dials it any more, so what it last said has gone stale --
+        and propagation will not judge the centre on it either."""
+        origin_broker(self.node, is_reachable=True, is_active=False)
+
+        self.assertEqual(self.polled(), [self.archive.pk])
+
+    def test_an_archive_switched_off_is_not_polled(self):
+        self.archive.is_active = False
+        self.archive.save()
+
+        self.assertEqual(self.polled(), [])
+
+    def test_an_archive_with_no_address_is_not_polled(self):
+        """A poll with nowhere to ask would record the centre unreachable over
+        a hole in this tool's own registry."""
+        self.archive.api_url = ""
+        self.archive.save()
+
+        self.assertEqual(self.polled(), [])
+
+    def test_a_broker_that_answers_speaks_only_for_its_own_centre(self):
+        elsewhere = make_node("gh-gmet")
+        origin_api(elsewhere)
+        origin_broker(elsewhere, is_reachable=True)
+
+        self.assertEqual(self.polled(), [self.archive.pk])
+
+    def test_a_broker_is_not_polled_in_place_of_an_archive(self):
+        """There is nothing to fetch at a broker over HTTP."""
+        origin_broker(self.node, is_reachable=False)
+
+        self.assertEqual(
+            {source.source_type for source in MessageSource.objects.archives_to_poll()},
+            {MessageSource.ORIGIN_API},
         )
 
 

--- a/wis2watch/src/wis2watch/core/tests/test_propagation.py
+++ b/wis2watch/src/wis2watch/core/tests/test_propagation.py
@@ -424,6 +424,25 @@ class SuppressionTests(PropagationTestCase):
         self.assertEqual(counts.nodes_evaluated, 1)
         self.assertEqual(counts.nodes_suppressed, 0)
 
+    def test_a_centre_heard_only_through_its_own_archive_is_judged(self):
+        """Which is what polling those archives is for.
+
+        A centre whose broker nothing outside can reach had no origin witness
+        at all until something asked its archive, so this comparison could not
+        be made for it -- and those are the shakiest centres in the region.
+        """
+        archive = origin_api(self.kenya, is_reachable=True)
+        self.kenya_origin.is_reachable = False
+        self.kenya_origin.save()
+
+        self.observe(archive, "published-and-never-carried", node=self.kenya)
+
+        counts = self.evaluate()
+
+        self.assertEqual(self.missing(), ["published-and-never-carried"])
+        self.assertEqual(counts.nodes_evaluated, 1)
+        self.assertEqual(counts.nodes_suppressed, 0)
+
     def test_what_the_connection_record_says_now_does_not_unjudge_past_hours(self):
         """Blindness is read off the traffic, not off a side record.
 

--- a/wis2watch/src/wis2watch/ingest/tasks.py
+++ b/wis2watch/src/wis2watch/ingest/tasks.py
@@ -1,0 +1,103 @@
+"""Asking, on a schedule, the centres whose own broker will not answer.
+
+Propagation refuses to judge a centre whose origin broker is unreachable,
+because it cannot tell what it did not see from what was never published. That
+is a great many of the centres in this region, and their archive is reachable
+over HTTPS where their broker is not -- so this is what gives them an origin
+witness, and with it the comparison this tool exists to make.
+
+Three things about the schedule are decisions rather than mechanics.
+
+**Hourly, rather than oftener.** The window each poll asks for covers several
+hours, so every message is fetched several times over and a shorter beat would
+buy redundancy rather than coverage. These are small national met service
+servers rather than CDNs. And the finding is read in a daily digest and acted
+on by writing to a national met service, so an hour of detection latency
+changes nothing.
+
+**One task per centre, rather than one run over the region.** Each poll is a
+sequence of HTTP requests against a different centre, and the centres this
+path exists for are exactly the ones whose servers are slow or hang. Fanning
+out keeps one of them from holding up everybody else's poll -- and the per
+centre task is a singleton on its own arguments, so a poll that outlasts the
+hour does not have the next one stacked on top of it.
+
+**Nothing is rolled up here.** The scheduled rollup recomputes a window far
+wider than a poll's, so an hour polled is counted within the quarter hour. A
+pull reaching deeper than that window is the management command's, and rebuilds
+its own hours before it returns.
+"""
+
+from celery import shared_task
+from celery.utils.log import get_task_logger
+from celery_singleton import Singleton
+
+from wis2watch.config.celery import app
+
+from ..core.models import MessageSource
+from .archive import poll_message_archive, trailing_window
+
+logger = get_task_logger(__name__)
+
+#: How deep a scheduled poll asks, in hours. Publication time is the
+#: publisher's own claim, and overlap is the only thing that absorbs a clock
+#: running behind: on an hourly beat this asks for each message six times over
+#: before it falls out of the window. Well inside the rollup window too, so
+#: what a poll stores is counted by the next scheduled rollup rather than
+#: waiting for a rebuild.
+POLL_HOURS = 6
+
+#: How long one centre's poll may hold its place before the lock is assumed
+#: dead, in seconds. A lock is given up when the run ends however it ends, so
+#: this is only reached by a worker killed mid-poll -- and without an expiry
+#: that centre would never be polled again, silently, which is a far worse
+#: failure than the stacking the lock prevents. Long enough that no poll still
+#: making progress trips it: a six-hour window of a small centre's traffic is
+#: a few requests, each bounded by the fetch timeout.
+LOCK_EXPIRY_SECONDS = 3 * 3600
+
+
+@app.task(base=Singleton, lock_expiry=LOCK_EXPIRY_SECONDS)
+def run_poll_message_archive(source_id):
+    """Ask one centre for the notifications it says it published.
+
+    A singleton on its own arguments, which is what keeps polls of one centre
+    from stacking: an archive that takes longer to read than the beat would
+    otherwise have a second read of the same window queued behind it every
+    hour, each of them re-fetching what the last was still fetching.
+
+    Failures are diagnostic state rather than task failures. A centre that
+    cannot be read is recorded as unreachable on its own vantage point and in
+    its own sync log -- which is the finding, not an error -- and the next hour
+    asks again. Retrying here would only duplicate the schedule.
+    """
+    source = MessageSource.objects.get(id=source_id)
+    since, until = trailing_window(POLL_HOURS)
+
+    sync_log = poll_message_archive(source, since=since, until=until)
+
+    logger.info(
+        "[ARCHIVE POLL] %s: %s", source.owning_centre_id, sync_log.summary
+    )
+
+    return sync_log.id
+
+
+@shared_task
+def run_poll_all_message_archives():
+    """Queue an archive poll for every centre nothing else can hear.
+
+    Which centres those are is the model's answer rather than this module's:
+    the same reachability that decides whether a centre may be judged on
+    propagation decides whether its archive is worth asking.
+    """
+    source_ids = list(
+        MessageSource.objects.archives_to_poll().values_list("id", flat=True)
+    )
+
+    logger.info("[ARCHIVE POLL] queueing %s centres", len(source_ids))
+
+    for source_id in source_ids:
+        run_poll_message_archive.delay(source_id)
+
+    return source_ids

--- a/wis2watch/src/wis2watch/ingest/tests/test_tasks.py
+++ b/wis2watch/src/wis2watch/ingest/tests/test_tasks.py
@@ -1,0 +1,270 @@
+"""The hourly poll of the centres whose own broker will not answer.
+
+Only the schedule's own decisions are here: which centres a run asks, how deep
+it asks them, and that one centre's poll is a run of its own. What a poll makes
+of what comes back -- the attribution, the reachability, the counts -- is
+asserted against the captured archives in ``test_archive``.
+
+Both halves of the choosing are worth guarding. A centre wrongly left out has
+no origin witness at all, and is precisely the centre this path exists for; a
+centre wrongly asked is a second copy of traffic already held, fetched off a
+small national server every hour for ever.
+"""
+
+from unittest import mock
+
+from celery.schedules import crontab
+from celery_singleton import Singleton
+from django.conf import settings
+from django.test import SimpleTestCase, TestCase
+
+from wis2watch.core.models import MessageSource, SyncLog, WIS2Node
+from wis2watch.core.rollups import window_start
+from wis2watch.core.tests.support import failing_fetch, origin_api, origin_broker, pages
+from wis2watch.ingest.tasks import (
+    LOCK_EXPIRY_SECONDS,
+    POLL_HOURS,
+    run_poll_all_message_archives,
+    run_poll_message_archive,
+)
+
+#: An archive that answered and had nothing to offer for the window. Answering
+#: is all these cases need of it.
+EMPTY_PAGE = {"type": "FeatureCollection", "features": [], "links": []}
+
+#: The poll a centre's lock is being held by, where a case is about what
+#: happens to a second one.
+POLL_ALREADY_RUNNING = "the-poll-already-running"
+
+
+class ScheduleTests(SimpleTestCase):
+    """That the beat actually reaches the fan-out.
+
+    A schedule naming a task that does not exist is the one failure here that
+    announces itself nowhere: nothing runs, nothing is logged, and the centres
+    this path exists for go on having no origin witness.
+    """
+
+    def setUp(self):
+        self.entry = settings.CELERY_BEAT_SCHEDULE["poll-message-archives"]
+
+    def test_the_scheduled_task_is_the_one_that_answers_to_that_name(self):
+        self.assertEqual(self.entry["task"], run_poll_all_message_archives.name)
+
+    def test_it_runs_once_an_hour(self):
+        """Each poll asks for a window several hours deep, so a shorter beat
+        would re-fetch rather than reach any further."""
+        self.assertEqual(self.entry["schedule"], crontab(minute=20))
+
+
+class PollFanOutTests(TestCase):
+    """That an hourly run asks the centres, one run each.
+
+    Which centres those are is the queryset's question and is asserted case by
+    case where the queryset lives; what is here is that a run asks the ones it
+    answers with, and asks each of them separately.
+    """
+
+    def setUp(self):
+        self.kenya = WIS2Node.objects.create(centre_id="ke-meteo", name="Kenya Met")
+        self.archive = origin_api(self.kenya)
+        self.broker = origin_broker(self.kenya, is_reachable=False)
+
+    def queued(self):
+        with mock.patch(
+            "wis2watch.ingest.tasks.run_poll_message_archive.delay"
+        ) as delay:
+            source_ids = run_poll_all_message_archives()
+
+        self.delay = delay
+
+        return source_ids
+
+    def test_a_centre_whose_broker_will_not_answer_is_asked(self):
+        self.assertEqual(self.queued(), [self.archive.id])
+
+    def test_a_centre_whose_broker_answers_is_not_asked(self):
+        """Its archive carries the same notifications the broker already
+        delivered, so a poll would buy storage rather than evidence -- and a
+        region whose brokers all answer is a run that queues nothing."""
+        self.broker.is_reachable = True
+        self.broker.save()
+
+        self.assertEqual(self.queued(), [])
+        self.assertEqual(self.delay.call_count, 0)
+
+    def test_every_centre_asked_is_a_run_of_its_own(self):
+        """Which is what keeps one hanging centre from costing the region its
+        hour: the centres this path exists for are the ones whose servers are
+        slow or never answer, and a single run over all of them would be held
+        up by the first."""
+        djibouti = WIS2Node.objects.create(centre_id="dj-anm", name="Djibouti ANM")
+        elsewhere = origin_api(djibouti)
+
+        self.assertEqual(set(self.queued()), {self.archive.id, elsewhere.id})
+        self.assertEqual(
+            {call.args for call in self.delay.call_args_list},
+            {(self.archive.id,), (elsewhere.id,)},
+        )
+
+    def test_a_region_whose_brokers_all_answer_queues_nothing(self):
+        self.broker.is_reachable = True
+        self.broker.save()
+
+        self.assertEqual(self.queued(), [])
+        self.assertEqual(self.delay.call_count, 0)
+
+
+class PollRunTests(TestCase):
+    """What one centre's scheduled poll asks for, and what it writes down."""
+
+    def setUp(self):
+        self.node = WIS2Node.objects.create(
+            centre_id="sc-seychelles-met",
+            name="Seychelles Meteorological Authority",
+            base_url="https://wis2.meteo.sc",
+        )
+        self.archive = origin_api(self.node)
+        origin_broker(self.node, is_reachable=False)
+
+    def poll(self, fetch=None):
+        with mock.patch(
+            "wis2watch.ingest.archive.fetch_archive_pages",
+            fetch or pages(EMPTY_PAGE),
+        ):
+            return run_poll_message_archive(self.archive.id)
+
+    def test_a_run_is_written_down_in_the_usual_sync_log(self):
+        sync_log = SyncLog.objects.get(id=self.poll())
+
+        self.assertEqual(sync_log.node, self.node)
+        self.assertEqual(sync_log.sync_type, SyncLog.MESSAGE_ARCHIVE)
+        self.assertEqual(sync_log.status, SyncLog.SUCCESS)
+
+    def test_a_centre_that_answers_is_recorded_as_reachable(self):
+        """A successful poll is itself the probe: nothing else asks this
+        vantage point whether it is there."""
+        self.poll()
+        self.archive.refresh_from_db()
+
+        self.assertIs(self.archive.is_reachable, True)
+        self.assertIsNotNone(self.archive.last_connected_at)
+
+    def test_a_centre_with_no_archive_is_recorded_and_does_not_fail_the_run(self):
+        """Most centres serve none, and that is a fact worth holding rather
+        than an accident to raise about."""
+        sync_log = SyncLog.objects.get(
+            id=self.poll(failing_fetch("404 Client Error: Not Found"))
+        )
+        self.archive.refresh_from_db()
+
+        self.assertEqual(sync_log.status, SyncLog.FAILED)
+        self.assertIs(self.archive.is_reachable, False)
+        self.assertIn("404", self.archive.last_error)
+
+    def test_the_window_asked_for_is_the_scheduled_depth(self):
+        asked = {}
+
+        def fetch(source, *, since, until, max_pages):
+            asked.update(since=since, until=until)
+
+            yield EMPTY_PAGE
+
+        self.poll(fetch)
+
+        # Whole hourly buckets, because what is asked for is afterwards counted
+        # into them: a window beginning mid-hour would have its first bucket
+        # recomputed from a fraction of that hour's messages.
+        self.assertEqual(asked["since"], window_start(asked["until"], POLL_HOURS))
+
+    def test_a_poll_of_a_centre_already_being_polled_is_not_queued(self):
+        """An archive slower to read than the beat would otherwise have the
+        next hour's read of the same window queued behind it, and the one
+        after that behind them both."""
+        self.assertIsInstance(run_poll_message_archive, Singleton)
+        self.assertEqual(self.dispatch(self.archive.id).id, POLL_ALREADY_RUNNING)
+
+    def test_one_centre_being_polled_does_not_hold_up_another(self):
+        """The lock is a centre's own, which is the whole of what it is for."""
+        self.assertNotEqual(*(self.lock_for(source_id) for source_id in (1, 2)))
+
+    def lock_for(self, source_id):
+        return run_poll_message_archive.generate_lock(
+            run_poll_message_archive.name, [source_id]
+        )
+
+    def dispatch(self, source_id):
+        """Queue a poll while its centre's lock is held by a run already going.
+
+        The lock is taken through the backend celery-singleton keeps it in, so
+        this exercises the refusal itself rather than the attributes that
+        configure it.
+        """
+        held = mock.Mock(
+            lock=mock.Mock(return_value=False),
+            get=mock.Mock(return_value=POLL_ALREADY_RUNNING),
+        )
+
+        run_poll_message_archive._singleton_backend = held
+        self.addCleanup(setattr, run_poll_message_archive, "_singleton_backend", None)
+
+        return run_poll_message_archive.delay(source_id)
+
+    def test_a_lock_outlives_no_worker_that_held_it(self):
+        """A lock left behind by a killed worker would retire that centre from
+        the schedule for good, and say nothing about having done so."""
+        self.assertEqual(run_poll_message_archive.lock_expiry, LOCK_EXPIRY_SECONDS)
+
+    def test_a_centre_asked_this_hour_may_be_asked_again_next_hour(self):
+        """The lock is a singleton on the run, not a record that it happened:
+        the window is asked for outright each time, and re-reading it is what
+        absorbs a publisher's clock skew."""
+        self.poll()
+        self.poll()
+
+        self.assertEqual(
+            SyncLog.objects.filter(sync_type=SyncLog.MESSAGE_ARCHIVE).count(), 2
+        )
+
+
+class PollSelectionAfterAnswerTests(TestCase):
+    """What a poll's own answer does to the next hour's run: nothing.
+
+    Which centres are asked is a question about their brokers, and a poll says
+    nothing about a broker. The two halves are written in different modules --
+    the poll records its answer, the fan-out chooses without reading it -- so
+    that they agree is asserted here rather than assumed at both ends.
+    """
+
+    def setUp(self):
+        self.node = WIS2Node.objects.create(centre_id="ke-meteo", name="Kenya Met")
+        self.archive = origin_api(self.node)
+        origin_broker(self.node, is_reachable=False)
+
+    def poll(self, fetch):
+        with mock.patch("wis2watch.ingest.archive.fetch_archive_pages", fetch):
+            run_poll_message_archive(self.archive.id)
+
+    def asked_next(self):
+        return [source.id for source in MessageSource.objects.archives_to_poll()]
+
+    def test_a_centre_that_answered_is_still_asked_the_next_hour(self):
+        """Its broker has not come back, so it is still the only witness."""
+        self.poll(pages(EMPTY_PAGE))
+
+        self.assertEqual(self.asked_next(), [self.archive.id])
+
+    def test_a_centre_that_serves_no_archive_is_still_asked_the_next_hour(self):
+        """A 404 is written down as what this centre is rather than acted on.
+
+        Serving an archive is a wis2box convention, so a centre may begin to
+        one release later, and where it serves it is a guess an operator can
+        correct in the admin at any time. Retiring a centre from the schedule
+        on one 404 would mean neither was ever noticed -- and there is nothing
+        else asking this vantage point whether it is there.
+        """
+        self.poll(failing_fetch("404 Client Error: Not Found"))
+        self.archive.refresh_from_db()
+
+        self.assertIs(self.archive.is_reachable, False)
+        self.assertEqual(self.asked_next(), [self.archive.id])


### PR DESCRIPTION
Closes #55.

The centres nothing outside can dial are now asked, every hour, for the notifications they say they published. Propagation refuses to judge a centre whose own broker is unreachable, because it cannot tell what it did not see from what was never published — so until something polled them, the shakiest centres in the region were precisely the ones this tool could say nothing about. Their archive answers over HTTPS where their broker does not, and a poll of it is the origin witness that makes the comparison possible.

## What it does

- **`MessageSource.objects.archives_to_poll()`** — which centres are asked is the model's answer rather than the schedule's, because it is the same reachability that decides whether a centre may be judged at all. Confirmed reachable is the only thing that keeps a centre out: a broker never attempted is null rather than fine, a broker switched off carries an answer that has gone stale, and a centre with no broker registered has never been heard from. A centre whose broker does answer is left alone, since its archive and its broker are the same witness and a second copy is storage rather than evidence.
- **`wis2watch.ingest.tasks`** — `run_poll_all_message_archives` queues `run_poll_message_archive` once per centre, because the centres this path exists for are the ones whose servers hang and a single run over the region would be held up by the first of them. Each is a singleton on its own arguments, so a poll outlasting the beat does not have the next hour's read of the same window stacked behind it — with an expiry on the lock, since one left behind by a killed worker would retire that centre from the schedule for good and say nothing about having done so.
- **Beat entry `poll-message-archives`**, hourly and off the hour. Each poll asks for a six-hour window, so a shorter beat would fetch the same messages again rather than reach any further; these are small national met service servers; and the finding is read in a daily digest, so an hour of detection latency changes nothing. The window sits well inside the rollup window, so what a poll stores is counted within the quarter hour without a rebuild.
- The poll itself is unchanged from #54: reachability, the moment, the address that answered, the 404 recorded as what a centre is, and the sync log a node's other syncs are read in all come from that path.

## Two readings worth naming

- *"A 404 records that this node has no archive … rather than a failure to retry hopefully"* is read as recording the fact rather than wrapping the task in retries — not as dropping the centre from the schedule. The acceptance criteria define the polled set by broker reachability alone (*"and no others"*), serving an archive is a wis2box convention a centre can begin to honour, and where it serves it is a guess an operator can correct in the admin. A test pins that reading.
- The propagation criterion needed no production change: #53 already made `watched_origins()` answer with both transports. What is added here is the regression test, plus the polling that actually marks an archive reachable.

## Testing

Full suite green — 1016 tests, ruff clean on the changed files. New coverage: the selection rules case by case, the fan-out shape, the scheduled window's depth, reachability / 404 / sync log on the scheduled path, a second dispatch of one centre being refused through celery-singleton's own backend, the beat entry resolving to a task that exists, and an archive-only centre now being judged on propagation.