### PR TITLE
fix: dbrestore silently lost the flags TimescaleDB needs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,7 @@ services:
     container_name: wis2watch_db
     # Pinned exactly, not to the floating pg17 tag. A TimescaleDB dump can only
     # be restored into the extension version it was taken from
-    image: timescale/timescaledb-ha:pg17.10-ts2.29.1
+    image: timescale/timescaledb-ha:pg17.10-ts2.28.1
     restart: always
     command: postgres -c max_connections=${POSTGRES_MAX_CONNECTIONS:-300} -c shared_buffers=${POSTGRES_SHARED_BUFFERS:-2GB}
     environment:

--- a/docs/development.md
+++ b/docs/development.md
@@ -209,7 +209,20 @@ a production host you run that command directly.
 
 ```bash
 docker compose exec wis2watch python manage.py dbbackup
+```
+
+A restore needs the writers stopped first. The connector empties the database
+before it replays the dump, and the services reconnect to the empty one and
+carry on writing -- so a row the stack writes during the restore collides with
+the same primary key arriving from the dump, and `pg_restore` fails at the end
+building the index. `wis2watch` itself stays up because it is the container
+being exec'd into; stopping the proxy is what leaves it idle.
+
+```bash
+docker compose stop wis2watch_celery_worker wis2watch_celery_beat \
+                    wis2watch_ingest wis2watch_web_proxy
 docker compose exec wis2watch python manage.py dbrestore --i-know-this-drops-the-database
+docker compose start
 ```
 
 There is deliberately no `make` target for this. A production deployment drives
@@ -247,7 +260,7 @@ the confirmation prompt in place.
 the extension version it was taken from, and a custom-format dump does not
 record which that was -- so a mismatch surfaces as catalogue-level strangeness
 rather than a legible error. `docker-compose.yml` therefore names
-`timescale/timescaledb-ha:pg17.10-ts2.29.1` rather than the floating `pg17` tag,
+`timescale/timescaledb-ha:pg17.10-ts2.28.1` rather than the floating `pg17` tag,
 which would otherwise drift between a server deployed once and a laptop that
 pulled last week. Moving the pin is a deliberate act: dumps taken before it
 cannot be restored after it.

--- a/wis2watch/src/wis2watch/utils/dbbackup.py
+++ b/wis2watch/src/wis2watch/utils/dbbackup.py
@@ -52,6 +52,10 @@ logger = logging.getLogger("dbbackup.command")
 #: past on the way to finding out whether the restore actually worked.
 DUMP_FLAGS = ("--no-owner", "--no-privileges", "--no-tablespaces")
 
+#: Applied to the restore. Named separately from DUMP_FLAGS because they have
+#: to be re-applied during the restore itself; see ``_restore_dump``.
+RESTORE_FLAGS = ("--no-owner", "--no-privileges")
+
 #: The extensions the dump's objects are defined in terms of. ``timescaledb``
 #: is here because ``pre_restore()`` needs it; ``postgis`` because a geometry
 #: column cannot be created before the type exists.
@@ -76,7 +80,7 @@ class TimescaleConnector(PgDumpBinaryConnector):
     #: Inserted immediately after ``pg_restore``. The dump was taken with the
     #: matching flags; repeating them means a dump someone took by hand still
     #: restores onto a laptop that has none of prod's roles.
-    pg_options = ["--no-owner", "--no-privileges"]
+    pg_options = list(RESTORE_FLAGS)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -124,10 +128,28 @@ class TimescaleConnector(PgDumpBinaryConnector):
 
     def _restore_dump(self, dump):
         """Replay the dump into a database made ready to receive a hypertable."""
-        # Django's own connection to the database being dropped would block the
-        # drop. Nothing here needs the ORM.
         from django.db import connections
 
+        # Setting these as class attributes is not enough. dbbackup's own
+        # `dbrestore` assigns `connector.drop` and `connector.pg_options` from
+        # its command-line options in the line before it calls this, so
+        # whatever the class said has already been overwritten by the time the
+        # restore starts -- `drop` back to True, `pg_options` back to empty.
+        # Re-asserting them here is the last word on it.
+        #
+        # What that assignment costs, left standing: `drop` puts back --clean
+        # and --if-exists, whose DROPs go against the extension-owned objects
+        # that `pre_restore()` has just suspended the guards on. They fail, the
+        # tables they should have removed keep the rows already in them, and
+        # the dump's data is then appended to those -- so the restore ends in
+        # a wall of duplicate-key errors, several minutes in, on a database it
+        # has already emptied.
+        self.drop = False
+        self.if_exists = False
+        self.pg_options = list(RESTORE_FLAGS)
+
+        # Django's own connection to the database being dropped would block the
+        # drop. Nothing here needs the ORM.
         connections.close_all()
 
         self._recreate_database()

--- a/wis2watch/src/wis2watch/utils/tests/test_dbbackup.py
+++ b/wis2watch/src/wis2watch/utils/tests/test_dbbackup.py
@@ -102,6 +102,28 @@ class RestoreCommandTests(SimpleTestCase):
             any("timescaledb_post_restore" in c for c in connector.commands)
         )
 
+    def test_holds_its_flags_against_the_command_that_overwrites_them(self):
+        """dbbackup's `dbrestore` sets these on the connector before it calls it.
+
+        `connector.drop = not self.no_drop` and `connector.pg_options = ...`,
+        in the two lines above `connector.restore_dump(...)`. So the class
+        attributes are set, then overwritten, then used -- and the restore runs
+        with the --clean that the whole procedure exists to avoid. This
+        reproduces that assignment rather than trusting the defaults, because
+        the defaults are not what the connector runs with in production.
+        """
+        connector = RecordingConnector()
+        connector.drop = True
+        connector.if_exists = True
+        connector.pg_options = ""
+
+        connector.restore_dump(io.BytesIO(b""))
+        restore = next(c for c in connector.commands if c.startswith("pg_restore"))
+
+        self.assertNotIn("--clean", restore)
+        self.assertNotIn("--if-exists", restore)
+        self.assertIn("--no-owner", restore)
+
     def test_replaces_the_database_rather_than_cleaning_it(self):
         """--clean would DROP the very objects pre_restore has just suspended."""
         commands = self.restore().commands


### PR DESCRIPTION
## What was wrong

django-dbbackup 5.0.0's `dbrestore` command does this immediately before handing off to the connector (`dbbackup/management/commands/dbrestore.py:160-161`):

```python
self.connector.drop = not self.no_drop
self.connector.pg_options = self.pg_options
```

Both assignments land after `__init__` and before the restore, so `TimescaleConnector`'s `drop = False` and `pg_options = [...]` were overwritten on every run. Every restore has been running as:

```
pg_restore --dbname=... --clean --if-exists
```

`--clean` emits DROPs against the extension-owned objects that `timescaledb_pre_restore()` has just suspended the guards on — the exact thing the connector's docstring says must not happen. The DROPs fail, the tables keep the rows already in them, the dump's data is appended on top, and the restore dies building unique indexes several minutes in, with ~91 duplicate-key errors that never mention the flag responsible.

## The fix

Re-assert the three flags inside `_restore_dump`, after the command has had its say. Class attributes are not sufficient here and the comment explains why, so the next dbbackup upgrade doesn't quietly undo it.

Verified end to end: the restore that produced 91 errors now exits 0 with none, and the restored database matches the dump exactly (105 hard failures, 7,976 stations, 32 nodes, 774,710 notification messages).

## Test gap this closes

The existing tests call `connector.restore_dump()` directly — the one path where the class attributes *do* survive, which is why they stayed green throughout. The new test performs the command's assignment first. Reverting the fix makes it fail with the exact command line from the traceback.

## Also here

- **Image pin moved to `pg17.10-ts2.28.1`**, matching the TimescaleDB the dumps are taken from. `_timescaledb_catalog.chunk` differs between 2.28.1 and 2.29.1, and restoring across that gap fails with `column "schema_name" of relation "chunk" does not exist` — which reads as corruption rather than a version mismatch. `docs/development.md` updated to match.
- **Production restore procedure now stops the writers first.** Separate problem, found while verifying: the connector empties the database, the running services reconnect to the empty one and keep writing, and a row written mid-restore collides with the same primary key arriving from the dump. Reproduced twice with timestamps. This PR documents the workaround; it does **not** fix it — see below.

## Not fixed here

Nothing stops the stack writing into the database mid-restore. `_recreate_database` clears connections with `WITH (FORCE)`, but they reconnect immediately. It needs a decision on whether `dbrestore` should refuse to run while writers are up, or the Makefile target should stop them — worth its own issue.