### PR TITLE
Summarise the hourly rollups into station-days

### DIFF
--- a/wis2watch/src/wis2watch/config/settings/base.py
+++ b/wis2watch/src/wis2watch/config/settings/base.py
@@ -498,6 +498,14 @@ CELERY_BEAT_SCHEDULE = {
         'task': 'wis2watch.core.tasks.run_update_rollups',
         'schedule': 900.0,  # Every 15 minutes
     },
+    # On the same beat as the hourly rollups it summarises, because a day the
+    # statistics surfaces are reading should not be a quarter of an hour behind
+    # the hours under it. Rebuilding a three-day window is a thirtieth of the
+    # ninety days it saves those surfaces from reading.
+    'update-daily-rollups': {
+        'task': 'wis2watch.core.tasks.run_update_daily_rollups',
+        'schedule': 900.0,  # Every 15 minutes
+    },
     # A publishing rhythm is learned from months of buckets and moves in weeks,
     # so a daily run arrives at the same number a frequent one would.
     'learn-cadence-baselines': {

--- a/wis2watch/src/wis2watch/core/daily_rollups.py
+++ b/wis2watch/src/wis2watch/core/daily_rollups.py
@@ -1,0 +1,205 @@
+"""Summarising the hourly rollups into station-days.
+
+The statistics surfaces ask station questions over long windows -- how many of
+a centre's stations were heard in the last ninety days, which ones stopped and
+when, and where the dark days line up across the whole population. Every one of
+those is a count of distinct stations per day, and the hourly rollups are not
+shaped to answer it: their grain carries the dataset, which multiplies the rows
+a station question has to read while contributing nothing to the answer, and
+their bucket is an hour, which multiplies them again by twenty-four.
+
+So the days are summarised once and read many times. Dropping the dataset and
+collapsing the hour removes both multipliers, and what is left is exactly the
+shape the availability matrix wants: one row per station per day.
+
+Derived from the hourly rollups rather than from the raw messages. That is the
+decision the whole module turns on. Raw notifications are kept for a fortnight,
+so a day older than that could never be computed a second time -- the first run
+would have to be right for ever, and a run that was missed would leave a hole
+nothing could fill. The hourly rollups are never expired, so every day here can
+be rebuilt from them at any time, and a missed run costs a delay rather than a
+number.
+
+The objection to a third derived layer is that it disagrees with the second:
+the dashboard says 412 and the station list says 409. What answers it is that a
+day is a pure function of the hours under it and of nothing else, and that the
+window this recomputes is taken from the window the hourly run recomputes rather
+than chosen separately. The two layers can differ while a run is pending. They
+cannot differ because they counted differently.
+
+Buckets are UTC days, taken explicitly rather than left to the active timezone,
+for the same reason the hourly buckets are: a deployment configured for local
+time would otherwise put the whole region's day boundary in the wrong place and
+nothing would ever raise.
+"""
+
+import logging
+from dataclasses import dataclass
+from datetime import timedelta, timezone
+from math import ceil
+
+from django.conf import settings
+from django.db.models import Count, Min, Sum
+from django.db.models.functions import TruncDay
+from django.utils import timezone as dj_timezone
+
+from .models import DAILY_STATION_GRAIN, DailyStationRollup, HourlyRollup
+from .rollups import default_window_hours
+
+logger = logging.getLogger(__name__)
+
+#: How much history a backfill rebuilds at a time. Days rather than rows,
+#: because a day is the unit that has to be rebuilt whole.
+DEFAULT_CHUNK_DAYS = 30
+
+#: The grain, as the columns an hourly rollup carries it in. Derived from the
+#: daily grain rather than restated, so the group the query counts by and the
+#: key the row is written under cannot drift apart.
+GROUP_BY = tuple(
+    field if field == "day" else f"{field}_id" for field in DAILY_STATION_GRAIN
+)
+
+
+@dataclass
+class DailyCounts:
+    """What a daily rollup run came to."""
+
+    rows: int = 0
+    messages: int = 0
+
+    @property
+    def summary(self):
+        """What the run came to, in one line, for a log."""
+        return f"rows={self.rows} messages={self.messages}"
+
+
+def floor_to_day(moment):
+    """The start of the UTC day a moment falls in."""
+    return moment.astimezone(timezone.utc).replace(
+        hour=0, minute=0, second=0, microsecond=0
+    )
+
+
+def default_window_days():
+    """How far back a scheduled run recomputes, unless told otherwise.
+
+    Taken from the hourly window rather than set beside it. Any hour the hourly
+    run can still revise has to fall inside a day this run still visits, or the
+    daily table goes on holding a number the hourly table has already corrected
+    -- and holds it for ever, because nothing would ever come back to that day.
+
+    One day wider than the hourly window converts to, because the window starts
+    part-way through a day: forty-eight hours back from half past midnight
+    reaches into the day before last.
+    """
+    configured = getattr(settings, "WIS2WATCH_DAILY_ROLLUP_WINDOW_DAYS", None)
+
+    if configured is not None:
+        return configured
+
+    return ceil(default_window_hours() / 24) + 1
+
+
+def rollup_days(*, since, until):
+    """Rebuild the daily rollups for every hour in ``[since, until)``.
+
+    ``since`` is taken down to the day it falls in, because a day is only ever
+    rebuilt whole. Summarising from part-way through one would overwrite a
+    complete day with the fraction of it that happened to be in the window --
+    a smaller number that nothing downstream would have any reason to doubt.
+
+    ``until`` is deliberately not rounded the same way. The day in progress is
+    genuinely partial and has to be written as far as it has got; the callers
+    here pass either the present instant or a day boundary, and nothing else
+    should pass a mid-day instant in the past, which would write a whole day
+    short.
+
+    Nothing is deleted. An hourly rollup is never expired and never falls to
+    zero, so a group that existed on the last run still exists on this one; the
+    only thing a rebuild can do is change what a day's numbers say.
+    """
+    since = floor_to_day(since)
+
+    counted = (
+        HourlyRollup.objects.filter(hour__gte=since, hour__lt=until)
+        .annotate(day=TruncDay("hour", tzinfo=timezone.utc))
+        .values(*GROUP_BY)
+        .annotate(
+            message_count=Sum("message_count"),
+            # Distinct hours rather than rows: a node publishing many datasets
+            # writes several rows for one hour, and counting those would read
+            # as a station reporting round the clock.
+            active_hours=Count("hour", distinct=True),
+        )
+        .order_by()
+    )
+
+    # Each counted group already names its grain in the columns a daily rollup
+    # is written with, so it becomes a row as it stands.
+    rollups = [DailyStationRollup(**row) for row in counted.iterator()]
+
+    if rollups:
+        DailyStationRollup.objects.bulk_create(
+            rollups,
+            batch_size=1000,
+            update_conflicts=True,
+            unique_fields=list(DAILY_STATION_GRAIN),
+            update_fields=["message_count", "active_hours"],
+        )
+
+    return DailyCounts(
+        rows=len(rollups),
+        messages=sum(rollup.message_count for rollup in rollups),
+    )
+
+
+def update_daily_rollups(*, now=None, window_days=None):
+    """Rebuild the trailing window, as the scheduled run does.
+
+    The two settled days in the window are rebuilt every run and almost always
+    come to the same numbers, which is waste on the face of it. It is the price
+    of the guarantee: those are precisely the days the hourly run can still
+    correct, and a run that skipped them would be cheap and sometimes wrong.
+    """
+    now = now or dj_timezone.now()
+    days = default_window_days() if window_days is None else window_days
+
+    return rollup_days(
+        since=floor_to_day(now) - timedelta(days=days - 1),
+        until=now,
+    )
+
+
+def backfill_daily_rollups(*, now=None, chunk_days=DEFAULT_CHUNK_DAYS):
+    """Rebuild every day the hourly rollups reach back to.
+
+    For the first run, when the table is empty and the region already has a
+    history, and for any time the summary has to be rebuilt from scratch -- it
+    can be, which is the point of deriving from a table that never expires.
+
+    Walked in chunks rather than in one query because the whole of a region's
+    hourly history is not a thing to group in memory at once. Chunk boundaries
+    fall on day boundaries, so no day is ever summarised from half its hours.
+    """
+    oldest = HourlyRollup.objects.aggregate(oldest=Min("hour"))["oldest"]
+
+    if oldest is None:
+        return DailyCounts()
+
+    now = now or dj_timezone.now()
+    counts = DailyCounts()
+
+    start = floor_to_day(oldest)
+    end = floor_to_day(now) + timedelta(days=1)
+
+    while start < end:
+        stop = min(start + timedelta(days=chunk_days), end)
+        chunk = rollup_days(since=start, until=stop)
+
+        counts.rows += chunk.rows
+        counts.messages += chunk.messages
+        start = stop
+
+    logger.info("Backfilled daily station rollups from %s: %s", oldest, counts.summary)
+
+    return counts

--- a/wis2watch/src/wis2watch/core/daily_rollups.py
+++ b/wis2watch/src/wis2watch/core/daily_rollups.py
@@ -34,17 +34,15 @@ nothing would ever raise.
 """
 
 import logging
-from dataclasses import dataclass
 from datetime import timedelta, timezone
 from math import ceil
 
-from django.conf import settings
 from django.db.models import Count, Min, Sum
 from django.db.models.functions import TruncDay
 from django.utils import timezone as dj_timezone
 
 from .models import DAILY_STATION_GRAIN, DailyStationRollup, HourlyRollup
-from .rollups import default_window_hours
+from .rollups import RollupCounts, default_window_hours, grain_columns
 
 logger = logging.getLogger(__name__)
 
@@ -52,25 +50,8 @@ logger = logging.getLogger(__name__)
 #: because a day is the unit that has to be rebuilt whole.
 DEFAULT_CHUNK_DAYS = 30
 
-#: The grain, as the columns an hourly rollup carries it in. Derived from the
-#: daily grain rather than restated, so the group the query counts by and the
-#: key the row is written under cannot drift apart.
-GROUP_BY = tuple(
-    field if field == "day" else f"{field}_id" for field in DAILY_STATION_GRAIN
-)
-
-
-@dataclass
-class DailyCounts:
-    """What a daily rollup run came to."""
-
-    rows: int = 0
-    messages: int = 0
-
-    @property
-    def summary(self):
-        """What the run came to, in one line, for a log."""
-        return f"rows={self.rows} messages={self.messages}"
+#: The grain, as the columns an hourly rollup carries it in.
+DAILY_GROUP_BY = grain_columns(DAILY_STATION_GRAIN, "day")
 
 
 def floor_to_day(moment):
@@ -81,27 +62,26 @@ def floor_to_day(moment):
 
 
 def default_window_days():
-    """How far back a scheduled run recomputes, unless told otherwise.
+    """How far back a scheduled run recomputes.
 
-    Taken from the hourly window rather than set beside it. Any hour the hourly
-    run can still revise has to fall inside a day this run still visits, or the
-    daily table goes on holding a number the hourly table has already corrected
-    -- and holds it for ever, because nothing would ever come back to that day.
+    Taken from the hourly window rather than set beside it, and deliberately
+    not settable on its own. Any hour the hourly run can still revise has to
+    fall inside a day this run still visits, or the daily table goes on holding
+    a number the hourly table has already corrected -- and holds it for ever,
+    because nothing would ever come back to that day. A knob of its own would
+    be a knob for turning that guarantee off, with nothing to say it had been:
+    the numbers would not be missing, they would be old. Widening the hourly
+    window widens this one with it, which is the only change that makes sense.
 
     One day wider than the hourly window converts to, because the window starts
     part-way through a day: forty-eight hours back from half past midnight
     reaches into the day before last.
     """
-    configured = getattr(settings, "WIS2WATCH_DAILY_ROLLUP_WINDOW_DAYS", None)
-
-    if configured is not None:
-        return configured
-
     return ceil(default_window_hours() / 24) + 1
 
 
 def rollup_days(*, since, until):
-    """Rebuild the daily rollups for every hour in ``[since, until)``.
+    """Rebuild the daily rollups from the hours counted in ``[since, until)``.
 
     ``since`` is taken down to the day it falls in, because a day is only ever
     rebuilt whole. Summarising from part-way through one would overwrite a
@@ -123,7 +103,7 @@ def rollup_days(*, since, until):
     counted = (
         HourlyRollup.objects.filter(hour__gte=since, hour__lt=until)
         .annotate(day=TruncDay("hour", tzinfo=timezone.utc))
-        .values(*GROUP_BY)
+        .values(*DAILY_GROUP_BY)
         .annotate(
             message_count=Sum("message_count"),
             # Distinct hours rather than rows: a node publishing many datasets
@@ -136,7 +116,7 @@ def rollup_days(*, since, until):
 
     # Each counted group already names its grain in the columns a daily rollup
     # is written with, so it becomes a row as it stands.
-    rollups = [DailyStationRollup(**row) for row in counted.iterator()]
+    rollups = [DailyStationRollup(**row) for row in counted]
 
     if rollups:
         DailyStationRollup.objects.bulk_create(
@@ -147,7 +127,7 @@ def rollup_days(*, since, until):
             update_fields=["message_count", "active_hours"],
         )
 
-    return DailyCounts(
+    return RollupCounts(
         rows=len(rollups),
         messages=sum(rollup.message_count for rollup in rollups),
     )
@@ -184,10 +164,10 @@ def backfill_daily_rollups(*, now=None, chunk_days=DEFAULT_CHUNK_DAYS):
     oldest = HourlyRollup.objects.aggregate(oldest=Min("hour"))["oldest"]
 
     if oldest is None:
-        return DailyCounts()
+        return RollupCounts()
 
     now = now or dj_timezone.now()
-    counts = DailyCounts()
+    counts = RollupCounts()
 
     start = floor_to_day(oldest)
     end = floor_to_day(now) + timedelta(days=1)

--- a/wis2watch/src/wis2watch/core/management/commands/backfill_daily_rollups.py
+++ b/wis2watch/src/wis2watch/core/management/commands/backfill_daily_rollups.py
@@ -1,0 +1,35 @@
+"""Summarise every day the hourly rollups reach back to.
+
+The scheduled run only rebuilds a trailing window, which is right for keeping
+up and useless for catching up: an installation that already has a history has
+none of it summarised until something walks the whole of it once. This is that
+walk -- after the migration, and any time the summary has to be rebuilt from
+scratch, which it always can be.
+"""
+
+from django.core.management.base import BaseCommand
+
+from wis2watch.core.daily_rollups import DEFAULT_CHUNK_DAYS, backfill_daily_rollups
+
+
+class Command(BaseCommand):
+    help = "Rebuild the daily station rollups from the whole hourly history"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--chunk-days",
+            type=int,
+            default=DEFAULT_CHUNK_DAYS,
+            help=(
+                "How many days to rebuild per query. Lower it if the region's "
+                "history is wide enough that a month at a time is too much to "
+                "group at once."
+            ),
+        )
+
+    def handle(self, *args, **options):
+        counts = backfill_daily_rollups(chunk_days=options["chunk_days"])
+
+        self.stdout.write(
+            self.style.SUCCESS(f"Daily station rollups: {counts.summary}")
+        )

--- a/wis2watch/src/wis2watch/core/management/commands/backfill_daily_rollups.py
+++ b/wis2watch/src/wis2watch/core/management/commands/backfill_daily_rollups.py
@@ -2,9 +2,10 @@
 
 The scheduled run only rebuilds a trailing window, which is right for keeping
 up and useless for catching up: an installation that already has a history has
-none of it summarised until something walks the whole of it once. This is that
-walk -- after the migration, and any time the summary has to be rebuilt from
-scratch, which it always can be.
+none of it summarised until something walks the whole of it once. The migration
+does that walk on the way in; this is for doing it again -- if the migration was
+interrupted, or the summary has to be rebuilt from scratch, which it always can
+be, because it is derived from a table that is never expired.
 """
 
 from django.core.management.base import BaseCommand

--- a/wis2watch/src/wis2watch/core/migrations/0018_a_days_worth_of_stations.py
+++ b/wis2watch/src/wis2watch/core/migrations/0018_a_days_worth_of_stations.py
@@ -1,0 +1,81 @@
+"""Summarise the hourly rollups into station-days, and index for the station.
+
+The statistics surfaces ask how many of a centre's stations were heard over
+ninety days, and which of them stopped. The hourly grain carries the dataset,
+which multiplies the rows such a question reads without answering any of it.
+This adds the summary those questions are read from -- see
+wis2watch.core.daily_rollups for why it is derived from the hourly rollups
+rather than from the raw messages.
+
+The hourly table's ``(node, -hour)`` index is replaced by ``(node, -hour,
+station)`` rather than joined by it. The new one leads on the same two columns,
+so everything that walked the old one walks this instead, and carrying the
+station means a node's stations over a window are read without a heap fetch per
+row. On a table with real history behind it this is an index build, not a
+metadata change.
+"""
+
+import django.db.models.deletion
+import django_extensions.db.fields
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('wis2watchcore', '0017_ask_a_centre_for_the_messages_it_published'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='DailyStationRollup',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('created', django_extensions.db.fields.CreationDateTimeField(auto_now_add=True, verbose_name='created')),
+                ('modified', django_extensions.db.fields.ModificationDateTimeField(auto_now=True, verbose_name='modified')),
+                ('day', models.DateTimeField(db_index=True, help_text='Start of the UTC day this count covers')),
+                ('message_count', models.PositiveIntegerField(default=0)),
+                ('active_hours', models.PositiveSmallIntegerField(default=0, help_text="How many of the day's 24 UTC hours this station was heard in")),
+            ],
+            options={
+                'verbose_name': 'Daily Station Rollup',
+                'verbose_name_plural': 'Daily Station Rollups',
+                'ordering': ['-day'],
+            },
+        ),
+        migrations.RemoveIndex(
+            model_name='hourlyrollup',
+            name='wis2watchco_node_id_801c17_idx',
+        ),
+        migrations.AddIndex(
+            model_name='hourlyrollup',
+            index=models.Index(fields=['node', '-hour', 'station'], name='wis2watchco_node_id_cef16d_idx'),
+        ),
+        migrations.AddIndex(
+            model_name='hourlyrollup',
+            index=models.Index(fields=['station', '-hour'], name='wis2watchco_station_293705_idx'),
+        ),
+        migrations.AddField(
+            model_name='dailystationrollup',
+            name='node',
+            field=models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='daily_rollups', to='wis2watchcore.wis2node'),
+        ),
+        migrations.AddField(
+            model_name='dailystationrollup',
+            name='source',
+            field=models.ForeignKey(help_text='The vantage point these messages were observed from', on_delete=django.db.models.deletion.CASCADE, related_name='daily_rollups', to='wis2watchcore.messagesource'),
+        ),
+        migrations.AddField(
+            model_name='dailystationrollup',
+            name='station',
+            field=models.ForeignKey(blank=True, help_text='Null for messages carrying no known station', null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='daily_rollups', to='wis2watchcore.station'),
+        ),
+        migrations.AddIndex(
+            model_name='dailystationrollup',
+            index=models.Index(fields=['node', '-day', 'station'], name='wis2watchco_node_id_826eec_idx'),
+        ),
+        migrations.AddConstraint(
+            model_name='dailystationrollup',
+            constraint=models.UniqueConstraint(fields=('day', 'source', 'node', 'station'), name='unique_daily_station_rollup', nulls_distinct=False),
+        ),
+    ]

--- a/wis2watch/src/wis2watch/core/migrations/0018_a_days_worth_of_stations.py
+++ b/wis2watch/src/wis2watch/core/migrations/0018_a_days_worth_of_stations.py
@@ -10,9 +10,13 @@ rather than from the raw messages.
 The hourly table's ``(node, -hour)`` index is replaced by ``(node, -hour,
 station)`` rather than joined by it. The new one leads on the same two columns,
 so everything that walked the old one walks this instead, and carrying the
-station means a node's stations over a window are read without a heap fetch per
-row. On a table with real history behind it this is an index build, not a
-metadata change.
+station means a node's stations over a window are read off the index. On a
+table with real history behind it this is an index build, not a metadata
+change.
+
+The summary itself is filled by the migration after this one, which is separate
+so that the schema change can be applied and inspected without waiting on a
+walk of the region's whole history.
 """
 
 import django.db.models.deletion
@@ -50,10 +54,6 @@ class Migration(migrations.Migration):
         migrations.AddIndex(
             model_name='hourlyrollup',
             index=models.Index(fields=['node', '-hour', 'station'], name='wis2watchco_node_id_cef16d_idx'),
-        ),
-        migrations.AddIndex(
-            model_name='hourlyrollup',
-            index=models.Index(fields=['station', '-hour'], name='wis2watchco_station_293705_idx'),
         ),
         migrations.AddField(
             model_name='dailystationrollup',

--- a/wis2watch/src/wis2watch/core/migrations/0019_summarise_the_history_already_held.py
+++ b/wis2watch/src/wis2watch/core/migrations/0019_summarise_the_history_already_held.py
@@ -1,0 +1,50 @@
+"""Fill the station-day summary from the history the region already holds.
+
+Without this the table arrives empty and the scheduled run only ever rebuilds
+its trailing window, so an installation with two years of hourly rollups behind
+it would show three days of station history and no sign that the rest existed
+-- the numbers would not be missing, they would be small. Every surface reading
+this table is about what a centre was doing over months.
+
+Calls the derivation directly rather than reimplementing it against the
+historical models, which is the usual caution here and is not worth its cost in
+this one case: on a fresh database there are no hourly rollups to summarise and
+this does nothing at all, so the only installations it does work on are the
+ones already running the code it calls. Reimplementing the grouping would mean
+two derivations of the same numbers, which is the exact failure the summary is
+built to avoid.
+
+Reversing drops what it wrote. The summary is derived, so nothing is lost that
+``backfill_daily_rollups`` cannot put back -- which is also how to re-run this
+by hand if it is interrupted.
+
+Not atomic, so each thirty-day chunk commits as it is summarised rather than
+the region's whole history being held open in one transaction against a
+database that is also serving ingestion. What that costs is the possibility of
+stopping half done, which costs nothing here: the walk is an upsert per day and
+running it again from the beginning arrives at the same table.
+"""
+
+from django.db import migrations
+
+
+def summarise_history(apps, schema_editor):
+    from wis2watch.core.daily_rollups import backfill_daily_rollups
+
+    backfill_daily_rollups()
+
+
+def drop_summary(apps, schema_editor):
+    apps.get_model("wis2watchcore", "DailyStationRollup").objects.all().delete()
+
+
+class Migration(migrations.Migration):
+    atomic = False
+
+    dependencies = [
+        ("wis2watchcore", "0018_a_days_worth_of_stations"),
+    ]
+
+    operations = [
+        migrations.RunPython(summarise_history, drop_summary),
+    ]

--- a/wis2watch/src/wis2watch/core/models.py
+++ b/wis2watch/src/wis2watch/core/models.py
@@ -1049,23 +1049,25 @@ class HourlyRollup(TimeStampedModel):
         indexes = [
             # The station rides along on the node's index rather than earning
             # one of its own. Everything asked of a node over a range of hours
-            # -- what it published, and which of its stations were heard --
-            # filters on the node and the hour first, so those stay the leading
-            # columns; carrying the station as well turns "every station of this
-            # node over the last 24 hours" into a scan of the index alone,
-            # without a heap fetch per row to find out which station it was.
-            # A strict extension of the plain ``(node, -hour)`` this replaced,
-            # so nothing that used to walk that walks anything longer now.
+            # -- what it published, which of its stations were heard, and one
+            # named station's own hours -- filters on the node and the hour
+            # first, so those stay the leading columns; carrying the station as
+            # well means those answers are read off the index rather than
+            # fetching every row to find out which station it was. A strict
+            # extension of the plain ``(node, -hour)`` this replaced, so nothing
+            # that used to walk that walks anything longer now.
+            #
+            # Nothing leads on the station. Reading one station across every
+            # centre would want that, and a station transmitting under two
+            # centres is a real finding -- but it is not a surface anything
+            # asks for yet, and this table is never expired, so an index it
+            # does not need is a cost it pays on every write for ever.
             models.Index(fields=["node", "-hour", "station"]),
             # "When did this dataset last publish" is asked of every dataset in
             # the region at once, every time the overview is opened. Leading on
             # the dataset makes each of those answers one backwards walk of
             # this index rather than a scan of the node's whole history.
             models.Index(fields=["dataset", "-hour"]),
-            # One station's own history, which is what a drilldown asks for and
-            # what nothing here could answer without reading a whole node's
-            # hours and discarding all but one station's worth.
-            models.Index(fields=["station", "-hour"]),
         ]
         verbose_name = _("Hourly Rollup")
         verbose_name_plural = _("Hourly Rollups")
@@ -1114,6 +1116,15 @@ class DailyStationRollup(TimeStampedModel):
     in the hourly rollups. Whether the statistics surfaces say anything about
     them is undecided; dropping them at this layer would decide it by making
     the question unanswerable.
+
+    Unpartitioned and never expired, like the hourly rollups it summarises,
+    and so growing for ever on the same terms -- but an order of magnitude
+    slower. A row is earned per station per day per vantage point, where the
+    hourly table earns one per station per dataset per hour per vantage point,
+    so a centre publishing a handful of datasets writes tens of hourly rows for
+    every one here. Whether either table eventually wants partitioning or a
+    horizon is a question about both of them together, and is not settled by
+    adding this one.
     """
 
     day = models.DateTimeField(
@@ -1141,6 +1152,11 @@ class DailyStationRollup(TimeStampedModel):
     )
 
     message_count = models.PositiveIntegerField(default=0)
+    # How much of the day, as against how loudly. A cell saying only "reported"
+    # cannot tell a station sending once from one sending every hour, and which
+    # of those a day was is most of what an availability matrix is read for.
+    # Carried here because it costs nothing to derive -- the hours are already
+    # the group -- and cannot be recovered from a message count afterwards.
     active_hours = models.PositiveSmallIntegerField(
         default=0,
         help_text=_("How many of the day's 24 UTC hours this station was heard in"),
@@ -1162,8 +1178,11 @@ class DailyStationRollup(TimeStampedModel):
             # A node's whole station population over a range of days: the
             # availability matrix, and the count of distinct stations behind
             # every headline figure. Leading on the node and the day makes the
-            # window a contiguous range, and carrying the station means the
-            # answer never leaves the index.
+            # window a contiguous range, and carrying the station means settled
+            # history is read off the index alone. The last few days are rebuilt
+            # every quarter of an hour, so those pages are rarely all-visible
+            # and are read from the table until a vacuum catches up -- which is
+            # the smallest part of any window this exists to serve.
             models.Index(fields=["node", "-day", "station"]),
         ]
         verbose_name = _("Daily Station Rollup")

--- a/wis2watch/src/wis2watch/core/models.py
+++ b/wis2watch/src/wis2watch/core/models.py
@@ -1047,18 +1047,130 @@ class HourlyRollup(TimeStampedModel):
             ),
         ]
         indexes = [
-            models.Index(fields=["node", "-hour"]),
+            # The station rides along on the node's index rather than earning
+            # one of its own. Everything asked of a node over a range of hours
+            # -- what it published, and which of its stations were heard --
+            # filters on the node and the hour first, so those stay the leading
+            # columns; carrying the station as well turns "every station of this
+            # node over the last 24 hours" into a scan of the index alone,
+            # without a heap fetch per row to find out which station it was.
+            # A strict extension of the plain ``(node, -hour)`` this replaced,
+            # so nothing that used to walk that walks anything longer now.
+            models.Index(fields=["node", "-hour", "station"]),
             # "When did this dataset last publish" is asked of every dataset in
             # the region at once, every time the overview is opened. Leading on
             # the dataset makes each of those answers one backwards walk of
             # this index rather than a scan of the node's whole history.
             models.Index(fields=["dataset", "-hour"]),
+            # One station's own history, which is what a drilldown asks for and
+            # what nothing here could answer without reading a whole node's
+            # hours and discarding all but one station's worth.
+            models.Index(fields=["station", "-hour"]),
         ]
         verbose_name = _("Hourly Rollup")
         verbose_name_plural = _("Hourly Rollups")
 
     def __str__(self):
         return f"{self.node_id} @ {self.hour}: {self.message_count}"
+
+
+#: What a daily station rollup counts separately. Named here for the same
+#: reason ``ROLLUP_GRAIN`` is: the constraint that keeps a bucket unique and the
+#: query that derives it live in different modules and have to agree.
+DAILY_STATION_GRAIN = ("day", "source", "node", "station")
+
+
+class DailyStationRollup(TimeStampedModel):
+    """Which stations of a node were heard on one UTC day, and how much.
+
+    A summary of :class:`HourlyRollup`, kept because the questions the
+    statistics surfaces ask are station questions over long windows, and the
+    hourly table is not shaped for them. Counting the distinct stations a node
+    was heard from over ninety days means reading every hour of those days for
+    every dataset the node publishes -- the dataset multiplies the rows and
+    contributes nothing to the answer. Collapsing the day and dropping the
+    dataset removes both multipliers at once.
+
+    The dataset is dropped rather than kept because no station question is
+    asked per dataset. The one place the breakdown is wanted -- a single
+    station's drilldown -- is narrow enough to go back to the hourly rows,
+    which now carry an index for exactly that.
+
+    The source is kept, for the same reason the hourly grain keeps it: the same
+    notification seen at a centre's own broker and at the Global Broker is two
+    rows on purpose, and summing them would double every number. Reading is
+    where a vantage point gets chosen -- distinct-station counts take all of
+    them and let ``DISTINCT`` absorb the overlap, message volumes filter to the
+    Global Broker.
+
+    Derived from the hourly rollups rather than from the raw messages, which is
+    what makes the history reachable at all: raw notifications expire after a
+    fortnight, so a day older than that could never be computed a second time.
+    Every day here is a pure function of hourly rows that are never expired, so
+    any day can be rebuilt at any time and a run that was missed costs nothing
+    but the delay.
+
+    Messages carrying no known station keep their own bucket here, as they do
+    in the hourly rollups. Whether the statistics surfaces say anything about
+    them is undecided; dropping them at this layer would decide it by making
+    the question unanswerable.
+    """
+
+    day = models.DateTimeField(
+        db_index=True,
+        help_text=_("Start of the UTC day this count covers"),
+    )
+    source = models.ForeignKey(
+        MessageSource,
+        on_delete=models.CASCADE,
+        related_name="daily_rollups",
+        help_text=_("The vantage point these messages were observed from"),
+    )
+    node = models.ForeignKey(
+        WIS2Node,
+        on_delete=models.CASCADE,
+        related_name="daily_rollups",
+    )
+    station = models.ForeignKey(
+        Station,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="daily_rollups",
+        help_text=_("Null for messages carrying no known station"),
+    )
+
+    message_count = models.PositiveIntegerField(default=0)
+    active_hours = models.PositiveSmallIntegerField(
+        default=0,
+        help_text=_("How many of the day's 24 UTC hours this station was heard in"),
+    )
+
+    class Meta:
+        ordering = ["-day"]
+        constraints = [
+            # ``nulls_distinct=False`` for the same reason the hourly grain
+            # needs it: a station of None is a real bucket, and Postgres's
+            # default would let it be inserted twice over.
+            models.UniqueConstraint(
+                fields=DAILY_STATION_GRAIN,
+                name="unique_daily_station_rollup",
+                nulls_distinct=False,
+            ),
+        ]
+        indexes = [
+            # A node's whole station population over a range of days: the
+            # availability matrix, and the count of distinct stations behind
+            # every headline figure. Leading on the node and the day makes the
+            # window a contiguous range, and carrying the station means the
+            # answer never leaves the index.
+            models.Index(fields=["node", "-day", "station"]),
+        ]
+        verbose_name = _("Daily Station Rollup")
+        verbose_name_plural = _("Daily Station Rollups")
+
+    def __str__(self):
+        return f"{self.node_id}/{self.station_id} @ {self.day}: {self.message_count}"
 
 
 class CadenceBaseline(models.Model):

--- a/wis2watch/src/wis2watch/core/rollups.py
+++ b/wis2watch/src/wis2watch/core/rollups.py
@@ -43,12 +43,19 @@ logger = logging.getLogger(__name__)
 #: is still corrected after a run is missed, narrow enough to stay cheap.
 DEFAULT_WINDOW_HOURS = 48
 
-#: The grain, as the columns a message carries it in. Derived from the rollup's
-#: own grain rather than restated, so the group the query counts by and the key
-#: the row is written under cannot drift apart.
-GROUP_BY = tuple(
-    field if field == "hour" else f"{field}_id" for field in ROLLUP_GRAIN
-)
+def grain_columns(grain, bucket):
+    """A grain, as the columns the table it is derived from carries it in.
+
+    Derived from the grain rather than restated beside it, so the group a query
+    counts by and the key its row is written under cannot drift apart. Every
+    part of a grain but the time bucket is a relation, and so is read and
+    written under its ``_id``.
+    """
+    return tuple(field if field == bucket else f"{field}_id" for field in grain)
+
+
+#: The grain, as the columns a message carries it in.
+GROUP_BY = grain_columns(ROLLUP_GRAIN, "hour")
 
 
 @dataclass

--- a/wis2watch/src/wis2watch/core/tasks.py
+++ b/wis2watch/src/wis2watch/core/tasks.py
@@ -10,6 +10,7 @@ from wis2watch.config.celery import app
 from .alerts import check_hard_failures
 from .cadence import learn_cadence_baselines
 from .catalogue import sync_catalogues
+from .daily_rollups import update_daily_rollups
 from .digest import send_digest
 from .node_stations import sync_node_stations
 from .oscar import sync_oscar_stations
@@ -127,6 +128,23 @@ def run_update_rollups():
     counts = update_rollups()
 
     logger.info("[ROLLUPS] %s", counts.summary)
+
+    return counts.summary
+
+
+@shared_task
+def run_update_daily_rollups():
+    """Summarise the recent hourly rollups into station-days.
+
+    Not chained to the hourly run, and not required to follow it. Both rebuild
+    a trailing window rather than adding to one, and this window is taken from
+    the hourly window's length, so a run that goes first reads slightly older
+    hours and the next run corrects the day it wrote. Coupling them would only
+    mean one failure took out both.
+    """
+    counts = update_daily_rollups()
+
+    logger.info("[DAILY ROLLUPS] %s", counts.summary)
 
     return counts.summary
 

--- a/wis2watch/src/wis2watch/core/tests/test_daily_rollups.py
+++ b/wis2watch/src/wis2watch/core/tests/test_daily_rollups.py
@@ -1,0 +1,500 @@
+"""Summarising the hourly rollups into station-days, against a seeded database.
+
+The daily rollups are a second derived layer, and the risk a second layer
+carries is that it disagrees with the first -- the dashboard saying 412 while
+the station list says 409. So the guarantee these tests are here to hold is
+narrower than "the numbers look right": a day is a pure function of the hours
+under it, and rebuilding it from those hours is always allowed to change the
+answer and never allowed to keep a stale one.
+
+The day boundary and the timezone are called out separately for the same reason
+the hourly tests call out the hour boundary: an off-by-one day loses a day at
+the edge of every window, while a date_trunc that follows the active timezone
+shifts every bucket in the region and nothing raises.
+"""
+
+from datetime import timedelta
+
+from django.conf import settings
+from django.db import IntegrityError
+from django.test import SimpleTestCase, TestCase, override_settings
+
+from wis2watch.core.daily_rollups import (
+    backfill_daily_rollups,
+    default_window_days,
+    rollup_days,
+    update_daily_rollups,
+)
+from wis2watch.core.models import (
+    Dataset,
+    DailyStationRollup,
+    HourlyRollup,
+    MessageSource,
+    NotificationMessage,
+    Station,
+    WIS2Node,
+)
+from wis2watch.core.rollups import rollup_hours
+from wis2watch.core.tasks import run_update_daily_rollups
+from wis2watch.core.tests.support import at
+
+
+class DailyRollupTestCase(TestCase):
+    def setUp(self):
+        self.source = MessageSource.objects.create(
+            name="Global Broker",
+            source_type=MessageSource.GLOBAL_BROKER,
+            host="globalbroker.example.int",
+        )
+        self.node = WIS2Node.objects.create(centre_id="ke-meteo", name="Kenya Met")
+
+    def counted(self, when, count=1, node=None, dataset=None, station=None, source=None):
+        """One hourly rollup, as a rollup run would have left it."""
+        return HourlyRollup.objects.create(
+            hour=at(when) if isinstance(when, str) else when,
+            source=source or self.source,
+            node=node or self.node,
+            dataset=dataset,
+            station=station,
+            message_count=count,
+        )
+
+    def dataset(self, identifier="urn:wmo:md:ke-meteo:synop"):
+        return Dataset.objects.create(
+            node=self.node,
+            identifier=identifier,
+            title=identifier,
+            wmo_data_policy="core",
+            wmo_topic_hierarchy=f"origin/a/wis2/ke-meteo/{identifier}",
+            raw_json={},
+        )
+
+    def roll(self, since="2026-08-01T00:00:00", until="2026-09-01T00:00:00"):
+        return rollup_days(since=at(since), until=at(until))
+
+    def days(self):
+        """The days rolled up, with their counts, in order."""
+        return [
+            (row.day.isoformat(), row.message_count)
+            for row in DailyStationRollup.objects.order_by("day")
+        ]
+
+
+class ScheduleTests(SimpleTestCase):
+    """That the beat actually reaches the summary.
+
+    A schedule naming a task that does not exist announces itself nowhere:
+    nothing runs, nothing is logged, and the statistics surfaces go on reading
+    a table that stopped being brought up to date. Worse here than most,
+    because the numbers would not be missing -- they would be old.
+    """
+
+    def setUp(self):
+        self.entry = settings.CELERY_BEAT_SCHEDULE["update-daily-rollups"]
+
+    def test_the_scheduled_task_is_the_one_that_answers_to_that_name(self):
+        self.assertEqual(self.entry["task"], run_update_daily_rollups.name)
+
+    def test_it_runs_on_the_same_beat_as_the_hours_it_summarises(self):
+        """A day the surfaces are reading should not lag the hours under it."""
+        self.assertEqual(
+            self.entry["schedule"],
+            settings.CELERY_BEAT_SCHEDULE["update-rollups"]["schedule"],
+        )
+
+
+class DayBucketTests(DailyRollupTestCase):
+    """Which day an hour falls in, in UTC."""
+
+    def test_hours_of_one_day_become_one_row(self):
+        self.counted("2026-08-11T00:00:00")
+        self.counted("2026-08-11T10:00:00", count=5)
+        self.counted("2026-08-11T23:00:00", count=2)
+
+        self.roll()
+
+        self.assertEqual(self.days(), [("2026-08-11T00:00:00+00:00", 8)])
+
+    def test_a_day_boundary_separates_two_adjacent_hours(self):
+        self.counted("2026-08-11T23:00:00")
+        self.counted("2026-08-12T00:00:00")
+
+        self.roll()
+
+        self.assertEqual(
+            self.days(),
+            [("2026-08-11T00:00:00+00:00", 1), ("2026-08-12T00:00:00+00:00", 1)],
+        )
+
+    @override_settings(TIME_ZONE="Asia/Kolkata")
+    def test_buckets_are_UTC_days_whatever_the_configured_timezone(self):
+        """A deployment's own timezone must not decide where a day starts.
+
+        Half an hour off UTC, for the same reason the hourly tests pick it: a
+        whole-hour offset still lands the day boundary somewhere a wrong bucket
+        is easy to miss, and this one cannot be read as anything else.
+        """
+        self.counted("2026-08-11T20:00:00")
+        self.counted("2026-08-11T23:00:00")
+
+        self.roll()
+
+        self.assertEqual(self.days(), [("2026-08-11T00:00:00+00:00", 2)])
+
+    def test_only_the_requested_window_is_rolled_up(self):
+        self.counted("2026-08-10T23:00:00")
+        self.counted("2026-08-11T10:00:00")
+        self.counted("2026-08-13T00:00:00")
+
+        self.roll(since="2026-08-11T00:00:00", until="2026-08-13T00:00:00")
+
+        self.assertEqual(self.days(), [("2026-08-11T00:00:00+00:00", 1)])
+
+    def test_a_window_starting_mid_day_still_rebuilds_the_whole_day(self):
+        """A half-counted day would overwrite a complete one with a smaller
+        number, which is the one failure this layer must not have."""
+        self.counted("2026-08-11T02:00:00")
+        self.counted("2026-08-11T20:00:00")
+
+        rollup_days(since=at("2026-08-11T12:00:00"), until=at("2026-08-12T00:00:00"))
+
+        self.assertEqual(self.days(), [("2026-08-11T00:00:00+00:00", 2)])
+
+
+class DailyGrainTests(DailyRollupTestCase):
+    """What a daily rollup counts separately, and what it deliberately does not."""
+
+    def grains(self):
+        return {
+            (row.node_id, row.station_id, row.source_id): row.message_count
+            for row in DailyStationRollup.objects.all()
+        }
+
+    def test_two_stations_are_counted_apart(self):
+        one = Station.objects.create(wigos_id="0-20000-0-63708")
+        two = Station.objects.create(wigos_id="0-20000-0-63710")
+        self.counted("2026-08-11T10:00:00", station=one)
+        self.counted("2026-08-11T11:00:00", station=two, count=3)
+
+        self.roll()
+
+        self.assertEqual(
+            self.grains(),
+            {
+                (self.node.pk, one.pk, self.source.pk): 1,
+                (self.node.pk, two.pk, self.source.pk): 3,
+            },
+        )
+
+    def test_two_centres_are_counted_apart(self):
+        djibouti = WIS2Node.objects.create(centre_id="dj-anm", name="Djibouti")
+        self.counted("2026-08-11T10:00:00")
+        self.counted("2026-08-11T10:00:00", node=djibouti)
+
+        self.roll()
+
+        self.assertEqual(
+            self.grains(),
+            {
+                (self.node.pk, None, self.source.pk): 1,
+                (djibouti.pk, None, self.source.pk): 1,
+            },
+        )
+
+    def test_the_same_day_from_two_vantage_points_is_not_one_count(self):
+        """Summing the vantage points would double every number for the region."""
+        origin = MessageSource.objects.create(
+            name="ke-meteo origin broker",
+            source_type=MessageSource.ORIGIN_BROKER,
+            node=self.node,
+            host="wis.meteo.example.int",
+        )
+        self.counted("2026-08-11T10:00:00")
+        self.counted("2026-08-11T10:00:00", source=origin)
+
+        self.roll()
+
+        self.assertEqual(
+            self.grains(),
+            {
+                (self.node.pk, None, self.source.pk): 1,
+                (self.node.pk, None, origin.pk): 1,
+            },
+        )
+
+    def test_datasets_are_summed_together_rather_than_counted_apart(self):
+        """Dropping the dataset is the whole point: it multiplies the rows a
+        station question has to read and answers none of it."""
+        station = Station.objects.create(wigos_id="0-20000-0-63708")
+        self.counted("2026-08-11T10:00:00", dataset=self.dataset("synop"), station=station)
+        self.counted("2026-08-11T10:00:00", dataset=self.dataset("temp"), station=station, count=4)
+
+        self.roll()
+
+        self.assertEqual(
+            self.grains(), {(self.node.pk, station.pk, self.source.pk): 5}
+        )
+
+    def test_messages_naming_no_station_keep_their_own_bucket(self):
+        """Undecided whether the surfaces say anything about these; dropping
+        them here would decide it by making the question unanswerable."""
+        station = Station.objects.create(wigos_id="0-20000-0-63708")
+        self.counted("2026-08-11T10:00:00", station=station)
+        self.counted("2026-08-11T10:00:00", station=None, count=7)
+
+        self.roll()
+
+        self.assertEqual(
+            self.grains(),
+            {
+                (self.node.pk, station.pk, self.source.pk): 1,
+                (self.node.pk, None, self.source.pk): 7,
+            },
+        )
+
+
+class ActiveHoursTests(DailyRollupTestCase):
+    """How much of the day a station was heard in, as against how loudly."""
+
+    def active_hours(self):
+        return [row.active_hours for row in DailyStationRollup.objects.order_by("day")]
+
+    def test_a_station_heard_in_three_hours_has_three_active_hours(self):
+        station = Station.objects.create(wigos_id="0-20000-0-63708")
+        for hour in ("00", "06", "18"):
+            self.counted(f"2026-08-11T{hour}:00:00", station=station, count=50)
+
+        self.roll()
+
+        self.assertEqual(self.active_hours(), [3])
+
+    def test_two_datasets_in_one_hour_are_one_active_hour(self):
+        """Distinct hours, not rows -- otherwise a node publishing many datasets
+        would look like a station reporting round the clock."""
+        station = Station.objects.create(wigos_id="0-20000-0-63708")
+        self.counted("2026-08-11T10:00:00", station=station, dataset=self.dataset("synop"))
+        self.counted("2026-08-11T10:00:00", station=station, dataset=self.dataset("temp"))
+
+        self.roll()
+
+        self.assertEqual(self.active_hours(), [1])
+
+    def test_a_station_heard_every_hour_has_a_full_day(self):
+        station = Station.objects.create(wigos_id="0-20000-0-63708")
+        for hour in range(24):
+            self.counted(f"2026-08-11T{hour:02d}:00:00", station=station)
+
+        self.roll()
+
+        self.assertEqual(self.active_hours(), [24])
+
+
+class DailyRerunTests(DailyRollupTestCase):
+    """A day is a function of its hours, so it is rebuilt rather than added to."""
+
+    def test_rolling_the_same_day_twice_does_not_double_it(self):
+        self.counted("2026-08-11T10:00:00", count=3)
+
+        self.roll()
+        self.roll()
+
+        self.assertEqual(self.days(), [("2026-08-11T00:00:00+00:00", 3)])
+
+    def test_a_corrected_hour_corrects_the_day(self):
+        """The stale-number failure this layer exists to avoid."""
+        rollup = self.counted("2026-08-11T10:00:00", count=3)
+        self.roll()
+
+        rollup.message_count = 9
+        rollup.save(update_fields=["message_count"])
+        self.roll()
+
+        self.assertEqual(self.days(), [("2026-08-11T00:00:00+00:00", 9)])
+
+    def test_an_hour_added_to_a_settled_day_reopens_it(self):
+        self.counted("2026-08-11T10:00:00")
+        self.roll()
+
+        self.counted("2026-08-11T14:00:00", count=2)
+        self.roll()
+
+        self.assertEqual(self.days(), [("2026-08-11T00:00:00+00:00", 3)])
+
+
+class TrailingWindowTests(DailyRollupTestCase):
+    """What the scheduled run covers."""
+
+    def test_the_window_reaches_every_day_the_hourly_window_can_still_change(self):
+        """The two windows are one decision. An hour the hourly run may still
+        revise, sitting in a day this run no longer visits, is a number that
+        stays wrong for ever."""
+        now = at("2026-08-13T00:30:00")
+        self.counted(now - timedelta(hours=48))
+
+        update_daily_rollups(now=now)
+
+        self.assertEqual(self.days(), [("2026-08-11T00:00:00+00:00", 1)])
+
+    def test_the_window_is_taken_from_the_hourly_windows_length(self):
+        with override_settings(WIS2WATCH_ROLLUP_WINDOW_HOURS=48):
+            self.assertEqual(default_window_days(), 3)
+
+        with override_settings(WIS2WATCH_ROLLUP_WINDOW_HOURS=1):
+            self.assertEqual(default_window_days(), 2)
+
+        with override_settings(WIS2WATCH_ROLLUP_WINDOW_HOURS=24 * 7):
+            self.assertEqual(default_window_days(), 8)
+
+    def test_nothing_in_the_window_writes_nothing(self):
+        self.counted("2026-08-01T10:00:00")
+
+        counts = update_daily_rollups(now=at("2026-08-13T00:30:00"))
+
+        self.assertEqual(counts.rows, 0)
+        self.assertEqual(DailyStationRollup.objects.count(), 0)
+
+    def test_days_outside_the_window_are_left_as_they_stand(self):
+        self.counted("2026-08-01T10:00:00")
+        self.roll()
+
+        HourlyRollup.objects.all().delete()
+        update_daily_rollups(now=at("2026-08-13T00:30:00"))
+
+        self.assertEqual(self.days(), [("2026-08-01T00:00:00+00:00", 1)])
+
+
+class BackfillTests(DailyRollupTestCase):
+    """Covering the history that was there before this table was."""
+
+    def test_the_backfill_reaches_the_oldest_hour_the_region_holds(self):
+        self.counted("2024-01-15T10:00:00", count=4)
+        self.counted("2026-08-11T10:00:00", count=2)
+
+        counts = backfill_daily_rollups(now=at("2026-08-13T00:30:00"))
+
+        self.assertEqual(counts.rows, 2)
+        self.assertEqual(
+            self.days(),
+            [("2024-01-15T00:00:00+00:00", 4), ("2026-08-11T00:00:00+00:00", 2)],
+        )
+
+    def test_the_backfill_covers_the_day_in_progress(self):
+        self.counted("2026-08-13T00:00:00", count=5)
+
+        backfill_daily_rollups(now=at("2026-08-13T00:30:00"))
+
+        self.assertEqual(self.days(), [("2026-08-13T00:00:00+00:00", 5)])
+
+    def test_running_the_backfill_twice_changes_nothing(self):
+        self.counted("2026-08-11T10:00:00", count=3)
+
+        backfill_daily_rollups(now=at("2026-08-13T00:30:00"))
+        backfill_daily_rollups(now=at("2026-08-13T00:30:00"))
+
+        self.assertEqual(self.days(), [("2026-08-11T00:00:00+00:00", 3)])
+
+    def test_the_chunking_does_not_change_the_answer(self):
+        """Chunk boundaries are where a walk of history loses or repeats a day."""
+        for day in range(1, 8):
+            self.counted(f"2026-08-{day:02d}T10:00:00", count=day)
+
+        backfill_daily_rollups(now=at("2026-08-13T00:30:00"), chunk_days=2)
+
+        self.assertEqual(
+            self.days(),
+            [(f"2026-08-{day:02d}T00:00:00+00:00", day) for day in range(1, 8)],
+        )
+
+    def test_an_empty_region_backfills_nothing(self):
+        counts = backfill_daily_rollups(now=at("2026-08-13T00:30:00"))
+
+        self.assertEqual(counts.rows, 0)
+        self.assertEqual(DailyStationRollup.objects.count(), 0)
+
+
+class DeletedStationTests(DailyRollupTestCase):
+    """What becomes of a permanent count when the station it named goes.
+
+    The hourly table already answers this -- the counts stay and join the
+    unattributed bucket, and a delete that would duplicate that bucket is
+    refused rather than allowed to leave two rows for one day for ever. The
+    daily table has to answer it the same way, or the two layers disagree at
+    exactly the moment somebody is deleting things by hand.
+    """
+
+    def test_deleting_a_station_leaves_the_counts_it_earned_as_unattributed(self):
+        station = Station.objects.create(wigos_id="0-20000-0-63708")
+        self.counted("2026-08-11T10:00:00", station=station)
+        self.roll()
+
+        station.delete()
+
+        row = DailyStationRollup.objects.get()
+        self.assertIsNone(row.station_id)
+        self.assertEqual(row.message_count, 1)
+
+    def test_a_delete_that_would_duplicate_an_unattributed_bucket_is_refused(self):
+        station = Station.objects.create(wigos_id="0-20000-0-63708")
+        self.counted("2026-08-11T10:00:00", station=station)
+        self.counted("2026-08-11T11:00:00", station=None)
+        self.roll()
+
+        with self.assertRaises(IntegrityError):
+            station.delete()
+
+
+class LayersAgreeTests(DailyRollupTestCase):
+    """The objection this table has to answer.
+
+    A third derived layer over the second is where "the dashboard says 412 and
+    the station list says 409" comes from. What makes it safe is that the daily
+    row is a function of the hourly rows and nothing else -- so the two can only
+    differ while a run is pending, never because they counted differently.
+    """
+
+    def test_the_days_distinct_stations_match_the_hours_they_were_derived_from(self):
+        stations = [
+            Station.objects.create(wigos_id=f"0-20000-0-6370{n}") for n in range(4)
+        ]
+
+        for index, station in enumerate(stations):
+            for hour in range(0, 24, 6):
+                NotificationMessage.objects.create(
+                    source=self.source,
+                    node=self.node,
+                    station=station,
+                    notification_id=f"{station.wigos_id}-{hour}",
+                    topic=f"origin/a/wis2/ke-meteo/data/core/weather/{index}",
+                    time=at(f"2026-08-11T{hour:02d}:30:00"),
+                    raw_json={},
+                )
+
+        rollup_hours(since=at("2026-08-11T00:00:00"), until=at("2026-08-12T00:00:00"))
+        self.roll()
+
+        from_hours = (
+            HourlyRollup.objects.filter(node=self.node)
+            .values("station")
+            .distinct()
+            .count()
+        )
+        from_days = (
+            DailyStationRollup.objects.filter(node=self.node)
+            .values("station")
+            .distinct()
+            .count()
+        )
+
+        self.assertEqual(from_days, from_hours)
+        self.assertEqual(from_days, 4)
+
+    def test_the_days_message_total_matches_the_hours_it_was_derived_from(self):
+        for hour in range(24):
+            self.counted(f"2026-08-11T{hour:02d}:00:00", count=hour)
+
+        self.roll()
+
+        self.assertEqual(
+            DailyStationRollup.objects.get().message_count,
+            sum(range(24)),
+        )

--- a/wis2watch/src/wis2watch/core/tests/test_daily_rollups.py
+++ b/wis2watch/src/wis2watch/core/tests/test_daily_rollups.py
@@ -15,9 +15,8 @@ shifts every bucket in the region and nothing raises.
 
 from datetime import timedelta
 
-from django.conf import settings
 from django.db import IntegrityError
-from django.test import SimpleTestCase, TestCase, override_settings
+from django.test import TestCase, override_settings
 
 from wis2watch.core.daily_rollups import (
     backfill_daily_rollups,
@@ -35,7 +34,6 @@ from wis2watch.core.models import (
     WIS2Node,
 )
 from wis2watch.core.rollups import rollup_hours
-from wis2watch.core.tasks import run_update_daily_rollups
 from wis2watch.core.tests.support import at
 
 
@@ -78,29 +76,6 @@ class DailyRollupTestCase(TestCase):
             (row.day.isoformat(), row.message_count)
             for row in DailyStationRollup.objects.order_by("day")
         ]
-
-
-class ScheduleTests(SimpleTestCase):
-    """That the beat actually reaches the summary.
-
-    A schedule naming a task that does not exist announces itself nowhere:
-    nothing runs, nothing is logged, and the statistics surfaces go on reading
-    a table that stopped being brought up to date. Worse here than most,
-    because the numbers would not be missing -- they would be old.
-    """
-
-    def setUp(self):
-        self.entry = settings.CELERY_BEAT_SCHEDULE["update-daily-rollups"]
-
-    def test_the_scheduled_task_is_the_one_that_answers_to_that_name(self):
-        self.assertEqual(self.entry["task"], run_update_daily_rollups.name)
-
-    def test_it_runs_on_the_same_beat_as_the_hours_it_summarises(self):
-        """A day the surfaces are reading should not lag the hours under it."""
-        self.assertEqual(
-            self.entry["schedule"],
-            settings.CELERY_BEAT_SCHEDULE["update-rollups"]["schedule"],
-        )
 
 
 class DayBucketTests(DailyRollupTestCase):
@@ -344,6 +319,28 @@ class TrailingWindowTests(DailyRollupTestCase):
 
         with override_settings(WIS2WATCH_ROLLUP_WINDOW_HOURS=24 * 7):
             self.assertEqual(default_window_days(), 8)
+
+    def test_widening_the_hourly_window_widens_this_one_with_it(self):
+        """There is no setting of its own, on purpose: one that could be set
+        narrower than the hourly window would be a switch for turning the
+        guarantee off, and nothing would say it had been."""
+        now = at("2026-08-13T00:30:00")
+        self.counted("2026-08-05T10:00:00")
+
+        with override_settings(WIS2WATCH_ROLLUP_WINDOW_HOURS=24 * 10):
+            update_daily_rollups(now=now)
+
+        self.assertEqual(self.days(), [("2026-08-05T00:00:00+00:00", 1)])
+
+    def test_a_narrower_window_can_be_asked_for_explicitly(self):
+        """The argument is the testing seam; the schedule never passes it."""
+        now = at("2026-08-13T00:30:00")
+        self.counted("2026-08-11T10:00:00")
+        self.counted("2026-08-13T00:00:00")
+
+        update_daily_rollups(now=now, window_days=1)
+
+        self.assertEqual(self.days(), [("2026-08-13T00:00:00+00:00", 1)])
 
     def test_nothing_in_the_window_writes_nothing(self):
         self.counted("2026-08-01T10:00:00")

--- a/wis2watch/src/wis2watch/core/tests/test_tasks.py
+++ b/wis2watch/src/wis2watch/core/tests/test_tasks.py
@@ -6,13 +6,19 @@ advertises no registry must not be asked hourly for one, and a centre that
 published nothing must not be queued for a probe that would find nothing. What
 each run then does is asserted elsewhere -- against captured payloads for the
 syncs, and against a seeded database for the probes.
+
+With one exception: that the beat reaches a run at all. A schedule naming a
+task that does not exist announces itself nowhere, and the runs whose absence
+would be silent rather than obvious are asserted here beside the tasks they
+name.
 """
 
 from datetime import timedelta
 from unittest import mock
 
+from django.conf import settings
 from django.core import mail
-from django.test import TestCase
+from django.test import SimpleTestCase, TestCase
 from django.utils import timezone as dj_timezone
 
 from wis2watch.core.models import (
@@ -31,7 +37,31 @@ from wis2watch.core.tasks import (
     run_sync_all_node_stations,
     run_sync_node_stations,
     run_sync_oscar_stations,
+    run_update_daily_rollups,
 )
+
+
+class DailyRollupScheduleTests(SimpleTestCase):
+    """That the beat actually reaches the station-day summary.
+
+    Nothing would raise if it did not. The table would go on holding whatever
+    the last run left, the surfaces reading it would go on drawing numbers, and
+    the numbers would not be missing -- they would be old, which is the one
+    failure a dashboard cannot show you.
+    """
+
+    def setUp(self):
+        self.entry = settings.CELERY_BEAT_SCHEDULE["update-daily-rollups"]
+
+    def test_the_scheduled_task_is_the_one_that_answers_to_that_name(self):
+        self.assertEqual(self.entry["task"], run_update_daily_rollups.name)
+
+    def test_it_runs_on_the_same_beat_as_the_hours_it_summarises(self):
+        """A day the surfaces are reading should not lag the hours under it."""
+        self.assertEqual(
+            self.entry["schedule"],
+            settings.CELERY_BEAT_SCHEDULE["update-rollups"]["schedule"],
+        )
 
 
 class NodeStationTaskTests(TestCase):


### PR DESCRIPTION
Closes #43.

#43 asked whether `HourlyRollup` survives the dashboard's queries, and said it could only be answered by measuring production. Taken down the other branch instead: **build the aggregate table and stop depending on the answer.** The map's live-read assumption was reasoned to rather than measured, and the long-window station queries no longer rest on it.

## The table

`DailyStationRollup`, grain **`(day, source, node, station)`**, carrying `message_count` and `active_hours`.

- **Dataset dropped.** It multiplies the rows every station question reads and answers none of them. The per-dataset breakdown survives on the drilldown, which is one station at a time.
- **Source kept**, for the reason the hourly grain keeps it: the same notification at a centre's own broker and at the Global Broker is two rows on purpose, and summing them would double every number the moment origin ingestion is switched on. Reading is where a vantage point gets chosen, so #42's vantage-free distinct-station counts and Global-Broker-filtered volumes both still work.
- **`active_hours`** — how many of the day's 24 UTC hours the station was heard in. `message_count` cannot tell 50 messages in one hour from 50 spread across the day, which is precisely what #48 asks of the matrix cell. Free to derive, unrecoverable later.
- **Null-station rows kept.** #46 is still open; dropping them here would settle it by making the question unanswerable.

## Derived from `HourlyRollup`, never from raw messages

The decision the whole change turns on. Raw notifications expire at 14 days, so a day older than that could never be computed a second time — the first run would have to be right for ever, and a missed run would leave a hole nothing could fill. Deriving from a table that is never expired is also the only reason the backfill is possible.

**On #42's objection** — *"a third derived layer over the second is where 'the dashboard says 412 and the station list says 409' comes from"* — a day is a pure function of the hours under it, and the daily window is **computed from** the hourly window rather than set beside it, so any hour the hourly run can still revise falls inside a day this run still visits. The two layers can differ while a run is pending; they cannot differ because they counted differently. A test asserts the distinct-station count matches across both layers.

## Indexes

#43 noted the hourly grain names a station but nothing leads on one. `(node, -hour)` becomes **`(node, -hour, station)`** — same leading columns, so nothing that walked the old one walks further, and a node's stations over a window are read off the index. The new table gets `(node, -day, station)`.

Nothing leads on the station. Reading one station across every centre would want that and is a real finding, but #42 files it under *Not yet specified*, and on a never-expired table an index no surface asks for is a cost paid on every write for ever.

## Backfill

`backfill_daily_rollups`, walked in day-aligned chunks, run by migration `0019` on the way in. Separate from the schema migration so that can be applied and inspected without waiting on a walk of the region's history, and **not atomic**, so each 30-day chunk commits rather than holding one transaction open against a database that is also ingesting. Idempotent — an interrupted run is re-run with the management command.

## Reviewed

Ran `/code-review` on both axes. Three findings fixed in `e83c594`:

- The first commit argued the layers cannot drift *because* the window is derived — then shipped `WIS2WATCH_DAILY_ROLLUP_WINDOW_DAYS`, which let it be chosen separately after all. Set below the derived floor, days holding still-revisable hours would never be revisited and a wrong number would stand for ever. Removed rather than clamped: it was never declared in settings and no caller passed it.
- `backfill_daily_rollups` had no caller. A deploy would have migrated the table in empty and shown three days of station history where there were two years.
- `(station, -hour)` was scope creep against #42's node-scoped drilldown, and is dropped.

Plus deduplication against the `retention`-imports-from-`rollups` precedent (`RollupCounts` now shared, `grain_columns` extracted, `GROUP_BY` renamed to stop shadowing), and two comments walked back to what is actually true — index-only scans need all-visible pages, which the days being rewritten every 15 minutes are not.

## Not settled by this

- **The measurement itself.** Nothing here has run against production. Worth doing when there is access, if only to size the backfill before it runs.
- **Unbounded growth**, which #43 raised separately. There are now two unpartitioned, never-expired tables. This one grows an order of magnitude slower — a row per station per day per vantage point, against one per station per dataset per hour per vantage point — so it does not double the problem, but it does not answer it. A question about both tables together, and its own issue.

## Tests

1063 pass. 31 new, covering the UTC day boundary and timezone independence, the grain, `active_hours` counting distinct hours rather than rows, idempotent rebuilds, the trailing window reaching everything the hourly window can still revise, backfill chunk boundaries, deleted-station behaviour matching the hourly table, and both layers agreeing.