### PR TITLE
Leave uv.lock out of version control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,6 +110,9 @@ ipython_config.py
 #   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
 #poetry.lock
 
+# uv
+uv.lock
+
 # pdm
 #   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
 #pdm.lock


### PR DESCRIPTION
Adds a `# uv` / `uv.lock` block to the root `.gitignore`, alongside the existing Pipfile/poetry/pdm lockfile entries.

`wis2watch/uv.lock` was untracked, so nothing is removed from the index — this only stops it showing up as an untracked file.

Worth a second opinion before merging: uv's own guidance is to commit `uv.lock` for applications, so that Docker builds and CI resolve to identical dependency versions. This repo ships a Dockerfile and a compose setup, which reads application-shaped. Ignoring the lockfile means each build re-resolves dependencies.