### PR TITLE
docs: document the production dbbackup command

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -202,6 +202,21 @@ make db-dump      # writes to docker/backup/
 make db-restore   # DROPS the database, then restores the newest dump
 ```
 
+Those two targets are development-only -- like everything in the `Makefile`,
+they refuse to run unless the development overlay is switched on. The backup
+itself is not: `make db-dump` is a wrapper around a management command, and on
+a production host you run that command directly.
+
+```bash
+docker compose exec wis2watch python manage.py dbbackup
+docker compose exec wis2watch python manage.py dbrestore --i-know-this-drops-the-database
+```
+
+There is deliberately no `make` target for this. A production deployment drives
+`docker compose` itself, and a friendlier name for the restore would put the
+command that drops the production database one tab-completion away from the one
+that drops the local one.
+
 Both go through `django-dbbackup`, but not through its stock PostgreSQL
 connector: that one cannot restore a TimescaleDB database, and the way it fails
 is worth knowing about before you need it to work.


### PR DESCRIPTION
`make db-dump` is guarded by `check-dev` like every other Makefile target, which makes it read as though database backups are a development-only capability. They are not — the target is a thin wrapper around `manage.py dbbackup`, which runs anywhere.

Documents the raw `docker compose exec` form for both dump and restore in `docs/development.md`, and records why there is deliberately no production `make` target: `dbrestore` drops whichever database the environment points at.

Docs only, no code change.