### PR TITLE
Say which transport is carrying a centre's own view

### DIFF
--- a/wis2watch/src/wis2watch/core/analysis/__init__.py
+++ b/wis2watch/src/wis2watch/core/analysis/__init__.py
@@ -36,7 +36,7 @@ from .node_detail import (
     NodeDatasetRow,
     NodeDetail,
     NodeStationRow,
-    OriginBrokerState,
+    OriginState,
     StationStanding,
     SyncRunRow,
     SyncScope,
@@ -48,7 +48,7 @@ from .overview import (
     default_volume_hours,
     node_overview,
 )
-from .reachability import OriginReachability
+from .reachability import OriginReachability, OriginTransport, OriginWatch
 from .silence import (
     DatasetSilenceRow,
     Expectation,
@@ -72,8 +72,10 @@ __all__ = [
     "NodeSilence",
     "NodeStationRow",
     "Notice",
-    "OriginBrokerState",
     "OriginReachability",
+    "OriginState",
+    "OriginTransport",
+    "OriginWatch",
     "PropagationGapRow",
     "Silence",
     "SilentStationRow",

--- a/wis2watch/src/wis2watch/core/analysis/gaps.py
+++ b/wis2watch/src/wis2watch/core/analysis/gaps.py
@@ -28,8 +28,8 @@ report that quietly drops findings is worse than one that is long.
 
 Two of those filters do most of the work, and both exist to keep the reports
 readable rather than complete. OSCAR is notoriously stale, so only stations it
-still reports as fully operational count as declared. And a centre whose own
-broker this tool cannot currently reach has its propagation gaps withheld,
+still reports as fully operational count as declared. And a centre no vantage
+point of its own currently answers at has its propagation gaps withheld,
 because they are indistinguishable from this tool having stopped listening.
 """
 
@@ -55,6 +55,7 @@ from ..models import (
     evidence_horizon,
 )
 from ..rollups import window_start
+from .reachability import OriginTransport
 from .silence import hours_between
 
 #: Over how many hours a centre's unattributed share is worked out. Longer than
@@ -124,7 +125,11 @@ class UndeclaredStationRow:
 
 @dataclass(frozen=True)
 class PropagationGapRow:
-    """One notification a centre published that the world never received."""
+    """One notification a centre published that the world never received.
+
+    The transport that observed it travels with the row rather than being left
+    to the reader, for the reason ``OriginTransport`` gives.
+    """
 
     gap_id: int
     node_id: int
@@ -133,10 +138,16 @@ class PropagationGapRow:
     dataset_title: str
     notification_id: str
     topic: str
+    origin_transport: str
     published_at: datetime
     observed_at_origin: datetime
     detected_at: datetime
     hours_missing: float | None
+
+    @property
+    def origin_transport_label(self):
+        """What the transport that observed this is called, for a cell or an email."""
+        return OriginTransport.label(self.origin_transport)
 
 
 @dataclass(frozen=True)
@@ -238,11 +249,15 @@ def propagation_gaps(*, now=None):
     Returns:
         list[PropagationGapRow]: newest publication first.
 
-    Only centres whose own broker answers right now are reported on. A gap
-    recorded while a broker was up and read after it went dark cannot be told
-    from this tool having stopped listening, and sending somebody to a centre
-    to ask about messages that may never have gone missing is how a diagnostic
-    stops being believed.
+    Only centres some vantage point of their own answers at right now are
+    reported on -- their broker, or the archive polled where that broker will
+    not answer. A gap recorded while a centre could be heard and read after it
+    went dark cannot be told from this tool having stopped listening, and
+    sending somebody to a centre to ask about messages that may never have
+    gone missing is how a diagnostic stops being believed.
+
+    Each row says which of the two saw the notification, for the reason
+    ``OriginTransport`` gives.
 
     And only gaps this tool can still stand behind. An open gap outlives the
     evidence that would close it: past the raw retention window the Global
@@ -451,7 +466,7 @@ def _reportable_gaps(*, now=None):
     return (
         _gaps_at_watched_centres()
         .within_evidence(now)
-        .select_related("node", "dataset")
+        .select_related("node", "dataset", "origin_source")
     )
 
 
@@ -477,11 +492,26 @@ def _propagation_gap_row(gap, *, now):
         dataset_title=gap.dataset.title if gap.dataset_id else "",
         notification_id=gap.notification_id,
         topic=gap.topic,
+        origin_transport=_transport_of(gap),
         published_at=gap.published_at,
         observed_at_origin=gap.observed_at_origin,
         detected_at=gap.detected_at,
         hours_missing=hours_between(gap.published_at, now),
     )
+
+
+def _transport_of(gap):
+    """Which of the centre's own transports observed this notification.
+
+    A vantage point may have been replaced by a later catalogue sync or
+    deleted by hand, which unmakes the note of how the notification was seen
+    without unmaking the observation. The gap is still a finding; what it can
+    no longer say is which transport carried it.
+    """
+    if gap.origin_source_id is None:
+        return OriginTransport.UNRECORDED
+
+    return OriginTransport.of(gap.origin_source.source_type)
 
 
 def _open_unregistered_centres():
@@ -627,12 +657,16 @@ def _propagation_gap_notice(row):
     is the path, and it is the path somebody is sent to look at; the
     notification named here is the evidence to open the conversation with, and
     the report holds however many others there are.
+
+    The transport is named after the finding rather than inside it, because it
+    is not part of what went wrong: it is how this tool knows.
     """
     return Notice(
         key=row.centre_id,
         summary=(
             f"{row.centre_id} published {row.notification_id} on {row.topic} "
-            f"and the Global Broker has not carried it"
+            f"and the Global Broker has not carried it. "
+            f"Seen at: {row.origin_transport_label}"
         ),
     )
 
@@ -762,9 +796,10 @@ GAP_REPORTS = (
         slug="propagation-gaps",
         title=_("Propagation gaps"),
         description=_(
-            "Notifications seen at a centre's own broker that the Global "
-            "Broker has never carried. Centres whose own broker cannot "
-            "currently be reached are left out."
+            "Notifications seen at a centre's own vantage point that the "
+            "Global Broker has never carried, each saying which of the "
+            "centre's transports saw it. Centres no vantage point of their "
+            "own currently answers at are left out."
         ),
         find_rows=propagation_gaps,
         count_rows=lambda *, now=None: _reportable_gaps(now=now).count(),

--- a/wis2watch/src/wis2watch/core/analysis/node_detail.py
+++ b/wis2watch/src/wis2watch/core/analysis/node_detail.py
@@ -13,7 +13,8 @@ observations are flowing while its daily bulletin has not appeared for a week
 reads as the second thing rather than as healthy. Per station, when it last
 transmitted, so a single silent station is nameable. And beside both, the two
 explanations that are about this tool rather than the centre: a sync run that
-failed, and a broker that does not answer from outside.
+failed, and which of the centre's own transports -- if either -- this tool is
+hearing it through at all.
 
 Nothing here is derived a second way. Dataset silence is the same function the
 overview reduces to one badge, asked for one centre, so the page and the table
@@ -37,7 +38,7 @@ from ..models import (
     StationSource,
     SyncLog,
 )
-from .reachability import OriginReachability
+from .reachability import OriginReachability, OriginTransport, OriginWatch
 from .silence import (
     BEFORE_ANYTHING,
     DatasetSilenceRow,
@@ -223,14 +224,24 @@ class SyncRunRow:
 
 
 @dataclass(frozen=True)
-class OriginBrokerState:
-    """What is known about the centre's own broker, from outside.
+class OriginState:
+    """Which transport carries the centre's own view, and how that one is faring.
 
-    An address beside the verdict, because "not reachable" is only actionable
-    with the host and port that were dialled: half of what this reports is a
-    broker advertised at an address that was never open to begin with.
+    Two readings of the same section, because they are acted on by different
+    people. The watch state is what the overview showed and what decides
+    whether this centre's propagation may be judged at all; the reachability
+    beside it is what the one vantage point in play last reported.
+
+    An address beside both, because "not reachable" is only actionable with
+    what was actually asked: half of what this reports is a transport
+    advertised somewhere that was never open to begin with. Which address that
+    is follows the vantage point in play -- an operator sent here by an
+    archive-only badge is being asked about an HTTPS endpoint, and showing
+    them a broker's host and port would send them after the wrong thing.
     """
 
+    watch: str
+    transport: str
     reachability: str
     address: str
     connections_enabled: bool
@@ -238,9 +249,18 @@ class OriginBrokerState:
     last_error: str
 
     @classmethod
-    def unadvertised(cls):
-        """A centre whose catalogue record names no broker of its own."""
+    def unwatched(cls):
+        """A centre with no vantage point of its own on the record at all.
+
+        Neither a broker its catalogue record advertises nor an archive this
+        tool has worked out an address for, so there is nothing to describe
+        and nothing being watched. None rather than unrecorded: no vantage
+        point has been lost here, and saying one had would send somebody
+        looking for a transport that never existed.
+        """
         return cls(
+            watch=OriginWatch.UNWATCHED,
+            transport=OriginTransport.NONE,
             reachability=OriginReachability.of(None, advertised=False),
             address="",
             connections_enabled=False,
@@ -249,8 +269,18 @@ class OriginBrokerState:
         )
 
     @property
+    def watch_label(self):
+        """What the centre's origin state is called, for the page."""
+        return OriginWatch.label(self.watch)
+
+    @property
+    def transport_label(self):
+        """What the vantage point in play is called, for the page."""
+        return OriginTransport.label(self.transport)
+
+    @property
     def reachability_label(self):
-        """What the broker's state is called, for the page."""
+        """What that vantage point last reported, for the page."""
         return OriginReachability.label(self.reachability)
 
 
@@ -266,7 +296,7 @@ class NodeDetail:
     retired_datasets: list[NodeDatasetRow]
     stations: list[NodeStationRow]
     sync_runs: list[SyncRunRow]
-    origin: OriginBrokerState
+    origin: OriginState
 
     @property
     def silent_dataset_count(self):
@@ -512,18 +542,62 @@ def _reading_order(row):
 
 
 def _origin(node):
-    """The centre's own broker, as the page reports it."""
-    source = MessageSource.objects.filter(
-        node=node, source_type=MessageSource.ORIGIN_BROKER
-    ).first()
+    """The centre's own view of itself, and the transport carrying it.
+
+    Read from both of the centre's vantage points in one query, because the
+    watch state is a statement about the pair: which one is answering decides
+    what the section says, and what the other is doing is the reason it says
+    it.
+    """
+    sources = {
+        source.source_type: source
+        for source in MessageSource.objects.filter(
+            node=node, source_type__in=MessageSource.ORIGIN_TRANSPORTS
+        )
+    }
+
+    # Which of them is watching is asked of the manager rather than worked out
+    # from the rows just fetched. It is the same question the propagation
+    # evaluation is bounded by -- answering, and still being asked -- and a
+    # page deciding it a second way is how the page and the evaluation would
+    # come to disagree about the centre being read.
+    watching = set(
+        MessageSource.objects.watched_origins()
+        .filter(node=node)
+        .values_list("source_type", flat=True)
+    )
+
+    watch = OriginWatch.of(
+        broker=MessageSource.ORIGIN_BROKER in watching,
+        archive=MessageSource.ORIGIN_API in watching,
+    )
+    source = _vantage_in_play(watch, sources)
 
     if source is None:
-        return OriginBrokerState.unadvertised()
+        return OriginState.unwatched()
 
-    return OriginBrokerState(
+    return OriginState(
+        watch=watch,
+        transport=OriginTransport.of(source.source_type),
         reachability=OriginReachability.of(source.is_reachable),
-        address=f"{source.host}:{source.port}",
+        address=source.address,
         connections_enabled=source.is_active,
         last_connected_at=source.last_connected_at,
         last_error=source.last_error,
+    )
+
+
+def _vantage_in_play(watch, sources):
+    """The vantage point this section is describing, or None if there is none.
+
+    Whichever is carrying the centre's view where one is. Where neither is,
+    the broker: its archive is an address this tool inferred and polls as a
+    fallback, and its broker is the one the centre is obliged to run and the
+    one somebody is going to be asked about.
+    """
+    if watch == OriginWatch.AT_ARCHIVE:
+        return sources.get(MessageSource.ORIGIN_API)
+
+    return sources.get(MessageSource.ORIGIN_BROKER) or sources.get(
+        MessageSource.ORIGIN_API
     )

--- a/wis2watch/src/wis2watch/core/analysis/overview.py
+++ b/wis2watch/src/wis2watch/core/analysis/overview.py
@@ -1,9 +1,11 @@
 """The node overview: the state of the region on one screen.
 
-Each row pairs what the world saw of a centre with whether that centre's own
-broker answers from outside. Read together they separate "gone quiet" from
-"publishing where no one can see it", which is the distinction the whole tool
-is built around.
+Each row pairs what the world saw of a centre with which of that centre's own
+transports this tool is hearing it through. Read together they separate "gone
+quiet" from "publishing where no one can see it", which is the distinction the
+whole tool is built around -- and the second of the two is a state rather than
+a yes, because a centre reachable only through its archive is both being
+watched and failing to run a broker anyone can dial.
 
 Beside them is the far end of the same chain: whether the Global Caches picked
 the centre's core data up. A centre whose notifications reach the Global Broker
@@ -46,7 +48,7 @@ from ..models import (
     WIS2Node,
 )
 from ..rollups import window_start
-from .reachability import OriginReachability
+from .reachability import OriginReachability, OriginWatch
 from .silence import BEFORE_ANYTHING, NodeSilence, Silence, hours_between, silence_by_node
 from .staleness import Staleness, default_stale_after_hours
 
@@ -109,7 +111,8 @@ class NodeOverviewRow:
     cache_pickup: str
     dataset_count: int
     station_count: int
-    origin_reachability: str
+    origin_watch: str
+    origin_broker_reachability: str
     origin_last_error: str
     silence: str
     silent_dataset_count: int
@@ -131,11 +134,33 @@ class NodeOverviewRow:
         return CachePickup.LABELS.get(self.cache_pickup, self.cache_pickup)
 
     @property
-    def origin_reachability_label(self):
-        """What the centre's own broker's state is called, for a table cell."""
-        return OriginReachability.LABELS.get(
-            self.origin_reachability, self.origin_reachability
-        )
+    def origin_watch_label(self):
+        """What the centre's origin state is called, for a table cell."""
+        return OriginWatch.label(self.origin_watch)
+
+    @property
+    def is_watched_at_broker(self):
+        """Whether the centre's own broker is what this row is reading it through.
+
+        What decides whether the line below the badge is worth spending. Where
+        the broker is carrying our view the badge has already said so, and the
+        line would repeat it.
+        """
+        return self.origin_watch == OriginWatch.AT_BROKER
+
+    @property
+    def origin_broker_reachability_label(self):
+        """What the centre's own broker last reported, for a table cell.
+
+        Read beneath the state rather than instead of it, and it is what keeps
+        the column honest wherever the broker is not what we are reading.
+        Three different centres are not watched at their broker -- one whose
+        broker refuses, one nothing has dialled yet, one that advertises no
+        broker at all -- and they are three conversations with three different
+        people. The state says whether the centre can be judged at all; this
+        says what its broker is doing about the obligation to be dialable.
+        """
+        return OriginReachability.label(self.origin_broker_reachability)
 
 
 def default_volume_hours():
@@ -257,6 +282,19 @@ def _annotated_nodes(*, since):
         node=OuterRef("pk"), source_type=MessageSource.ORIGIN_BROKER
     )
 
+    # Whether each transport is watching the centre now, asked through the
+    # queryset the propagation evaluation is bounded by rather than through
+    # the row above. The row above is what the centre's broker last said; this
+    # is whether that answer still entitles anything to judge the centre, and
+    # deriving the second from the first here is how the table and the
+    # evaluation would come to disagree.
+    def watching(source_type):
+        return Exists(
+            MessageSource.objects.watched_origins().filter(
+                node=OuterRef("pk"), source_type=source_type
+            )
+        )
+
     return WIS2Node.objects.annotate(
         last_seen_at=Subquery(last_seen[:1]),
         recent_message_count=Coalesce(Subquery(recent_messages), 0),
@@ -267,6 +305,8 @@ def _annotated_nodes(*, since):
         has_origin_broker=Exists(origin_broker),
         origin_reachable=Subquery(origin_broker.values("is_reachable")[:1]),
         origin_error=Subquery(origin_broker.values("last_error")[:1]),
+        watched_at_broker=watching(MessageSource.ORIGIN_BROKER),
+        watched_at_archive=watching(MessageSource.ORIGIN_API),
     )
 
 
@@ -290,7 +330,10 @@ def _row(node, *, now, stale_after, silence):
         cache_pickup=_cache_pickup(node),
         dataset_count=node.dataset_count,
         station_count=node.station_count,
-        origin_reachability=_origin_reachability(node),
+        origin_watch=OriginWatch.of(
+            broker=node.watched_at_broker, archive=node.watched_at_archive
+        ),
+        origin_broker_reachability=_origin_reachability(node),
         origin_last_error=node.origin_error or "",
         silence=node_silence.silence,
         silent_dataset_count=node_silence.silent_dataset_count,

--- a/wis2watch/src/wis2watch/core/analysis/reachability.py
+++ b/wis2watch/src/wis2watch/core/analysis/reachability.py
@@ -1,21 +1,29 @@
-"""What is known about a centre's own broker, from outside.
+"""What is known about the transports a centre offers on its own account.
 
-Its own module because two surfaces read it: the overview asks it of every
-centre at once, off annotations across the whole region, and a centre's page
-asks it of one broker record. The states and the rule that decides between
-them are written once here, so that the table and the page can never disagree
-about the same broker -- which is the kind of contradiction that costs a
-diagnostic tool its credibility on the row that mattered.
+Its own module because several surfaces read it: the overview asks it of every
+centre at once, off annotations across the whole region, a centre's page asks
+it of that centre's own vantage points, and the propagation report names the
+one an individual finding came through. The states and the rules that decide
+between them are written once here, so that the table, the page and the report
+can never disagree about the same centre -- which is the kind of contradiction
+that costs a diagnostic tool its credibility on the row that mattered.
+
+Three vocabularies, because they answer three questions. What one vantage
+point last reported is ``OriginReachability``. Which transport is carrying a
+centre's view of itself, if either is, is ``OriginWatch``. Which one a
+particular observation arrived through is ``OriginTransport``.
 """
 
 from django.utils.translation import gettext_lazy as _
 
+from ..models import MessageSource
+
 
 class OriginReachability:
-    """What is known about a centre's own broker, from outside.
+    """What one of a centre's own vantage points last reported, from outside.
 
     Four states, because two of them are absences that mean different things.
-    A broker nothing has attempted yet is not a broker that failed, and a
+    A vantage point nothing has attempted yet is not one that failed, and a
     centre whose catalogue record advertises no broker at all is neither --
     calling any of these "unreachable" would report a fault that has not been
     observed.
@@ -55,3 +63,134 @@ class OriginReachability:
     def label(cls, reachability):
         """What a reachability is called, for a table cell or a page."""
         return cls.LABELS.get(reachability, reachability)
+
+
+class OriginWatch:
+    """Which transport is carrying a centre's own view of itself, if either.
+
+    Three states, because a centre offers two transports on its own account
+    and the difference between them is a finding rather than plumbing. Its
+    broker is what WIS2 obliges it to run; its archive is an HTTP endpoint
+    polled precisely when that broker will not answer. Both entitle this tool
+    to judge the centre's propagation, and only one of them says the centre is
+    doing what it is required to do.
+
+    So the fallback is a state of its own rather than a second kind of green.
+    Collapsing the two into one "watched" would launder a broker nobody
+    outside can dial into a healthy row, and reporting only the broker would
+    call a centre this tool is watching over HTTPS unwatched -- an operator
+    reading "origin unreachable" beside propagation gaps piling up for the
+    same centre would reasonably conclude the tool was broken.
+
+    Watched means answering *and* still being asked. Reachability is only ever
+    what the last attempt recorded, so a vantage point switched off in the
+    admin carries an answer that has since gone stale -- and it is the same
+    rule ``MessageSource.objects.watched_origins`` applies, because a table
+    calling a centre watched while the evaluation refuses to judge it is the
+    contradiction that costs both of them their credibility.
+    """
+
+    AT_BROKER = "watched_at_broker"
+    AT_ARCHIVE = "watched_at_archive"
+    UNWATCHED = "unwatched"
+
+    # "No broker answering" rather than "broker not answering": a centre may
+    # reach this state having advertised no broker at all, and the archive is
+    # polled for exactly those centres too. What is true of all of them is
+    # that nothing is answering at a broker; which flavour of not answering it
+    # is belongs beside the state rather than inside it.
+    CHOICES = [
+        (UNWATCHED, _("Not watched")),
+        (AT_ARCHIVE, _("Archive only, no broker answering")),
+        (AT_BROKER, _("Watched at broker")),
+    ]
+
+    LABELS = dict(CHOICES)
+
+    #: The states in which some vantage point of the centre's own is
+    #: answering, and the centre may therefore be judged on what it published.
+    WATCHED = (AT_BROKER, AT_ARCHIVE)
+
+    @classmethod
+    def of(cls, *, broker, archive):
+        """Which transport is carrying the centre, given what each is doing.
+
+        Both arguments are whether that vantage point is watching now --
+        answering and still being asked. The broker is preferred where both
+        are, because the two are the same witness seen twice and the broker is
+        the one the centre is obliged to run.
+        """
+        if broker:
+            return cls.AT_BROKER
+
+        if archive:
+            return cls.AT_ARCHIVE
+
+        return cls.UNWATCHED
+
+    @classmethod
+    def label(cls, watch):
+        """What a watch state is called, for a table cell or a page."""
+        return cls.LABELS.get(watch, watch)
+
+
+class OriginTransport:
+    """Which of a centre's own transports an observation arrived through.
+
+    Named on the finding rather than left to the reader, because a propagation
+    gap is taken to a national met service by email and "we saw you publish
+    this and the world did not" invites the obvious question of how we saw it.
+    A centre whose broker is dark is being watched through its archive, and a
+    finding that does not say so reads as evidence from a broker the centre
+    knows nobody can reach. Everywhere that names a transport says it by
+    reference to this, so the report, the page and the email cannot describe
+    the same observation three ways.
+
+    Two ways of naming no transport, because they are opposite findings. The
+    vantage point a gap was found through may since have been deleted, which
+    is not "no transport": something observed the notification and what has
+    been lost is only the note of which. A centre that offers neither
+    transport has nothing observing it at all, and telling an operator that
+    its vantage point is no longer recorded would send them looking for one
+    that never existed.
+
+    The two named transports take the source types they stand for rather than
+    values of their own. They are one vocabulary read two ways -- what a row
+    is stored as, and what a centre is told -- and a second set of constants
+    would be a mapping to keep in step for no gain.
+    """
+
+    BROKER = MessageSource.ORIGIN_BROKER
+    ARCHIVE = MessageSource.ORIGIN_API
+    UNRECORDED = "unrecorded"
+    NONE = "none"
+
+    CHOICES = [
+        (BROKER, _("The centre's own broker")),
+        (ARCHIVE, _("The centre's message archive")),
+        (UNRECORDED, _("No longer recorded")),
+        (NONE, _("None")),
+    ]
+
+    LABELS = dict(CHOICES)
+
+    @classmethod
+    def of(cls, source_type):
+        """Which transport observed something, from the source type it was seen at.
+
+        Anything that is not one of the centre's own transports is unrecorded
+        rather than named. An observation is only ever made at a vantage
+        point, so a source type from outside that set -- or none at all, where
+        the row it named has since been deleted -- is one this tool can no
+        longer explain, and inventing a transport for it would be the one
+        thing naming the transport exists to prevent.
+        """
+        if source_type in (cls.BROKER, cls.ARCHIVE):
+            return source_type
+
+        return cls.UNRECORDED
+
+    @classmethod
+    def label(cls, transport):
+        """What a transport is called, for a table cell or an email."""
+        return cls.LABELS.get(transport, transport)

--- a/wis2watch/src/wis2watch/core/templates/wis2watchcore/gap_reports/propagation_gaps.html
+++ b/wis2watch/src/wis2watch/core/templates/wis2watchcore/gap_reports/propagation_gaps.html
@@ -13,6 +13,9 @@
     <th>{% trans "Dataset" %}</th>
     <th>{% trans "Topic" %}</th>
     <th>{% trans "Notification" %}</th>
+    <th title="{% trans "Which of the centre's own transports observed this notification. A centre whose broker will not answer is watched through its archive instead." %}">
+        {% trans "Seen at" %}
+    </th>
     <th>{% trans "Published" %}</th>
     <th>{% trans "Missing for" %}</th>
 {% endblock %}
@@ -25,11 +28,12 @@
     <td class="wrapping"><code>{{ row.topic }}</code></td>
     <td class="wrapping"><code>{{ row.notification_id }}</code></td>
     <td>
-        {{ row.published_at|date:"Y-m-d H:i" }}
+        {{ row.origin_transport_label }}
         <div class="row-detail">
-            {% blocktrans with seen=row.observed_at_origin|date:"Y-m-d H:i" %}seen at origin {{ seen }}{% endblocktrans %}
+            {% blocktrans with seen=row.observed_at_origin|date:"Y-m-d H:i" %}observed {{ seen }}{% endblocktrans %}
         </div>
     </td>
+    <td>{{ row.published_at|date:"Y-m-d H:i" }}</td>
     <td>
         {% if row.hours_missing is not None %}
             {% blocktrans with hours=row.hours_missing|floatformat:1 %}{{ hours }}h{% endblocktrans %}
@@ -40,5 +44,5 @@
 {% endblock %}
 
 {% block empty_message %}
-    {% trans "Everything published at a reachable centre's own broker has reached the Global Broker" %}
+    {% trans "Everything seen at a centre's own vantage point has reached the Global Broker" %}
 {% endblock %}

--- a/wis2watch/src/wis2watch/core/templates/wis2watchcore/node_details.html
+++ b/wis2watch/src/wis2watch/core/templates/wis2watchcore/node_details.html
@@ -99,6 +99,7 @@
         .badge-core,
         .badge-active,
         .badge-reachable,
+        .badge-watched_at_broker,
         .badge-on_schedule,
         .badge-transmitting,
         .badge-success {
@@ -111,7 +112,10 @@
             color: #004085;
         }
 
+        /* The fallback is amber rather than green: the centre can be judged,
+           and the broker it is obliged to run is not answering. */
         .badge-undeclared,
+        .badge-watched_at_archive,
         .badge-gone_quiet,
         .badge-partial {
             background: #fff3cd;
@@ -122,6 +126,7 @@
         .badge-deleted,
         .badge-error,
         .badge-unreachable,
+        .badge-unwatched,
         .badge-silent,
         .badge-never_transmitted,
         .badge-failed {
@@ -241,37 +246,45 @@
         </a>
     </div>
 
-    <!-- The centre's own broker -->
+    <!-- The centre's own view of itself -->
     <div class="detail-section">
         <div class="section-header">
-            <h3>{% trans "This centre's own broker" %}</h3>
-            <span class="badge badge-{{ detail.origin.reachability }}">
-                {{ detail.origin.reachability_label }}
+            <h3>{% trans "This centre's own view" %}</h3>
+            <span class="badge badge-{{ detail.origin.watch }}">
+                {{ detail.origin.watch_label }}
             </span>
         </div>
         <p class="section-note">
-            {% trans "Whether this centre's broker answers from outside. A centre publishing where nobody can reach it looks the same as a centre that has stopped, until this column says otherwise." %}
+            {% trans "Which of this centre's own transports this tool is hearing it through. A centre publishing where nobody can reach it looks the same as a centre that has stopped, until this says otherwise -- and its archive is polled only where its broker will not answer, so a centre watched there is being watched and is failing to run a broker anyone can dial." %}
         </p>
         <div class="node-info">
+            <div class="info-item">
+                <span class="info-label">{% trans "Vantage point" %}</span>
+                <span class="info-value">{{ detail.origin.transport_label }}</span>
+            </div>
+            <div class="info-item">
+                <span class="info-label">{% trans "Last said" %}</span>
+                <span class="info-value">{{ detail.origin.reachability_label }}</span>
+            </div>
             <div class="info-item">
                 <span class="info-label">{% trans "Address" %}</span>
                 <span class="info-value"><code>{{ detail.origin.address|default:"—" }}</code></span>
             </div>
             <div class="info-item">
-                <span class="info-label">{% trans "Last connected" %}</span>
+                <span class="info-label">{% trans "Last answered" %}</span>
                 <span class="info-value">
                     {{ detail.origin.last_connected_at|date:"Y-m-d H:i"|default:"—" }}
                 </span>
             </div>
             <div class="info-item">
-                <span class="info-label">{% trans "Connections enabled" %}</span>
+                <span class="info-label">{% trans "Enabled" %}</span>
                 <span class="info-value"
-                      title="{% trans 'Whether this tool is set to dial this broker at all. A disabled broker is never attempted, so nothing is learned about it.' %}">
+                      title="{% trans 'Whether this tool is set to ask this vantage point at all. A disabled one is never attempted, so nothing is learned about it.' %}">
                     {% if detail.origin.connections_enabled %}{% trans "Yes" %}{% else %}{% trans "No" %}{% endif %}
                 </span>
             </div>
             <div class="info-item">
-                <span class="info-label">{% trans "Last connection error" %}</span>
+                <span class="info-label">{% trans "Last error" %}</span>
                 <span class="info-value">
                     {% if detail.origin.last_error %}
                         <span class="row-error">{{ detail.origin.last_error }}</span>

--- a/wis2watch/src/wis2watch/core/templates/wis2watchcore/node_overview.html
+++ b/wis2watch/src/wis2watch/core/templates/wis2watchcore/node_overview.html
@@ -78,12 +78,21 @@
             color: #721c24;
         }
 
-        .badge-reachable {
+        .badge-reachable,
+        .badge-watched_at_broker {
             background: #d4edda;
             color: #155724;
         }
 
-        .badge-unreachable {
+        /* The fallback is amber rather than green: the centre can be judged,
+           and the broker it is obliged to run is not answering. */
+        .badge-watched_at_archive {
+            background: #fff3cd;
+            color: #856404;
+        }
+
+        .badge-unreachable,
+        .badge-unwatched {
             background: #f8d7da;
             color: #721c24;
         }
@@ -200,8 +209,8 @@
                 </th>
                 <th class="numeric">{% trans "Datasets" %}</th>
                 <th class="numeric">{% trans "Stations" %}</th>
-                <th title="{% trans "Whether this centre's own broker answers from outside" %}">
-                    {% trans "Origin broker" %}
+                <th title="{% trans "Which of this centre's own transports this tool is hearing it through. Its archive is polled only where its broker will not answer, so a centre watched there is being watched and is failing to run a broker anyone can dial." %}">
+                    {% trans "Origin" %}
                 </th>
                 <th title="{% trans "Whether the Global Caches carried this centre's core data. Only core data is cached, so a centre publishing none has nothing to pick up." %}">
                     {% trans "Global Cache" %}
@@ -233,9 +242,15 @@
                     <td class="numeric">{{ row.dataset_count }}</td>
                     <td class="numeric">{{ row.station_count }}</td>
                     <td>
-                        <span class="badge badge-{{ row.origin_reachability }}">
-                            {{ row.origin_reachability_label }}
+                        <span class="badge badge-{{ row.origin_watch }}">
+                            {{ row.origin_watch_label }}
                         </span>
+                        {% if not row.is_watched_at_broker %}
+                            <div class="silence-detail"
+                                 title="{% trans "What this centre's own broker is doing. A centre is obliged to run one anything can dial, whether or not this tool can see the centre another way." %}">
+                                {% blocktrans with reachability=row.origin_broker_reachability_label %}Broker: {{ reachability }}{% endblocktrans %}
+                            </div>
+                        {% endif %}
                         {% if row.origin_last_error %}
                             <div class="broker-error" title="{{ row.origin_last_error }}">
                                 {{ row.origin_last_error|truncatechars:60 }}

--- a/wis2watch/src/wis2watch/core/tests/test_gaps.py
+++ b/wis2watch/src/wis2watch/core/tests/test_gaps.py
@@ -19,6 +19,7 @@ from django.test import TestCase, override_settings
 
 from wis2watch.core.analysis import (
     GAP_REPORTS,
+    OriginTransport,
     gap_report,
     gap_report_summaries,
     propagation_gaps,
@@ -38,7 +39,7 @@ from wis2watch.core.models import (
     UnregisteredCentre,
     WIS2Node,
 )
-from wis2watch.core.tests.support import at, origin_broker
+from wis2watch.core.tests.support import at, origin_api, origin_broker
 
 
 NOW = at("2026-08-11T12:00:00")
@@ -288,12 +289,13 @@ class PropagationGapTestCase(GapReportTestCase):
         hours_ago=2,
         resolved=False,
         dataset=None,
+        source=None,
     ):
         node = node or self.kenya
 
         return PropagationGap.objects.create(
             node=node,
-            origin_source=node.origin_source,
+            origin_source=node.origin_source if source is None else source,
             dataset=dataset,
             notification_id=notification_id,
             topic=f"origin/a/wis2/{node.centre_id}/data/core/weather/surface-based-observations/synop",
@@ -362,6 +364,55 @@ class PropagationGapTests(PropagationGapTestCase):
         self.assertEqual(
             [row.notification_id for row in self.report()], ["newer", "older"]
         )
+
+    def test_a_gap_seen_at_the_centres_own_broker_says_so(self):
+        origin_broker(self.kenya, is_reachable=True)
+        self.gap()
+
+        (row,) = self.report()
+
+        self.assertEqual(row.origin_transport, OriginTransport.BROKER)
+
+    def test_a_gap_seen_in_the_centres_archive_says_so(self):
+        """How the tool knows, on a finding that goes to a met service by email.
+
+        A centre whose broker is dark is watched through its archive, and a
+        gap that did not say so would read as evidence from a broker the
+        centre knows nobody outside can reach.
+        """
+        origin_broker(self.kenya, is_reachable=False)
+        archive = origin_api(self.kenya, is_reachable=True)
+        self.gap(source=archive)
+
+        (row,) = self.report()
+
+        self.assertEqual(row.origin_transport, OriginTransport.ARCHIVE)
+        self.assertEqual(
+            row.origin_transport_label, OriginTransport.label(OriginTransport.ARCHIVE)
+        )
+
+    def test_a_gap_whose_vantage_point_is_gone_does_not_invent_one(self):
+        """Something saw it; what has been lost is the note of which."""
+        origin_broker(self.kenya, is_reachable=True)
+        archive = origin_api(self.kenya, is_reachable=True)
+        self.gap(source=archive)
+        archive.delete()
+
+        (row,) = self.report()
+
+        self.assertEqual(row.origin_transport, OriginTransport.UNRECORDED)
+
+    def test_the_notice_a_digest_sends_names_the_transport(self):
+        origin_broker(self.kenya, is_reachable=False)
+        archive = origin_api(self.kenya, is_reachable=True)
+        self.gap(source=archive)
+
+        (row,) = self.report()
+        notice = gap_report("propagation-gaps").describe_row(row)
+
+        archive_label = str(OriginTransport.label(OriginTransport.ARCHIVE))
+
+        self.assertIn(archive_label, notice.summary)
 
     def test_a_gap_names_the_dataset_where_the_registry_knows_one(self):
         origin_broker(self.kenya, is_reachable=True)

--- a/wis2watch/src/wis2watch/core/tests/test_node_detail.py
+++ b/wis2watch/src/wis2watch/core/tests/test_node_detail.py
@@ -20,6 +20,8 @@ from django.test import TestCase
 from wis2watch.core.analysis import (
     Expectation,
     OriginReachability,
+    OriginTransport,
+    OriginWatch,
     Silence,
     StationStanding,
     SyncScope,
@@ -37,7 +39,7 @@ from wis2watch.core.models import (
     SyncLog,
     WIS2Node,
 )
-from wis2watch.core.tests.support import at, origin_broker
+from wis2watch.core.tests.support import at, origin_api, origin_broker
 
 
 NOW = at("2026-08-11T12:00:00")
@@ -437,38 +439,117 @@ class SyncRunTests(NodeDetailTestCase):
         self.assertEqual(self.detail().sync_runs, [])
 
 
-class OriginBrokerTests(NodeDetailTestCase):
-    """Whether the missing data is a broker nothing outside can reach."""
+class OriginTests(NodeDetailTestCase):
+    """Which transport carries this centre's own view, and how that one is faring.
 
-    def test_a_broker_that_answers_is_reachable_and_says_where_it_is(self):
+    The page is where an operator lands having read one badge on the overview,
+    so the vantage point behind that badge has to be named here with the
+    address that was asked and whatever it last said -- half of what this
+    reports is a transport advertised somewhere that was never open.
+    """
+
+    def test_a_broker_that_answers_is_what_the_page_reports_watching_at(self):
         broker = origin_broker(
             self.kenya, is_reachable=True, last_connected_at=NOW - timedelta(minutes=5)
         )
 
         origin = self.detail().origin
 
+        self.assertEqual(origin.watch, OriginWatch.AT_BROKER)
+        self.assertEqual(origin.transport, OriginTransport.BROKER)
         self.assertEqual(origin.reachability, OriginReachability.REACHABLE)
         self.assertEqual(origin.address, f"{broker.host}:{broker.port}")
         self.assertEqual(origin.last_connected_at, NOW - timedelta(minutes=5))
+
+    def test_a_centre_watched_at_its_archive_says_so_and_where_that_is(self):
+        """The vantage point in play is the one the page has to describe.
+
+        An operator sent here by an archive-only badge is being asked to check
+        an HTTPS endpoint, and a page showing them the broker's address and
+        the broker's error would send them after the wrong thing.
+        """
+        origin_broker(self.kenya, is_reachable=False, last_error="Connection timed out")
+        archive = origin_api(
+            self.kenya,
+            is_reachable=True,
+            last_connected_at=NOW - timedelta(minutes=20),
+        )
+
+        origin = self.detail().origin
+
+        self.assertEqual(origin.watch, OriginWatch.AT_ARCHIVE)
+        self.assertEqual(origin.transport, OriginTransport.ARCHIVE)
+        self.assertEqual(origin.reachability, OriginReachability.REACHABLE)
+        self.assertEqual(origin.address, archive.api_url)
+        self.assertEqual(origin.last_connected_at, NOW - timedelta(minutes=20))
+        self.assertEqual(origin.last_error, "")
+
+    def test_a_broker_that_answers_is_preferred_to_an_archive_that_does(self):
+        broker = origin_broker(self.kenya, is_reachable=True)
+        origin_api(self.kenya, is_reachable=True)
+
+        origin = self.detail().origin
+
+        self.assertEqual(origin.watch, OriginWatch.AT_BROKER)
+        self.assertEqual(origin.address, f"{broker.host}:{broker.port}")
 
     def test_a_broker_that_does_not_answer_says_what_went_wrong(self):
         origin_broker(self.kenya, is_reachable=False, last_error="Connection timed out")
 
         origin = self.detail().origin
 
+        self.assertEqual(origin.watch, OriginWatch.UNWATCHED)
+        self.assertEqual(origin.transport, OriginTransport.BROKER)
         self.assertEqual(origin.reachability, OriginReachability.UNREACHABLE)
+        self.assertEqual(origin.last_error, "Connection timed out")
+
+    def test_an_unwatched_centre_is_described_by_the_broker_it_owes(self):
+        """Where nothing answers, the broker is the vantage point to describe.
+
+        Its archive is an address this tool inferred and polls as a fallback;
+        its broker is the one the centre is obliged to run, and the one whose
+        error somebody is going to be asked about.
+        """
+        origin_broker(self.kenya, is_reachable=False, last_error="Connection timed out")
+        origin_api(self.kenya, is_reachable=False, last_error="404 Not Found")
+
+        origin = self.detail().origin
+
+        self.assertEqual(origin.watch, OriginWatch.UNWATCHED)
+        self.assertEqual(origin.transport, OriginTransport.BROKER)
         self.assertEqual(origin.last_error, "Connection timed out")
 
     def test_a_broker_nothing_has_tried_yet_is_not_called_unreachable(self):
         origin_broker(self.kenya)
 
-        self.assertEqual(
-            self.detail().origin.reachability, OriginReachability.NOT_ATTEMPTED
-        )
-
-    def test_a_centre_advertising_no_broker_of_its_own_says_so(self):
         origin = self.detail().origin
 
+        self.assertEqual(origin.watch, OriginWatch.UNWATCHED)
+        self.assertEqual(origin.reachability, OriginReachability.NOT_ATTEMPTED)
+
+    def test_a_vantage_point_switched_off_is_not_read_as_watching(self):
+        origin_broker(self.kenya, is_reachable=True, is_active=False)
+
+        origin = self.detail().origin
+
+        self.assertEqual(origin.watch, OriginWatch.UNWATCHED)
+        self.assertFalse(origin.connections_enabled)
+
+    def test_a_centre_with_only_an_archive_is_described_by_it(self):
+        archive = origin_api(self.kenya, is_reachable=False, last_error="404 Not Found")
+
+        origin = self.detail().origin
+
+        self.assertEqual(origin.watch, OriginWatch.UNWATCHED)
+        self.assertEqual(origin.transport, OriginTransport.ARCHIVE)
+        self.assertEqual(origin.address, archive.api_url)
+        self.assertEqual(origin.last_error, "404 Not Found")
+
+    def test_a_centre_with_no_vantage_point_at_all_says_so(self):
+        origin = self.detail().origin
+
+        self.assertEqual(origin.watch, OriginWatch.UNWATCHED)
+        self.assertEqual(origin.transport, OriginTransport.NONE)
         self.assertEqual(origin.reachability, OriginReachability.NOT_ADVERTISED)
         self.assertEqual(origin.address, "")
 
@@ -477,6 +558,7 @@ class OriginBrokerTests(NodeDetailTestCase):
         self.global_broker.is_reachable = True
         self.global_broker.save()
 
-        self.assertEqual(
-            self.detail().origin.reachability, OriginReachability.NOT_ADVERTISED
-        )
+        origin = self.detail().origin
+
+        self.assertEqual(origin.watch, OriginWatch.UNWATCHED)
+        self.assertEqual(origin.reachability, OriginReachability.NOT_ADVERTISED)

--- a/wis2watch/src/wis2watch/core/tests/test_overview.py
+++ b/wis2watch/src/wis2watch/core/tests/test_overview.py
@@ -18,6 +18,7 @@ from django.test import TestCase
 from wis2watch.core.analysis import (
     CachePickup,
     OriginReachability,
+    OriginWatch,
     Silence,
     Staleness,
     node_overview,
@@ -32,7 +33,7 @@ from wis2watch.core.models import (
     StationSource,
     WIS2Node,
 )
-from wis2watch.core.tests.support import at, origin_broker
+from wis2watch.core.tests.support import at, origin_api, origin_broker
 
 
 NOW = at("2026-08-11T12:00:00")
@@ -420,50 +421,123 @@ class SilenceTests(OverviewTestCase):
         self.assertEqual(rows["dj-anm"].silence, Silence.ON_SCHEDULE)
 
 
-class OriginReachabilityTests(OverviewTestCase):
-    """Whether a centre's own broker answers from outside, on the same screen.
+class OriginWatchTests(OverviewTestCase):
+    """Which of a centre's own transports is carrying its view of itself.
 
     A large share of these brokers are unreachable, which is a finding about
     the centre rather than a fault to hide: read next to the volume the Global
     Broker saw, "not reachable, and yet publishing" is the row that starts an
-    investigation.
+    investigation. What the archive changes is that such a centre can still be
+    watched -- which the column has to say without letting "we can see them
+    another way" stand in for a broker that answers.
     """
 
-    def test_a_centre_whose_broker_answers_is_reachable(self):
+    def test_a_centre_whose_broker_answers_is_watched_at_its_broker(self):
         origin_broker(self.node("ke-meteo"), is_reachable=True)
 
         row = self.by_centre()["ke-meteo"]
 
-        self.assertEqual(row.origin_reachability, OriginReachability.REACHABLE)
+        self.assertEqual(row.origin_watch, OriginWatch.AT_BROKER)
+        self.assertTrue(row.is_watched_at_broker)
         self.assertEqual(row.origin_last_error, "")
 
-    def test_a_centre_whose_broker_does_not_answer_says_why(self):
-        origin_broker(
-            self.node("ke-meteo"),
-            is_reachable=False,
-            last_error="Could not reach wis.ke-meteo.example.int:1883",
-        )
+    def test_a_centre_watched_only_through_its_archive_says_the_broker_is_down(self):
+        """The fallback is not a green tick.
+
+        The centre is being watched and its broker is not answering, and the
+        row has to say both: the first is what entitles this tool to judge its
+        propagation, and the second is the WIS2 obligation it is failing.
+        """
+        node = self.node("ke-meteo")
+        origin_broker(node, is_reachable=False, last_error="Connection timed out")
+        origin_api(node, is_reachable=True)
 
         row = self.by_centre()["ke-meteo"]
 
-        self.assertEqual(row.origin_reachability, OriginReachability.UNREACHABLE)
+        self.assertEqual(row.origin_watch, OriginWatch.AT_ARCHIVE)
+        self.assertFalse(row.is_watched_at_broker)
         self.assertEqual(
-            row.origin_last_error, "Could not reach wis.ke-meteo.example.int:1883"
+            row.origin_broker_reachability, OriginReachability.UNREACHABLE
+        )
+        self.assertEqual(row.origin_last_error, "Connection timed out")
+
+    def test_a_centre_watched_at_an_archive_it_never_advertised_a_broker_for(self):
+        """The fallback does not assert a broker that was never advertised.
+
+        The archive is polled for these centres too -- a centre with no broker
+        on the record has never been heard from at all -- so the state has to
+        be true of them, and what its broker is doing is the line beneath.
+        """
+        origin_api(self.node("ke-meteo"), is_reachable=True)
+
+        row = self.by_centre()["ke-meteo"]
+
+        self.assertEqual(row.origin_watch, OriginWatch.AT_ARCHIVE)
+        self.assertEqual(
+            row.origin_broker_reachability, OriginReachability.NOT_ADVERTISED
         )
 
-    def test_a_broker_nothing_has_tried_yet_is_not_called_reachable(self):
+    def test_a_broker_that_answers_is_what_the_row_reports_watching_at(self):
+        """The two transports are one witness, and the broker is the one owed."""
+        node = self.node("ke-meteo")
+        origin_broker(node, is_reachable=True)
+        origin_api(node, is_reachable=True)
+
+        row = self.by_centre()["ke-meteo"]
+
+        self.assertEqual(row.origin_watch, OriginWatch.AT_BROKER)
+
+    def test_a_centre_neither_transport_answers_for_is_not_watched(self):
+        node = self.node("ke-meteo")
+        origin_broker(node, is_reachable=False, last_error="Connection timed out")
+        origin_api(node, is_reachable=False)
+
+        row = self.by_centre()["ke-meteo"]
+
+        self.assertEqual(row.origin_watch, OriginWatch.UNWATCHED)
+        self.assertEqual(row.origin_last_error, "Connection timed out")
+
+    def test_a_broker_nothing_has_tried_yet_is_not_read_as_watching(self):
         origin_broker(self.node("ke-meteo"))
 
         row = self.by_centre()["ke-meteo"]
 
-        self.assertEqual(row.origin_reachability, OriginReachability.NOT_ATTEMPTED)
+        self.assertEqual(row.origin_watch, OriginWatch.UNWATCHED)
+        self.assertEqual(
+            row.origin_broker_reachability, OriginReachability.NOT_ATTEMPTED
+        )
 
-    def test_a_centre_advertising_no_broker_of_its_own_says_so(self):
+    def test_an_archive_nothing_has_polled_yet_is_not_read_as_watching(self):
+        node = self.node("ke-meteo")
+        origin_broker(node, is_reachable=False)
+        origin_api(node)
+
+        row = self.by_centre()["ke-meteo"]
+
+        self.assertEqual(row.origin_watch, OriginWatch.UNWATCHED)
+
+    def test_a_vantage_point_switched_off_is_not_read_as_watching(self):
+        """What is not being asked any more carries an answer that has gone stale.
+
+        The same rule the propagation evaluation applies, because a row
+        claiming a centre is watched while the evaluation refuses to judge it
+        is the contradiction that costs the table its credibility.
+        """
+        origin_broker(self.node("ke-meteo"), is_reachable=True, is_active=False)
+
+        row = self.by_centre()["ke-meteo"]
+
+        self.assertEqual(row.origin_watch, OriginWatch.UNWATCHED)
+
+    def test_a_centre_with_no_vantage_point_at_all_says_so(self):
         self.node("ke-meteo")
 
         row = self.by_centre()["ke-meteo"]
 
-        self.assertEqual(row.origin_reachability, OriginReachability.NOT_ADVERTISED)
+        self.assertEqual(row.origin_watch, OriginWatch.UNWATCHED)
+        self.assertEqual(
+            row.origin_broker_reachability, OriginReachability.NOT_ADVERTISED
+        )
         self.assertEqual(row.origin_last_error, "")
 
     def test_the_global_broker_is_not_mistaken_for_a_centres_own(self):
@@ -475,20 +549,19 @@ class OriginReachabilityTests(OverviewTestCase):
 
         row = self.by_centre()["ke-meteo"]
 
-        self.assertEqual(row.origin_reachability, OriginReachability.NOT_ADVERTISED)
+        self.assertEqual(row.origin_watch, OriginWatch.UNWATCHED)
+        self.assertEqual(
+            row.origin_broker_reachability, OriginReachability.NOT_ADVERTISED
+        )
 
-    def test_each_centre_carries_its_own_brokers_state(self):
+    def test_each_centre_carries_its_own_state(self):
         origin_broker(self.node("ke-meteo"), is_reachable=True)
         origin_broker(self.node("dj-anm"), is_reachable=False)
 
         rows = self.by_centre()
 
-        self.assertEqual(
-            rows["ke-meteo"].origin_reachability, OriginReachability.REACHABLE
-        )
-        self.assertEqual(
-            rows["dj-anm"].origin_reachability, OriginReachability.UNREACHABLE
-        )
+        self.assertEqual(rows["ke-meteo"].origin_watch, OriginWatch.AT_BROKER)
+        self.assertEqual(rows["dj-anm"].origin_watch, OriginWatch.UNWATCHED)
 
 
 class CachePickupTests(OverviewTestCase):


### PR DESCRIPTION
Closes #56.

The pages that describe a centre said whether its own broker answers. Now that an archive can stand in for that broker (#55), that reading misled in both directions: a centre watched over HTTPS read as unwatched, and an operator seeing "origin unreachable" while propagation gaps piled up for the same centre would reasonably have concluded the tool was broken.

## What changed

**One origin state with three values** — `OriginWatch` in `core/analysis/reachability.py`: watched at the centre's broker, watched at its archive with no broker answering, not watched at all. The fallback is a state of its own rather than a second kind of green: the archive is polled precisely where the broker will not answer, and being visible another way does not excuse the obligation the centre is failing. It reads amber for the same reason.

Which state a centre is in is asked of `MessageSource.objects.watched_origins()` on both surfaces, rather than worked out from a broker's stored reachability. Reachability is only ever what the last attempt recorded, so a vantage point switched off carries an answer that has since gone stale — and a table calling a centre watched while the evaluation refuses to judge it is the contradiction that would cost both of them their credibility.

**The node overview**'s `Origin broker` column is now `Origin`, carrying the state badge with the centre's own broker standing on the line beneath it. Three centres are not watched at their broker — one whose broker refuses, one nothing has dialled yet, one that advertises no broker at all — and those are three conversations with three different people. It is also why the fallback says "no broker answering" rather than naming a broker: the archive is polled for centres that have never advertised one.

**The node detail page** describes whichever vantage point is in play, with its own address, last answer and last error. Somebody sent there by an archive-only badge is being asked about an HTTPS endpoint, and a broker's host and port would send them after the wrong thing.

**The propagation gap report** names the transport behind each finding, in a `Seen at` column and in the digest notice. The gap already recorded which source observed the notification, so this needed no schema change — and "we saw you publish this and the world did not" invites the obvious question of how we saw it, which is the first thing a national met service will ask of a finding sent to it by email.

## Acceptance criteria

- [x] The node overview shows one origin state distinguishing broker, archive fallback, and unwatched.
- [x] A node watched only through its archive is visibly not a node whose broker is answering.
- [x] The node detail page shows the same state, with the address and last error of whichever vantage point is in play.
- [x] The propagation gap report names the transport that observed each finding.
- [x] A node with no origin vantage at all remains distinguishable from both watched states.

## Testing

1030 tests pass. New coverage sits at the three analysis seams the repo already tests at — `test_overview`, `test_node_detail`, `test_gaps`. The three changed templates were rendered against a seeded database to confirm the badge classes and label wiring, with a throwaway test that was then removed; the repo has no view tests and this change did not seem the place to introduce the category.

## One deliberate deviation, worth a second opinion

The issue asks for one state with three values. The broker standing under the badge could be read as re-splitting that collapse. It is kept because dropping it loses "no broker advertised" and "not attempted yet" from the overview entirely — a catalogue finding and a tool state that the old column did show — and because it spends a detail line rather than a twelfth column, in the way the silence and cache columns already do. Happy to drop it if that reads as too much.
