### PR TITLE
A database backup a hypertable survives

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,6 +156,21 @@ attach: check-dev ## Attach to runserver -- ctrl-c stops it, ctrl-p ctrl-q detac
 	$(COMPOSE) attach wis2watch
 
 # ======================================================
+# DATABASE BACKUPS
+# ======================================================
+
+.PHONY: db-dump
+db-dump: check-dev ## Dump the database to docker/backup/
+	$(MANAGE) dbbackup
+
+# No --noinput: the prompt is the second of the two things standing between a
+# mistyped environment and a destroyed database. The flag is the first, and it
+# is spelled out rather than abbreviated on purpose. See docs/development.md.
+.PHONY: db-restore
+db-restore: check-dev ## Restore the newest dump -- DROPS the current database first
+	$(MANAGE) dbrestore --i-know-this-drops-the-database
+
+# ======================================================
 # HELP
 # ======================================================
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,9 @@ x-backend-variables: &backend-variables
 services:
   wis2watch_db:
     container_name: wis2watch_db
-    image: timescale/timescaledb-ha:pg17
+    # Pinned exactly, not to the floating pg17 tag. A TimescaleDB dump can only
+    # be restored into the extension version it was taken from
+    image: timescale/timescaledb-ha:pg17.10-ts2.29.1
     restart: always
     command: postgres -c max_connections=${POSTGRES_MAX_CONNECTIONS:-300} -c shared_buffers=${POSTGRES_SHARED_BUFFERS:-2GB}
     environment:

--- a/docs/development.md
+++ b/docs/development.md
@@ -195,6 +195,55 @@ On **Linux** it fails. Your source tree belongs to you, uid 9999 cannot write
 to it, and `makemigrations` dies on a permission error. Set `UID` and `GID` in
 `.env` to your own `id -u` and `id -g`, then `docker compose build`.
 
+## Database backups
+
+```bash
+make db-dump      # writes to docker/backup/
+make db-restore   # DROPS the database, then restores the newest dump
+```
+
+Both go through `django-dbbackup`, but not through its stock PostgreSQL
+connector: that one cannot restore a TimescaleDB database, and the way it fails
+is worth knowing about before you need it to work.
+
+`pg_dump` writes a hypertable out as two separate things -- the chunks, as
+ordinary tables in a `_timescaledb_internal` schema, and the catalogue rows
+saying which tables those are, inside the extension. Replaying either against a
+live extension is what TimescaleDB refuses: the catalogue is guarded, and a
+chunk restored without its catalogue row is a table that merely resembles part
+of a hypertable. The documented way through is to suspend the guards for the
+duration, with `timescaledb_pre_restore()` before and
+`timescaledb_post_restore()` after -- and dbbackup has nowhere to put those
+calls, because `RESTORE_PREFIX` and `RESTORE_SUFFIX` wrap the command line
+rather than the SQL.
+
+So `wis2watch/utils/dbbackup.py` subclasses the connector to do it, and
+`wis2watch/core/management/commands/dbrestore.py` guards what that costs.
+
+**The restore drops the database.** Not `--clean`: a hypertable cannot be
+replayed over its own remains, so the target is dropped and recreated outright.
+That makes `dbrestore` a one-command way to destroy whichever database the
+environment points at, and on a production host the environment points at
+production. Hence `--i-know-this-drops-the-database`, which has no short form
+and is not implied by `--noinput`. `make db-restore` passes the flag and leaves
+the confirmation prompt in place.
+
+**The database image is pinned.** A TimescaleDB dump can only be restored into
+the extension version it was taken from, and a custom-format dump does not
+record which that was -- so a mismatch surfaces as catalogue-level strangeness
+rather than a legible error. `docker-compose.yml` therefore names
+`timescale/timescaledb-ha:pg17.10-ts2.29.1` rather than the floating `pg17` tag,
+which would otherwise drift between a server deployed once and a laptop that
+pulled last week. Moving the pin is a deliberate act: dumps taken before it
+cannot be restored after it.
+
+**Dumps are not in `media/`.** dbbackup 5 reads its storage from
+`STORAGES["dbbackup"]`, and silently ignores the older `DBBACKUP_STORAGE`
+settings -- so configuring the old ones sends dumps to `MEDIA_ROOT` instead,
+which `nginx.conf` serves at `/media/` with nothing in front of it. A dump holds
+every broker password in the registry. `settings/base.py` sets the `STORAGES`
+alias; leave it there.
+
 ## Things worth knowing
 
 **The watchers poll.** Filesystem events from the host do not cross a bind

--- a/wis2watch/src/wis2watch/config/settings/base.py
+++ b/wis2watch/src/wis2watch/config/settings/base.py
@@ -83,6 +83,13 @@ INSTALLED_APPS = [
     "wis2watch.ingest",
     "wis2watch.ws",
     "wis2watch.monitoring",
+
+    # Below the project's own apps on purpose. Django registers management
+    # commands by walking INSTALLED_APPS in reverse, so the application listed
+    # *earliest* wins a duplicate name -- and wis2watch.core deliberately
+    # shadows dbbackup's `dbrestore` to guard the drop it performs. Moving this
+    # line above wis2watch.core would silently reinstate the unguarded version.
+    "dbbackup",
 ]
 
 MIDDLEWARE = [
@@ -136,20 +143,28 @@ DATABASES = {
     )
 }
 
-DBBACKUP_STORAGE = 'django.core.files.storage.FileSystemStorage'
-DBBACKUP_STORAGE_OPTIONS = {'location': os.path.join(BASE_DIR, "backup")}
+# Database backups. Where the dumps go is set in STORAGES["dbbackup"] below:
+# dbbackup 5 reads that alias, and ignores the DBBACKUP_STORAGE settings older
+# versions used. Ignores them silently, so the symptom of setting them instead
+# is dumps landing in MEDIA_ROOT, which nginx serves to the public.
 DBBACKUP_CLEANUP_KEEP_MEDIA = 1
 DBBACKUP_CLEANUP_KEEP = 1
+
+# Both entries name the same connector because dbbackup consults them in turn:
+# the alias entry wins whenever one exists for the database being dumped, so
+# CONNECTOR_MAPPING on its own would never be reached while "default" is here.
+#
+# There are deliberately no DUMP_SUFFIX or RESTORE_SUFFIX entries. `-e plpgsql`
+# once lived here, and excluded TimescaleDB's catalogue from the dump while
+# still dumping the chunk tables it describes -- which is a dump that cannot be
+# restored. The connector owns its own flags; see wis2watch/utils/dbbackup.py.
+DBBACKUP_CONNECTOR = "wis2watch.utils.dbbackup.TimescaleConnector"
 DBBACKUP_CONNECTORS = {
-    "default": {
-        "CONNECTOR": "dbbackup.db.postgresql.PgDumpBinaryConnector",  # Use pg_dump binary
-        "DUMP_SUFFIX": "-e plpgsql",  # dump only system extensions
-        "RESTORE_SUFFIX": "--if-exists"  # Drop only if exists
-    }
+    "default": {"CONNECTOR": DBBACKUP_CONNECTOR},
 }
 
 DBBACKUP_CONNECTOR_MAPPING = {
-    "timescale.db.backends.postgis": "dbbackup.db.postgresql.PgDumpBinaryConnector",
+    "timescale.db.backends.postgis": DBBACKUP_CONNECTOR,
 }
 
 # Password validation
@@ -207,6 +222,13 @@ STORAGES = {
     },
     "staticfiles": {
         "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
+    },
+    # Database dumps, which must not fall back to the default storage: that is
+    # MEDIA_ROOT, and nginx serves MEDIA_ROOT at /media/ with no authentication
+    # in front of it. A dump holds every broker password in the registry.
+    "dbbackup": {
+        "BACKEND": "django.core.files.storage.FileSystemStorage",
+        "OPTIONS": {"location": os.path.join(BASE_DIR, "backup")},
     },
 }
 

--- a/wis2watch/src/wis2watch/core/management/commands/dbrestore.py
+++ b/wis2watch/src/wis2watch/core/management/commands/dbrestore.py
@@ -1,0 +1,58 @@
+"""``dbrestore``, with the drop it performs made impossible to do by accident.
+
+The TimescaleDB connector restores by dropping the target database and
+recreating it, because a hypertable cannot be replayed over its own remains.
+That makes ``dbrestore`` a one-command way to destroy whichever database the
+environment happens to point at -- and the environment on a production host
+points at production. Upstream's confirmation prompt is not enough on its own:
+``--noinput`` exists precisely to skip it, and a restore is the kind of thing
+that ends up in a script.
+
+So the destruction has to be named on the command line. A flag nobody types by
+muscle memory, and which reads, in a shell history or a runbook, as a decision
+that was made rather than a default that was taken.
+
+This shadows ``dbbackup``'s own command. Django registers commands by walking
+INSTALLED_APPS in reverse, so a duplicate name goes to the application listed
+*earliest* -- which is why ``dbbackup`` sits below the project's apps there.
+Reordering the two silently reinstates upstream's version, and with it the
+unguarded drop, which is the sort of change that looks like tidying.
+"""
+
+from dbbackup.management.commands.dbrestore import Command as DbRestoreCommand
+from django.core.management.base import CommandError
+
+#: Long, unabbreviated, and a full sentence about the consequence. Typing it is
+#: meant to be the moment someone checks which database they are pointed at.
+CONFIRM_FLAG = "--i-know-this-drops-the-database"
+
+
+class Command(DbRestoreCommand):
+    help = (
+        "Restore a database backup. Drops and recreates the target database, "
+        f"so it requires {CONFIRM_FLAG}."
+    )
+
+    def add_arguments(self, parser):
+        super().add_arguments(parser)
+        parser.add_argument(
+            CONFIRM_FLAG,
+            action="store_true",
+            dest="confirmed_drop",
+            help="Required. Confirms that the target database is to be destroyed.",
+        )
+
+    def handle(self, *args, **options):
+        if not options.get("confirmed_drop"):
+            # The database is named because the whole failure mode this guards
+            # against is being sure you were pointed somewhere else.
+            from django.db import connections
+
+            name = connections["default"].settings_dict["NAME"]
+            raise CommandError(
+                f"This would DROP the database '{name}' and rebuild it from a "
+                f"backup. Every row currently in it would be lost.\n\n"
+                f"If that is what you want, pass {CONFIRM_FLAG}."
+            )
+
+        return super().handle(*args, **options)

--- a/wis2watch/src/wis2watch/utils/dbbackup.py
+++ b/wis2watch/src/wis2watch/utils/dbbackup.py
@@ -1,0 +1,159 @@
+"""Making ``dbbackup`` able to restore a TimescaleDB database.
+
+django-dbbackup's PostgreSQL connector is written for a plain database, and a
+hypertable is not one. ``pg_dump`` writes the chunks out as ordinary tables in
+``_timescaledb_internal``, and writes the rows that say *which* tables those
+are into the extension's own catalogue. Replaying either one against a live
+extension is what TimescaleDB refuses to allow: the catalogue is guarded, and
+a chunk arriving without its catalogue row is a table that merely resembles
+part of a hypertable.
+
+TimescaleDB's answer is to put the extension into a restoring state for the
+duration -- ``timescaledb_pre_restore()`` before and ``timescaledb_post_restore()``
+after -- which suspends the guards and the background workers. dbbackup has
+nowhere to put those calls: ``restore_prefix`` and ``restore_suffix`` wrap the
+*command line*, not statements, so there is no hook that runs SQL either side
+of ``pg_restore``. Hence a connector rather than configuration.
+
+Three consequences follow from that pair of calls, and each is why one of
+upstream's defaults is turned off below:
+
+``--single-transaction``
+    ``pre_restore()`` has to be committed before ``pg_restore`` starts, so the
+    restore cannot be the same transaction. Wrapping it in one is not a
+    stricter version of this procedure; it is a different procedure that
+    cannot work.
+
+``--clean --if-exists``
+    Emits ``DROP`` against extension-owned objects -- the very machinery
+    ``pre_restore()`` has just suspended. The target is dropped and recreated
+    here instead, which is both cleaner and what TimescaleDB documents.
+
+extension creation
+    ``timescaledb_pre_restore()`` is provided *by* the extension, so it cannot
+    be called on a database that does not have it yet -- and a freshly created
+    database has nothing. The extensions are therefore created before the
+    dump is replayed, rather than by it. ``PgDumpGisConnector`` already does
+    exactly this for PostGIS, for exactly this reason.
+
+The restore drops the database it points at. Nothing here guards that; the
+guard belongs where the argv is, and lives in the ``dbrestore`` command in
+``wis2watch.core.management.commands``.
+"""
+
+import logging
+
+from dbbackup.db.postgresql import PgDumpBinaryConnector, parse_postgres_settings
+
+logger = logging.getLogger("dbbackup.command")
+
+#: Applied to the dump. Prod's roles, grants and tablespaces do not exist on a
+#: developer's laptop, and without these every one of them is an error to read
+#: past on the way to finding out whether the restore actually worked.
+DUMP_FLAGS = ("--no-owner", "--no-privileges", "--no-tablespaces")
+
+#: The extensions the dump's objects are defined in terms of. ``timescaledb``
+#: is here because ``pre_restore()`` needs it; ``postgis`` because a geometry
+#: column cannot be created before the type exists.
+REQUIRED_EXTENSIONS = ("timescaledb", "postgis")
+
+
+class TimescaleConnector(PgDumpBinaryConnector):
+    """``pg_dump``/``pg_restore`` with TimescaleDB's restore procedure around it.
+
+    Restoring is destructive by design: the target database is dropped and
+    recreated, because a hypertable cannot be replayed over its own remains.
+    """
+
+    psql_cmd = "psql"
+
+    # See the module docstring. Each of these is incompatible with the
+    # pre/post-restore procedure rather than merely unnecessary alongside it.
+    single_transaction = False
+    drop = False
+    if_exists = False
+
+    #: Inserted immediately after ``pg_restore``. The dump was taken with the
+    #: matching flags; repeating them means a dump someone took by hand still
+    #: restores onto a laptop that has none of prod's roles.
+    pg_options = ["--no-owner", "--no-privileges"]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Appended rather than substituted for upstream's `_create_dump`, so a
+        # dbbackup upgrade that changes how the dump line is assembled does not
+        # silently drop these.
+        self.dump_suffix = " ".join((*DUMP_FLAGS, self.dump_suffix)).strip()
+
+    def _psql(self, statement, *, dbname=None):
+        """Run one statement, against the target database unless told otherwise.
+
+        Args:
+            statement: the SQL to run.
+            dbname: the database to run it in, or None for the target. The
+                drop and create are run against ``postgres``, since a database
+                cannot be dropped by a session connected to it.
+        """
+        cmd_part, pg_env = parse_postgres_settings(self)
+
+        if dbname is not None:
+            cmd_part = f"{cmd_part.rsplit('/', 1)[0]}/{dbname}"
+
+        # --tuples-only --no-align so that a statement asked for its value
+        # yields the value alone. DDL prints nothing either way.
+        cmd = (
+            f"{self.psql_cmd} {cmd_part} --quiet --no-psqlrc --tuples-only --no-align "
+            f'--set ON_ERROR_STOP=on -c "{statement}"'
+        )
+        return self.run_command(cmd, env={**self.restore_env, **pg_env})
+
+    def _recreate_database(self):
+        """Replace the target database with an empty one carrying the extensions.
+
+        ``WITH (FORCE)`` because the developer stack keeps five services
+        connected to this database, and a restore that fails on whichever one
+        happened to be up is a coin toss rather than a procedure.
+        """
+        name = self.settings["NAME"]
+
+        self._psql(f'DROP DATABASE IF EXISTS "{name}" WITH (FORCE)', dbname="postgres")
+        self._psql(f'CREATE DATABASE "{name}"', dbname="postgres")
+
+        for extension in REQUIRED_EXTENSIONS:
+            self._psql(f"CREATE EXTENSION IF NOT EXISTS {extension} CASCADE")
+
+    def _restore_dump(self, dump):
+        """Replay the dump into a database made ready to receive a hypertable."""
+        # Django's own connection to the database being dropped would block the
+        # drop. Nothing here needs the ORM.
+        from django.db import connections
+
+        connections.close_all()
+
+        self._recreate_database()
+
+        version = self._extension_version()
+        logger.info("Restoring into timescaledb %s", version)
+
+        self._psql("SELECT timescaledb_pre_restore()")
+        try:
+            return super()._restore_dump(dump)
+        finally:
+            # Unconditional: a database left in the restoring state has its
+            # background workers stopped and its guards down, and a failed
+            # restore is exactly when someone is least likely to notice.
+            self._psql("SELECT timescaledb_post_restore()")
+
+    def _extension_version(self):
+        """The target's TimescaleDB version, for the log.
+
+        A dump can only be replayed into the version it was taken from, and
+        nothing in a custom-format dump records which that was. This cannot
+        check the pairing, then -- it can only leave the target's half of it in
+        the log, so that a restore that behaved strangely can be placed against
+        the image that was running.
+        """
+        stdout, _ = self._psql(
+            "SELECT extversion FROM pg_extension WHERE extname = 'timescaledb'"
+        )
+        return stdout.read().decode().strip() or "unknown"

--- a/wis2watch/src/wis2watch/utils/tests/test_dbbackup.py
+++ b/wis2watch/src/wis2watch/utils/tests/test_dbbackup.py
@@ -1,0 +1,145 @@
+"""Tests for the TimescaleDB backup connector.
+
+These assert on the command lines the connector builds, and run no database
+commands at all. That is the point rather than a shortcut: the connector
+overrides a *private* method of django-dbbackup, whose command builder has
+changed shape between releases, and the failure this guards against is an
+upgrade quietly reinstating a flag that TimescaleDB cannot restore under.
+
+A round trip against a real hypertable would exercise something these cannot,
+but it would also be the slowest test in the suite, and it would not fail on
+the change these are here to catch.
+"""
+
+import io
+
+from django.test import SimpleTestCase
+
+from ..dbbackup import TimescaleConnector
+
+
+class RecordingConnector(TimescaleConnector):
+    """A connector that records its commands instead of running them."""
+
+    def __init__(self, *args, fail_restore=False, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.commands = []
+        self.fail_restore = fail_restore
+
+    def run_command(self, command, stdin=None, env=None):
+        self.commands.append(command)
+
+        if self.fail_restore and command.startswith("pg_restore"):
+            raise RuntimeError("pg_restore failed")
+
+        return io.BytesIO(b"2.29.1\n"), io.BytesIO(b"")
+
+    @property
+    def restore_commands(self):
+        """Just the statements, for asserting on the order they ran in."""
+        return [c for c in self.commands if not c.startswith("pg_restore")]
+
+
+class DumpCommandTests(SimpleTestCase):
+    """What the dump is taken with."""
+
+    def dump_command(self):
+        connector = RecordingConnector()
+        connector.create_dump()
+        return connector.commands[0]
+
+    def test_dumps_in_the_format_pg_restore_reads(self):
+        self.assertIn("--format=custom", self.dump_command())
+
+    def test_drops_what_a_laptop_cannot_reproduce(self):
+        """Prod's roles, grants and tablespaces exist on no developer machine."""
+        command = self.dump_command()
+
+        self.assertIn("--no-owner", command)
+        self.assertIn("--no-privileges", command)
+        self.assertIn("--no-tablespaces", command)
+
+    def test_does_not_exclude_the_extensions(self):
+        """`-e plpgsql` once lived in the settings, and made restores impossible.
+
+        It excluded TimescaleDB's catalogue from the dump while still dumping
+        the chunk tables that catalogue describes -- so the chunks arrived
+        naming a schema that nothing had created.
+        """
+        self.assertNotIn(" -e ", self.dump_command())
+        self.assertNotIn("--extension", self.dump_command())
+
+
+class RestoreCommandTests(SimpleTestCase):
+    """What the restore does, and in what order."""
+
+    def restore(self, **kwargs):
+        connector = RecordingConnector(**kwargs)
+        connector.restore_dump(io.BytesIO(b""))
+        return connector
+
+    def test_puts_the_extension_into_the_restoring_state(self):
+        commands = self.restore().commands
+
+        pre = next(i for i, c in enumerate(commands) if "timescaledb_pre_restore" in c)
+        restore = next(i for i, c in enumerate(commands) if c.startswith("pg_restore"))
+        post = next(i for i, c in enumerate(commands) if "timescaledb_post_restore" in c)
+
+        self.assertLess(pre, restore)
+        self.assertLess(restore, post)
+
+    def test_leaves_the_extension_out_of_it_when_the_restore_fails(self):
+        """A database left restoring has its guards down and its workers stopped.
+
+        Which is the state nobody checks for, on the occasion nobody expected.
+        """
+        connector = RecordingConnector(fail_restore=True)
+
+        with self.assertRaises(RuntimeError):
+            connector.restore_dump(io.BytesIO(b""))
+
+        self.assertTrue(
+            any("timescaledb_post_restore" in c for c in connector.commands)
+        )
+
+    def test_replaces_the_database_rather_than_cleaning_it(self):
+        """--clean would DROP the very objects pre_restore has just suspended."""
+        commands = self.restore().commands
+        restore = next(c for c in commands if c.startswith("pg_restore"))
+
+        self.assertNotIn("--clean", restore)
+        self.assertNotIn("--if-exists", restore)
+        self.assertTrue(any("DROP DATABASE" in c for c in commands))
+        self.assertTrue(any("CREATE DATABASE" in c for c in commands))
+
+    def test_does_not_wrap_the_restore_in_a_transaction(self):
+        """pre_restore has to be committed before pg_restore starts."""
+        restore = next(c for c in self.restore().commands if c.startswith("pg_restore"))
+
+        self.assertNotIn("--single-transaction", restore)
+
+    def test_creates_the_extensions_before_it_needs_them(self):
+        """pre_restore is provided by the extension, so it cannot come first."""
+        commands = self.restore().commands
+
+        timescale = next(i for i, c in enumerate(commands) if "EXTENSION IF NOT EXISTS timescaledb" in c)
+        postgis = next(i for i, c in enumerate(commands) if "EXTENSION IF NOT EXISTS postgis" in c)
+        pre = next(i for i, c in enumerate(commands) if "timescaledb_pre_restore" in c)
+
+        self.assertLess(timescale, pre)
+        self.assertLess(postgis, pre)
+
+    def test_drops_the_database_from_outside_itself(self):
+        """A session connected to a database cannot drop it."""
+        drop = next(c for c in self.restore().commands if "DROP DATABASE" in c)
+
+        self.assertIn("/postgres", drop)
+        # The developer stack keeps five services connected; without FORCE the
+        # drop succeeds or fails depending on which of them happened to be up.
+        self.assertIn("WITH (FORCE)", drop)
+
+    def test_restores_without_prod_ownership(self):
+        restore = next(c for c in self.restore().commands if c.startswith("pg_restore"))
+
+        self.assertIn("--no-owner", restore)
+        self.assertIn("--no-privileges", restore)


### PR DESCRIPTION
`django-dbbackup` was configured in settings but never added to `INSTALLED_APPS`, so `dbbackup` and `dbrestore` did not exist as commands. Turning them on found that neither half worked against this database.

## What was broken

**The dump could not be restored.** `DUMP_SUFFIX: "-e plpgsql"` excluded the extensions from the dump while still dumping the chunk tables TimescaleDB's catalogue describes, so `pg_restore` died on a schema nothing had created:

```
pg_restore: error: ERROR:  schema "_timescaledb_internal" does not exist
Command was: CREATE TABLE _timescaledb_internal._hyper_1_1_chunk (...)
```

**The restore procedure was unreachable.** `pg_dump` writes a hypertable out as two separate things — the chunks, as ordinary tables, and the catalogue rows saying which tables those are, inside the extension. Replaying either against a live extension is what TimescaleDB refuses; it has to be suspended with `timescaledb_pre_restore()` / `post_restore()`. dbbackup has nowhere to put those calls, since `RESTORE_PREFIX`/`RESTORE_SUFFIX` wrap the command line rather than the SQL.

**Dumps were landing in `MEDIA_ROOT`.** dbbackup 5 reads `STORAGES["dbbackup"]` and silently ignores the `DBBACKUP_STORAGE` settings that were set. `nginx.conf` serves `/media/` with no authentication, and a dump holds every broker password in `MessageSource`.

## What this does

- `utils/dbbackup.py` — a connector that creates the extensions, drops and recreates the target, and wraps `pg_restore` in the pre/post-restore procedure. Drops `--single-transaction` and `--clean`, which are incompatible with it rather than merely unnecessary alongside it.
- `core/management/commands/dbrestore.py` — the restore drops the database, so it requires `--i-know-this-drops-the-database`. `dbbackup` sits below the project's apps in `INSTALLED_APPS` so this shadow wins.
- `STORAGES["dbbackup"]` points at `backup/`, and the dead settings are gone.
- The database image is pinned to `pg17.10-ts2.29.1`. A dump only restores into the extension version it came from, and nothing in a custom-format dump records which that was.
- `make db-dump` / `make db-restore`, and a section in `docs/development.md`.

## Verification

Round trip against a seeded hypertable — 5 daily chunks, 240 rows, PostGIS geometry. Post-restore state diffed **byte-identical** to pre-dump, and a fresh insert afterwards created chunk #6 at the correct day boundary, which is what separates a live hypertable from a table holding the old rows. `timescaledb.restoring` back to `off`.

10 connector tests assert on the built command lines and touch no database — the failure worth catching is a dbbackup upgrade quietly reinstating a flag a hypertable cannot restore under. Full suite: 1252 tests, OK.

## Not addressed here

If `dbbackup` was ever run on a deployed instance before this change, a dump may already exist in prod's `media/` directory and be fetchable at `/media/`. This stops new ones landing there; it cannot retract an old one.