### PR TITLE
A stack that shows a change when you save it

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -126,7 +126,11 @@ WIS2WATCH_BACKUP_VOLUME=./docker/backup
 ## nginx port
 WIS2WATCH_WEB_PROXY_PORT=80
 
-# user and group id
+# user and group id. On Linux set these to your own `id -u` and `id -g` before
+# building, or the container -- which runs as 9999:9999 by default -- cannot
+# write to a bind-mounted source tree, and `manage makemigrations` fails on
+# permissions. On macOS Docker Desktop translates ownership and these can stay
+# empty. See docs/development.md.
 UID=
 GID=
 
@@ -137,3 +141,17 @@ DOCKER_COMPOSE_WAIT_PLATFORM_SUFFIX=
 # ensure that the network is created before running the docker-compose
 # docker network create <network_name>
 WIS2WATCH_NETWORK_NAME=
+
+
+## Development
+# Uncomment to develop against the stack: Python changes under wis2watch/src
+# then take effect on save, in every service. Leaving it commented gives you
+# the production stack, which is what a deployment wants. See
+# docs/development.md.
+# COMPOSE_FILE=docker-compose.yml:docker-compose.dev.yml
+#
+# Where the Vue islands are loaded from while developing. Left unset they come
+# from the Vite dev server at http://localhost:5173, so `npm run dev` in
+# wis2watch/src/wis2watch/monitoring/wis2watch-monitoring must be running.
+# Set it False to use the committed bundles instead and skip node entirely.
+# VUE_FRONTEND_USE_DEV_SERVER=False

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,13 @@ The five canonical triage roles, each label string equal to its name. See `docs/
 
 Single-context: `CONTEXT.md` and `docs/adr/` at the repo root. See `docs/agents/domain.md`.
 
+### Development stack
+
+Changes reflect on save once `COMPOSE_FILE` is set in `.env`. Rebuilding the
+image for every edit is not necessary. `make` lists the shortcuts -- `make up`,
+`make test`, `make logs-ingest`, `make frontend`. See
+`docs/development.md`.
+
 ## Adding new features or fixing bugs
 
 **IMPORTANT**: When you work on a new feature or bug fix, create a git branch first. Then work on changes in that

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,167 @@
+# Development shortcuts. Every target here assumes the development overlay, so
+# they all go through the same switch: COMPOSE_FILE in your .env. There is no
+# production target -- a deployment runs `docker compose` directly, and giving
+# it a friendlier name here would only make the two easier to confuse.
+#
+# `make` on its own lists what is available. See docs/development.md.
+
+FRONTEND_DIR := wis2watch/src/wis2watch/monitoring/wis2watch-monitoring
+COMPOSE := docker compose
+
+.DEFAULT_GOAL := help
+
+# ======================================================
+# GUARD
+# ======================================================
+
+# Refuses to run if the development overlay is not switched on. Without this a
+# missing .env line means `make up` quietly starts the production stack, which
+# looks identical until you save a file and nothing happens.
+.PHONY: check-dev
+check-dev:
+	@grep -qE '^[[:space:]]*COMPOSE_FILE=.*docker-compose\.dev\.yml' .env 2>/dev/null || { \
+		echo "The development overlay is not enabled."; \
+		echo ""; \
+		echo "Add this line to .env, uncommented:"; \
+		echo ""; \
+		echo "  COMPOSE_FILE=docker-compose.yml:docker-compose.dev.yml"; \
+		echo ""; \
+		echo "See docs/development.md."; \
+		exit 1; \
+	}
+
+# ======================================================
+# THE STACK
+# ======================================================
+
+.PHONY: up
+up: check-dev ## Start the stack in the foreground (ctrl-c stops it)
+	$(COMPOSE) up
+
+.PHONY: start
+start: check-dev ## Start the stack in the background
+	$(COMPOSE) up -d
+
+.PHONY: stop
+stop: check-dev ## Stop the containers, keeping them
+	$(COMPOSE) stop
+
+.PHONY: down
+down: check-dev ## Stop and remove the containers (the database volume survives)
+	$(COMPOSE) down
+
+.PHONY: restart
+restart: check-dev ## Restart every service
+	$(COMPOSE) restart
+
+.PHONY: build
+build: check-dev ## Rebuild the image -- needed after a requirements.txt or entrypoint change
+	$(COMPOSE) build
+
+.PHONY: ps
+ps: check-dev ## What is running
+	$(COMPOSE) ps
+
+.PHONY: logs
+logs: check-dev ## Follow every service's logs
+	$(COMPOSE) logs -f
+
+.PHONY: logs-web logs-worker logs-beat logs-ingest
+logs-web: check-dev ## Follow the web server's logs
+	$(COMPOSE) logs -f wis2watch
+
+logs-worker: check-dev ## Follow the celery worker's logs
+	$(COMPOSE) logs -f wis2watch_celery_worker
+
+logs-beat: check-dev ## Follow the celery beat logs
+	$(COMPOSE) logs -f wis2watch_celery_beat
+
+logs-ingest: check-dev ## Follow the ingestion supervisor's logs
+	$(COMPOSE) logs -f wis2watch_ingest
+
+# ======================================================
+# FRONTEND
+# ======================================================
+
+.PHONY: frontend
+frontend: $(FRONTEND_DIR)/node_modules ## Run the Vite dev server on :5173, with hot reload
+	cd $(FRONTEND_DIR) && npm run dev
+
+.PHONY: frontend-build
+frontend-build: $(FRONTEND_DIR)/node_modules ## Build the Vue bundles -- commit the result
+	cd $(FRONTEND_DIR) && npm run build
+
+.PHONY: frontend-install
+frontend-install: ## Reinstall the frontend dependencies from the lockfile
+	cd $(FRONTEND_DIR) && npm ci
+
+# Installs on first use rather than making you remember to, and reinstalls when
+# the lockfile moves. Not .PHONY: whether the directory is up to date is the
+# whole test.
+$(FRONTEND_DIR)/node_modules: $(FRONTEND_DIR)/package-lock.json
+	cd $(FRONTEND_DIR) && npm install
+	@touch $(FRONTEND_DIR)/node_modules
+
+# ======================================================
+# DJANGO
+# ======================================================
+
+# `docker compose exec` does not run the image's entrypoint, so the entrypoint's
+# `manage` command is not on PATH for it. The container's workdir and PATH are
+# already right, so manage.py is called directly.
+MANAGE := $(COMPOSE) exec wis2watch python manage.py
+
+.PHONY: migrate
+migrate: check-dev ## Apply migrations
+	$(MANAGE) migrate
+
+.PHONY: makemigrations
+makemigrations: check-dev ## Write new migrations (Linux: needs UID/GID set, see docs/development.md)
+	$(MANAGE) makemigrations
+
+.PHONY: superuser
+superuser: check-dev ## Create a login
+	$(MANAGE) createsuperuser
+
+.PHONY: collectstatic
+collectstatic: check-dev ## Collect static files, so the nginx proxy on :80 serves current ones
+	$(MANAGE) collectstatic --noinput
+
+# What to run when no T= is given: everything.
+TEST_LABEL = $(if $(T),$(T),wis2watch)
+
+.PHONY: test
+test: check-dev ## Run the test suite (T=dotted.path to narrow it)
+	$(MANAGE) test $(TEST_LABEL) --noinput
+
+# Building the test database means running every migration, which is most of
+# the wait on a short run. Keeping it is worth minutes over an afternoon spent
+# on one module -- at the price that a schema change lands in a database that
+# already exists, so if a test starts failing in a way that makes no sense,
+# run `make test` once to build it afresh.
+.PHONY: test-keepdb
+test-keepdb: check-dev ## The same, reusing the test database (fast to rerun)
+	$(MANAGE) test $(TEST_LABEL) --keepdb
+
+.PHONY: shell
+shell: check-dev ## A Django shell
+	$(MANAGE) shell
+
+.PHONY: bash
+bash: check-dev ## A bash prompt inside the web container
+	$(COMPOSE) exec wis2watch bash
+
+.PHONY: attach
+attach: check-dev ## Attach to runserver -- ctrl-c stops it, ctrl-p ctrl-q detaches
+	$(COMPOSE) attach wis2watch
+
+# ======================================================
+# HELP
+# ======================================================
+
+.PHONY: help
+help: ## List these targets
+	@echo "WIS2Watch development. Browse the stack at http://localhost:8000/"
+	@echo ""
+	@grep -hE '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) \
+		| awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-16s\033[0m %s\n", $$1, $$2}'

--- a/README.md
+++ b/README.md
@@ -73,3 +73,5 @@ in `.env`, empty for all of Africa.
 
 - [WIS2 data flow](docs/wis2-data-flow.md) -- the Global Services and the
   journey a notification takes through them.
+- [Development](docs/development.md) -- running the stack so that a change
+  takes effect when you save it, rather than when you rebuild.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Then create yourself a login. This is the one step that is not automated, and
 deliberately so:
 
 ```bash
-docker compose exec wis2watch manage createsuperuser
+docker compose exec wis2watch python manage.py createsuperuser
 ```
 
 The admin is at the site root -- `http://localhost/` behind the bundled proxy --

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,84 @@
+# The development overlay. It is not applied unless you ask for it: set
+#
+#   COMPOSE_FILE=docker-compose.yml:docker-compose.dev.yml
+#
+# in your .env. Production never sets that line, so this file cannot be picked
+# up by a deployment that merely has it checked out.
+#
+# What it buys: every Python change under wis2watch/src takes effect on save,
+# in all five services. See docs/development.md for the whole loop, including
+# the Vue side, which runs on the host rather than in here.
+
+# What every Python service needs in order to reload. In one anchor because a
+# service that had only part of it is the confusing case -- code that reloads
+# but under production settings, or dev settings without the mount that makes
+# them reach anything.
+x-dev-environment: &dev-environment
+  # The dev settings module, not production. production.py hardcodes
+  # DEBUG = False after reading the environment, so selecting this module --
+  # not setting a variable -- is the only way to turn DEBUG on.
+  DJANGO_SETTINGS_MODULE: wis2watch.config.settings.dev
+  # dev.py sets DEBUG = True, but only after base.py has read this and derived
+  # VUE_FRONTEND_USE_DEV_SERVER from it. Setting it here keeps base's DEBUG and
+  # the effective DEBUG in agreement instead of quietly disagreeing.
+  DEBUG: "True"
+  # Host filesystem events do not reach a bind-mounted container reliably.
+  # See autoreload_exec in docker-entrypoint.sh.
+  WATCHFILES_FORCE_POLLING: "true"
+  # Bytecode belongs to the image, not to your working copy. Without this the
+  # container scatters __pycache__ through the mounted source tree.
+  PYTHONDONTWRITEBYTECODE: "1"
+
+# Only src. requirements.txt and pyproject.toml are installed at build time, so
+# a change to either needs a rebuild whether it is mounted or not. The editable
+# install points at this exact path, so imports resolve unchanged. The static
+# and media mounts from the base file sit deeper inside this one and still win.
+x-dev-source: &dev-source
+  - ./wis2watch/src:/wis2watch/app/src
+
+services:
+  wis2watch:
+    # runserver, which reloads itself. Daphne is first in INSTALLED_APPS, so
+    # this serves ASGI and /ws/ just as gunicorn does.
+    command: django-dev
+    # django-dev hands you a shell whose history holds the runserver command:
+    # `docker compose attach wis2watch`, then ctrl-c stops the server and
+    # leaves you inside the container. Also what makes breakpoint() usable.
+    tty: true
+    stdin_open: true
+    environment:
+      <<: *dev-environment
+      # Nothing reads the collected files in dev: with DEBUG on, urls.py serves
+      # static from the finders and media from MEDIA_ROOT. Collecting them on
+      # every start is startup latency spent for nobody.
+      COLLECT_STATICFILES_ON_STARTUP: "false"
+      # Whether the Vue islands come from the Vite dev server on the host or
+      # from the bundles committed under monitoring/static/vue. Defaults on,
+      # because DEBUG is on; set it False in .env if you are not running node.
+      VUE_FRONTEND_USE_DEV_SERVER: ${VUE_FRONTEND_USE_DEV_SERVER:-True}
+    volumes: *dev-source
+    # Replaces the base file's random host port rather than adding to it: dev
+    # is browsed at a fixed http://localhost:8000/, which is also the origin
+    # the Vite dev server allows by default. Not through the nginx proxy --
+    # that serves /static/ from collectstatic output, which is stale the moment
+    # you edit anything. docs/development.md says how to check nginx on purpose.
+    ports: !override
+      - "8000:8000"
+
+  wis2watch_celery_worker:
+    command: celery-worker-dev
+    environment: *dev-environment
+    volumes: *dev-source
+
+  wis2watch_celery_beat:
+    command: celery-beat-dev
+    environment: *dev-environment
+    volumes: *dev-source
+
+  # Still one, still the only owner of the broker connections. Reloading it
+  # drops and remakes those connections, which is the cost of editing the
+  # supervisor while it runs.
+  wis2watch_ingest:
+    command: ingest-dev
+    environment: *dev-environment
+    volumes: *dev-source

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -34,8 +34,12 @@ ingest              : Start the WIS2 ingestion supervisor, which owns every
                       single ownership is what removes the need for locking.
 
 DEV COMMANDS:
-django-dev      : Start a normal WIS2Watch backend django development server, performs
-                  the same checks and setup as the gunicorn command above.
+django-dev          : Start a normal WIS2Watch backend django development server,
+                      performs the same checks and setup as the gunicorn command above.
+celery-worker-dev   : The celery worker, restarted whenever a Python file changes.
+celery-beat-dev     : The celery beat service, restarted whenever a Python file changes.
+ingest-dev          : The ingestion supervisor, restarted whenever a Python file changes.
+                      Still exactly one of these -- see the ingest command above.
 """
 }
 
@@ -61,14 +65,54 @@ run_setup_commands_if_configured(){
   fi
 }
 
-start_celery_worker() {
+# Where the source tree is mounted from the host by docker-compose.dev.yml.
+# Nothing outside it can change without a rebuild, so nothing outside it is
+# worth watching.
+WIS2WATCH_SRC=/wis2watch/app/src
 
-    EXTRA_CELERY_ARGS=()
+# The one directory under the source tree that is not source. It holds ~8000
+# files; a poll that walks them is a poll spent on nothing.
+WIS2WATCH_AUTORELOAD_IGNORE="$WIS2WATCH_SRC/wis2watch/monitoring/wis2watch-monitoring/node_modules"
+
+# Run the given command under a watcher that restarts it when a Python file
+# under the mounted source changes. Only the dev commands use this; the
+# production commands exec their process directly.
+#
+# Polling rather than filesystem events: host changes reach a bind-mounted
+# container through the Docker VM, which does not forward inotify reliably,
+# and watchfiles' own auto-detection only covers WSL. A missed restart is
+# silent -- you debug code that is no longer running -- which is worth more
+# than the CPU a stat sweep of a few hundred files costs.
+autoreload_exec(){
+    export WATCHFILES_FORCE_POLLING="${WATCHFILES_FORCE_POLLING:-true}"
+    echo "watching $WIS2WATCH_SRC: $*"
+    exec watchfiles --filter python \
+        --ignore-paths "$WIS2WATCH_AUTORELOAD_IGNORE" \
+        "$*" \
+        "$WIS2WATCH_SRC"
+}
+
+# The worker's argv, built in one place. The production command and its
+# auto-reloading twin start the same worker with the same arguments; the only
+# difference between them is what wraps it.
+build_celery_worker_argv() {
+    CELERY_WORKER_ARGV=(celery -A wis2watch worker)
 
     if [[ -n "$WIS2WATCH_GUNICORN_NUM_OF_WORKERS" ]]; then
-        EXTRA_CELERY_ARGS+=(--concurrency "$WIS2WATCH_GUNICORN_NUM_OF_WORKERS")
+        CELERY_WORKER_ARGV+=(--concurrency "$WIS2WATCH_GUNICORN_NUM_OF_WORKERS")
     fi
-    exec celery -A wis2watch worker "${EXTRA_CELERY_ARGS[@]}" -l "${WIS2WATCH_CELERY_WORKER_LOG_LEVEL}" "$@"
+
+    CELERY_WORKER_ARGV+=(-l "${WIS2WATCH_CELERY_WORKER_LOG_LEVEL}" "$@")
+}
+
+start_celery_worker() {
+    build_celery_worker_argv "$@"
+    exec "${CELERY_WORKER_ARGV[@]}"
+}
+
+start_celery_worker_dev() {
+    build_celery_worker_argv "$@"
+    autoreload_exec "${CELERY_WORKER_ARGV[@]}"
 }
 
 # Lets devs attach to this container running the passed command, press ctrl-c and only
@@ -151,11 +195,20 @@ shell)
 celery-worker)
     start_celery_worker -Q celery -n default-worker@%h "${@:2}"
     ;;
+celery-worker-dev)
+    start_celery_worker_dev -Q celery -n default-worker@%h "${@:2}"
+    ;;
 celery-beat)
     exec celery -A wis2watch beat -l "${WIS2WATCH_CELERY_BEAT_DEBUG_LEVEL}" -S django_celery_beat.schedulers:DatabaseScheduler "${@:2}"
     ;;
+celery-beat-dev)
+    autoreload_exec celery -A wis2watch beat -l "${WIS2WATCH_CELERY_BEAT_DEBUG_LEVEL}" -S django_celery_beat.schedulers:DatabaseScheduler "${@:2}"
+    ;;
 ingest)
     exec python3 /wis2watch/app/src/wis2watch/manage.py run_ingest "${@:2}"
+    ;;
+ingest-dev)
+    autoreload_exec python3 /wis2watch/app/src/wis2watch/manage.py run_ingest "${@:2}"
     ;;
 *)
     echo "Command given was $*"

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,224 @@
+# Developing WIS2Watch
+
+The stack in `docker-compose.yml` is the one a deployment runs: gunicorn,
+production settings, code baked into the image. Editing anything means
+rebuilding. This document is about the other mode, where a change takes effect
+when you save it.
+
+## Turning it on
+
+```bash
+cp .env.sample .env      # if you have not already
+```
+
+Then uncomment one line in `.env`:
+
+```
+COMPOSE_FILE=docker-compose.yml:docker-compose.dev.yml
+```
+
+and bring the stack up, building once:
+
+```bash
+make build
+make up
+```
+
+The build is needed the first time only, and only if you already had an image:
+the development commands live in `docker-entrypoint.sh`, which is copied into
+the image rather than mounted. After that, `make up` alone.
+
+`make` on its own lists every target. They are all thin wrappers over
+`docker compose`, and every one of them refuses to run unless the `COMPOSE_FILE`
+line above is set -- which is the point: a `make up` that quietly started the
+production stack would look identical until you saved a file and nothing
+happened. Nothing here is required; `docker compose up` works just as well.
+
+There is deliberately no production target. A deployment runs `docker compose`
+directly, and giving that a friendlier name would only make the two easier to
+confuse.
+
+`COMPOSE_FILE` is what makes `docker compose` read the development overlay on
+top of the production file, for every command, without your having to pass
+`-f` twice each time. It lives in `.env` because that file is already yours
+alone and already untracked. A deployment checks out the same repository, does
+not set the line, and is unaffected by anything below.
+
+The cost of that convenience is that it is invisible: if a container is running
+something you did not expect, `.env` is the first place to look.
+
+## What you get
+
+`docker compose up` now runs the same seven containers, four of them changed:
+
+| Service | Runs | Reloads on |
+|---|---|---|
+| `wis2watch` | `runserver` | any Python file, via Django's own reloader |
+| `wis2watch_celery_worker` | the worker under `watchfiles` | any `.py` under `wis2watch/src` |
+| `wis2watch_celery_beat` | beat under `watchfiles` | the same |
+| `wis2watch_ingest` | the supervisor under `watchfiles` | the same |
+
+`wis2watch_db`, `wis2watch_redis` and `wis2watch_web_proxy` are untouched.
+
+`wis2watch/src` is bind-mounted into all four. Only `src` -- `requirements.txt`
+and `pyproject.toml` are installed during the build, so changing either needs
+`docker compose build` whether they are mounted or not.
+
+Templates, being under `src`, reload with everything else.
+
+## Browse it at `http://localhost:8000/`
+
+Not `http://localhost/`. The nginx proxy on port 80 serves `/static/` from the
+`collectstatic` output in `docker/static`, which goes stale the moment you edit
+anything. Port 8000 is the Django process itself, and with `DEBUG` on,
+`config/urls.py` serves static from the staticfiles finders -- your source tree,
+live -- and media from `MEDIA_ROOT`.
+
+The proxy keeps running, so when you specifically want to check something
+nginx-shaped -- a proxy header, the `/ws/` route, gzip -- collect the files once
+and use port 80:
+
+```bash
+make collectstatic
+```
+
+(That runs `docker compose exec wis2watch python manage.py collectstatic`.
+`docker compose exec` does not run the image's entrypoint, so the entrypoint's
+own `manage` command is not available to it -- but the container's working
+directory and `PATH` are already the right ones, so `manage.py` is called
+directly.)
+
+Websockets work on port 8000 without it: `daphne` is first in `INSTALLED_APPS`,
+so `runserver` is an ASGI server.
+
+## Settings
+
+The development containers run `wis2watch.config.settings.dev`, not
+`production`. This is not a convenience -- `production.py` assigns
+`DEBUG = False` outright, after the environment has been read, so no variable
+can turn debug on while that module is selected.
+
+`dev.py` gives you `DEBUG = True`, `ALLOWED_HOSTS = ["*"]`, an insecure
+built-in `SECRET_KEY`, the console email backend -- so the daily digest and the
+alert mails print into the worker's logs instead of needing an SMTP host -- and
+plain static files storage rather than the hashed manifest.
+
+The consequence to keep in mind: local development does not exercise
+`production.py`. A bug that lives only there -- in the manifest storage, in
+`CSRF_TRUSTED_ORIGINS`, in the CORS list -- will not show up until you run the
+production stack. When you touch any of those, run without the `COMPOSE_FILE`
+line once before you trust it.
+
+## The Vue islands
+
+The frontend is not in Docker. It is a Vite project at
+`wis2watch/src/wis2watch/monitoring/wis2watch-monitoring`, and it runs on your
+machine:
+
+```bash
+make frontend
+```
+
+That installs the dependencies if they are missing, then runs the Vite dev
+server. Long form, if you would rather:
+
+```bash
+cd wis2watch/src/wis2watch/monitoring/wis2watch-monitoring
+npm install
+npm run dev
+```
+
+That serves the islands from `http://localhost:5173` with hot module
+replacement -- a component edit appears without a page reload. The Django side
+already knows to point at it: with `DEBUG` on, `{% vue_bundle_url %}` emits the
+dev server's URL instead of a `{% static %}` path.
+
+**If you are not working on the frontend**, you do not need node at all. Set
+
+```
+VUE_FRONTEND_USE_DEV_SERVER=False
+```
+
+in `.env`, and the templates load the bundles committed under
+`monitoring/static/vue/` instead. Without either the dev server running or this
+variable set, the two pages carrying islands -- the ingest monitor map and the
+node statistics panel -- come up blank, because their script tags point at a
+port with nothing behind it.
+
+The bundles are committed, so a frontend change is not finished until you have
+run `make frontend-build` and committed the result. See
+`docs/adr/0001-vue-islands-in-wagtail-admin-pages.md`.
+
+## Tests
+
+Django's own runner, inside the web container, against a throwaway copy of the
+real database:
+
+```bash
+make test                                        # all 1242 of them, about 90s
+make test T=wis2watch.core.tests.test_silence    # one module
+make test T=wis2watch.ingest                     # one app
+```
+
+The stack has to be up -- these run through `docker compose exec`.
+
+Most of a short run is spent building the test database, which means applying
+every migration. `make test-keepdb` keeps it between runs and takes the same
+narrowed `T=`:
+
+```bash
+make test-keepdb T=wis2watch.core.tests.test_silence   # ~3s instead of ~14s
+```
+
+The catch is the usual one: a schema change lands in a database that already
+exists. If a test starts failing in a way that makes no sense, run `make test`
+once to build it afresh.
+
+Tests that exercise failure paths log at ERROR while they pass -- unreachable
+brokers, refused OSCAR connections. Noise in the output is not a failing run;
+the last line is.
+
+## Migrations, and a note for Linux
+
+```bash
+make makemigrations
+```
+
+This writes files into the bind-mounted source tree, which means it writes as
+the container's user. The image runs as `9999:9999` unless `UID` and `GID` are
+set in `.env` before the build.
+
+On **macOS** that does not matter: Docker Desktop translates ownership across
+the mount and the write succeeds regardless.
+
+On **Linux** it fails. Your source tree belongs to you, uid 9999 cannot write
+to it, and `makemigrations` dies on a permission error. Set `UID` and `GID` in
+`.env` to your own `id -u` and `id -g`, then `docker compose build`.
+
+## Things worth knowing
+
+**The watchers poll.** Filesystem events from the host do not cross a bind
+mount into the container reliably, and `watchfiles` only auto-detects WSL, not
+Docker -- so `WATCHFILES_FORCE_POLLING` is set for the three watched services.
+A missed restart is silent, and debugging code that is no longer running costs
+more than the stat sweep does. `node_modules` is excluded from the sweep
+explicitly; it is 8,000 files that are never watched for.
+
+**`ingest` grows.** With `DEBUG` on, Django keeps every SQL query it runs in
+`connection.queries`. In the web process that list is cleared each request. The
+ingestion supervisor has no requests and never exits, so the list grows for as
+long as the container is up. Over a working day it is not worth noticing; if
+you leave the stack running for days, `docker compose restart wis2watch_ingest`
+puts it back.
+
+**Ingestion runs by default.** The supervisor subscribes to the real WIS2
+Global Broker as soon as the stack is up, and writes what it sees to your local
+database. That is deliberate -- almost every page in this tool is a view over
+ingested data, and an empty database looks like a broken install. If you want
+it quiet, `docker compose stop wis2watch_ingest`.
+
+**Attaching to the web container.** `make attach` puts you on the `runserver`
+process. Ctrl-C stops the server and leaves you at a shell
+inside the container with the command in history, which is also what makes
+`breakpoint()` in a view usable. Ctrl-P Ctrl-Q detaches without stopping
+anything.

--- a/wis2watch/src/wis2watch/config/settings/base.py
+++ b/wis2watch/src/wis2watch/config/settings/base.py
@@ -460,7 +460,11 @@ LOGGING = {
 }
 
 VUE_FRONTEND_USE_TYPESCRIPT = False
-VUE_FRONTEND_USE_DEV_SERVER = DEBUG
+# Where the Vue islands are loaded from: the Vite dev server on the developer's
+# machine, or the bundles committed under monitoring/static/vue. Follows DEBUG,
+# because in production there is no dev server to point at -- but overridable,
+# so that working on the backend does not oblige you to run node.
+VUE_FRONTEND_USE_DEV_SERVER = env.bool('VUE_FRONTEND_USE_DEV_SERVER', DEBUG)
 VUE_FRONTEND_DEV_SERVER_URL = 'http://localhost:5173'
 VUE_FRONTEND_DEV_SERVER_PATH = '/static/vue/src'
 VUE_FRONTEND_STATIC_PATH = 'vue'


### PR DESCRIPTION
Editing anything meant rebuilding the image, because the code is copied into it. This mounts `wis2watch/src` into the four Python services and gives each of them a way to notice the change.

| Service | Runs | Reloads on |
|---|---|---|
| `wis2watch` | `runserver` | any Python file, via Django's own reloader |
| `wis2watch_celery_worker` | the worker under `watchfiles` | any `.py` under `wis2watch/src` |
| `wis2watch_celery_beat` | beat under `watchfiles` | the same |
| `wis2watch_ingest` | the supervisor under `watchfiles` | the same |

`watchfiles` needed no new dependency — it is already in the image by way of `uvicorn[standard]`.

## How it is switched on

One line in `.env`, not a `-f` flag, so that every `docker compose` and `make` command agrees about which stack is meant and a deployment that merely has the file checked out is unaffected:

```
COMPOSE_FILE=docker-compose.yml:docker-compose.dev.yml
```

## Two things that had to give way

**`production.py` assigns `DEBUG = False` after reading the environment**, so no variable could turn debug on while that module was selected. The overlay selects `settings.dev` instead — which is what `dev.py` has been sitting there for, unreachable until now.

**`VUE_FRONTEND_USE_DEV_SERVER` followed `DEBUG` with no way to say otherwise.** It decides whether the Vue islands come from Vite or from the committed bundles, so turning on the backend dev loop would have obliged everyone to run node. It is now overridable from `.env`.

## Decisions worth reviewing

- **The watchers poll** rather than wait on filesystem events. Host changes do not reach a bind-mounted container reliably, `watchfiles` only auto-detects WSL, and a missed restart is silent — you debug code that is no longer running, which costs more than the stat sweep does.
- **Development is browsed on `:8000`**, not through the nginx proxy on `:80`. The proxy serves `/static/` from `collectstatic` output, stale the moment anything is edited; Django with `DEBUG` on serves it from the source tree. The proxy keeps running for deliberate parity checks.
- **Local development does not exercise `production.py`.** A bug living only there — manifest storage, `CSRF_TRUSTED_ORIGINS`, the CORS list — will not show up locally. Documented.
- **`DEBUG` on `ingest` grows `connection.queries`**, since it has no request cycle to clear them. Accepted and documented over splitting the settings module per service.
- **Ingestion runs by default**, because almost every page is a view over ingested data and an empty database looks like a broken install.

## The Makefile

`make` lists the targets — `up`, `test`, `frontend`, `logs-ingest`, `makemigrations`. Every one refuses to run unless the overlay is enabled, since a `make up` that quietly started the production stack would look identical until a save did nothing. There is deliberately no production target.

## Verified on a running stack

- One `touch` restarted **all four** services: Django's `StatReloader` logged the reload, `watchfiles` logged the change in worker, beat and ingest.
- `http://localhost:8000/` → 302; `/static/vue/mqtt-monitor-map.js` → 200 straight from the source tree, no `collectstatic`.
- Vue switch on → `http://localhost:5173/static/vue/src/mqtt-monitor-map.js`; off → `/static/vue/mqtt-monitor-map.js`.
- `make frontend` served the island entry at the exact URL `{% vue_bundle_url %}` emits.
- `make attach` target: PID 1 is the `bash --init-file` shell with `runserver` its child.
- No `__pycache__` written into the host tree.
- **Full suite: 1242 tests, 92.9s, green.** `make test-keepdb` cold → warm: 13.6s → 3.5s.

## Also here

`README.md` documented `docker compose exec wis2watch manage createsuperuser`, which fails — `docker compose exec` does not run the image's entrypoint, so its `manage` command is not on `PATH`. Fixed in its own commit.

No issue reference in the commit subjects: `gh issue list` turned up nothing covering this, and I would rather leave them unqualified than invent a number.