### PR TITLE
fix: dbrestore refuses to run while the writers are up

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,12 +163,24 @@ attach: check-dev ## Attach to runserver -- ctrl-c stops it, ctrl-p ctrl-q detac
 db-dump: check-dev ## Dump the database to docker/backup/
 	$(MANAGE) dbbackup
 
+# Not $(MANAGE): that is `compose exec`, which needs the web container running,
+# and `dbrestore` refuses to start while anything else holds a connection to
+# the database it is about to empty. So the stack comes down, the restore runs
+# in a container of its own, and the stack goes back up -- back up even when
+# the restore failed, which is why this is one shell line keeping the status.
+#
 # No --noinput: the prompt is the second of the two things standing between a
 # mistyped environment and a destroyed database. The flag is the first, and it
 # is spelled out rather than abbreviated on purpose. See docs/development.md.
+WRITERS = wis2watch wis2watch_celery_worker wis2watch_celery_beat wis2watch_ingest wis2watch_web_proxy
+
 .PHONY: db-restore
 db-restore: check-dev ## Restore the newest dump -- DROPS the current database first
-	$(MANAGE) dbrestore --i-know-this-drops-the-database
+	@$(COMPOSE) stop $(WRITERS); \
+	$(COMPOSE) run --rm --no-deps wis2watch manage dbrestore --i-know-this-drops-the-database; \
+	status=$$?; \
+	$(COMPOSE) start; \
+	exit $$status
 
 # ======================================================
 # HELP

--- a/docs/development.md
+++ b/docs/development.md
@@ -211,19 +211,24 @@ a production host you run that command directly.
 docker compose exec wis2watch python manage.py dbbackup
 ```
 
-A restore needs the writers stopped first. The connector empties the database
-before it replays the dump, and the services reconnect to the empty one and
-carry on writing -- so a row the stack writes during the restore collides with
-the same primary key arriving from the dump, and `pg_restore` fails at the end
-building the index. `wis2watch` itself stays up because it is the container
-being exec'd into; stopping the proxy is what leaves it idle.
+A restore needs the whole stack stopped first, `wis2watch` included, which is
+why it runs in a container of its own rather than through `exec`:
 
 ```bash
-docker compose stop wis2watch_celery_worker wis2watch_celery_beat \
-                    wis2watch_ingest wis2watch_web_proxy
-docker compose exec wis2watch python manage.py dbrestore --i-know-this-drops-the-database
+docker compose stop wis2watch wis2watch_celery_worker \
+                    wis2watch_celery_beat wis2watch_ingest wis2watch_web_proxy
+docker compose run --rm --no-deps wis2watch manage dbrestore --i-know-this-drops-the-database
 docker compose start
 ```
+
+`dbrestore` checks this rather than trusting it, and names whatever it finds
+still connected. The reason is that the connector empties the database before
+it replays the dump, and nothing that was connected stays away: `WITH (FORCE)`
+closes those sessions, and the services reopen them within the second, against
+a database that is now empty and taking writes. A celery tick or an ingest
+write then takes a primary key the dump is about to bring, and `pg_restore`
+fails building that index at the very end -- naming a row written an hour
+earlier, which is nobody's first guess.
 
 There is deliberately no `make` target for this. A production deployment drives
 `docker compose` itself, and a friendlier name for the restore would put the

--- a/wis2watch/src/wis2watch/core/management/commands/dbrestore.py
+++ b/wis2watch/src/wis2watch/core/management/commands/dbrestore.py
@@ -12,6 +12,14 @@ So the destruction has to be named on the command line. A flag nobody types by
 muscle memory, and which reads, in a shell history or a runbook, as a decision
 that was made rather than a default that was taken.
 
+The same reasoning covers the second guard here. The restore empties the
+database before it replays the dump, and every other service goes on holding
+its connection through that -- so a celery beat tick or an ingest write lands
+in the empty database, takes the primary key the dump is about to bring, and
+the restore fails building an index an hour after the row that broke it was
+written. The connection is the thing that can be checked, so it is what gets
+checked.
+
 This shadows ``dbbackup``'s own command. Django registers commands by walking
 INSTALLED_APPS in reverse, so a duplicate name goes to the application listed
 *earliest* -- which is why ``dbbackup`` sits below the project's apps there.
@@ -25,6 +33,18 @@ from django.core.management.base import CommandError
 #: Long, unabbreviated, and a full sentence about the consequence. Typing it is
 #: meant to be the moment someone checks which database they are pointed at.
 CONFIRM_FLAG = "--i-know-this-drops-the-database"
+
+#: Sessions on the target database that are neither this command's own nor the
+#: extension's. ``backend_type`` excludes TimescaleDB's background workers,
+#: which are always there and which ``pre_restore()`` stops anyway.
+OTHER_SESSIONS = """
+    SELECT pid, coalesce(host(client_addr), 'local socket'), state
+    FROM pg_stat_activity
+    WHERE datname = current_database()
+      AND backend_type = 'client backend'
+      AND pid <> pg_backend_pid()
+    ORDER BY pid
+"""
 
 
 class Command(DbRestoreCommand):
@@ -55,4 +75,47 @@ class Command(DbRestoreCommand):
                 f"If that is what you want, pass {CONFIRM_FLAG}."
             )
 
+        self.refuse_if_anything_else_is_connected()
+
         return super().handle(*args, **options)
+
+    def other_sessions(self):
+        """Every session on the target database except this command's own."""
+        from django.db import connection
+
+        with connection.cursor() as cursor:
+            cursor.execute(OTHER_SESSIONS)
+            return cursor.fetchall()
+
+    def refuse_if_anything_else_is_connected(self):
+        """Stop unless this command has the database to itself.
+
+        Dropping the database does not need this -- ``WITH (FORCE)`` closes
+        whatever is connected. Surviving the next ten minutes does: the
+        services reconnect immediately, to a database that is now empty and
+        accepting writes, and go on writing into it for the whole length of
+        the restore. What that costs is a duplicate key, discovered at the end
+        while the indexes are built, naming a row that arrived long before.
+        """
+        sessions = self.other_sessions()
+
+        if not sessions:
+            return
+
+        listed = "\n".join(
+            f"  pid {pid}, from {address} ({state})" for pid, address, state in sessions
+        )
+
+        raise CommandError(
+            f"{len(sessions)} other session(s) are connected to this database:\n\n"
+            f"{listed}\n\n"
+            f"They would keep writing into the restored database while it is "
+            f"being restored, and the restore would fail on their rows. Stop "
+            f"them first -- including the web container, which is why this is "
+            f"run in a container of its own:\n\n"
+            f"  docker compose stop wis2watch wis2watch_celery_worker \\\n"
+            f"                      wis2watch_celery_beat wis2watch_ingest \\\n"
+            f"                      wis2watch_web_proxy\n"
+            f"  docker compose run --rm --no-deps wis2watch manage dbrestore {CONFIRM_FLAG}\n"
+            f"  docker compose start"
+        )

--- a/wis2watch/src/wis2watch/core/tests/test_dbrestore_command.py
+++ b/wis2watch/src/wis2watch/core/tests/test_dbrestore_command.py
@@ -1,0 +1,80 @@
+"""Tests for the two things ``dbrestore`` refuses to do.
+
+Neither test lets the restore itself run. What is being checked is the pair of
+guards in front of it, and a restore that got as far as `super().handle()`
+would drop the database the test suite is running in.
+"""
+
+from unittest.mock import patch
+
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.test import TestCase
+
+from ..management.commands.dbrestore import Command
+
+CONFIRM = "--i-know-this-drops-the-database"
+
+#: Shaped like a `pg_stat_activity` row, because that is what the real query
+#: returns and the message is built out of the columns.
+A_SESSION = (4242, "172.23.0.5", "idle")
+
+
+class ConfirmationFlagTests(TestCase):
+    """The flag that has to be typed out."""
+
+    def test_refuses_without_it(self):
+        with self.assertRaises(CommandError) as caught:
+            call_command("dbrestore")
+
+        self.assertIn(CONFIRM, str(caught.exception))
+
+    def test_names_the_database_it_would_have_dropped(self):
+        """The failure this guards against is being sure you were elsewhere."""
+        with self.assertRaises(CommandError) as caught:
+            call_command("dbrestore")
+
+        from django.db import connections
+
+        self.assertIn(connections["default"].settings_dict["NAME"], str(caught.exception))
+
+
+class OtherSessionsTests(TestCase):
+    """The guard against restoring underneath a running stack."""
+
+    def test_refuses_while_anything_else_is_connected(self):
+        with patch.object(Command, "other_sessions", return_value=[A_SESSION]):
+            with self.assertRaises(CommandError) as caught:
+                call_command("dbrestore", CONFIRM)
+
+        message = str(caught.exception)
+        self.assertIn("4242", message)
+        self.assertIn("172.23.0.5", message)
+
+    def test_says_how_to_get_the_database_to_itself(self):
+        """A refusal nobody can act on is one people learn to work around."""
+        with patch.object(Command, "other_sessions", return_value=[A_SESSION]):
+            with self.assertRaises(CommandError) as caught:
+                call_command("dbrestore", CONFIRM)
+
+        self.assertIn("docker compose stop", str(caught.exception))
+
+    def test_restores_when_it_has_the_database_to_itself(self):
+        with patch.object(Command, "other_sessions", return_value=[]):
+            with patch(
+                "dbbackup.management.commands.dbrestore.Command.handle",
+                return_value=None,
+            ) as upstream:
+                call_command("dbrestore", CONFIRM)
+
+        self.assertTrue(upstream.called)
+
+    def test_counts_the_extension_workers_out(self):
+        """TimescaleDB's own workers are always connected, and pre_restore
+        stops them. Counting them would mean the guard never passes."""
+        sessions = Command().other_sessions()
+
+        self.assertNotIn(
+            "TimescaleDB",
+            " ".join(str(column) for row in sessions for column in row),
+        )


### PR DESCRIPTION
Follow-up to #93, which fixed the flag clobbering but left this open.

## The problem

`_recreate_database` drops the target with `WITH (FORCE)`, which closes every other session — and they reopen immediately, against a database that is now empty and accepting writes. The stack then writes into it for the entire length of the restore.

Observed twice while verifying #93, both times as `wis2watchcore_hardfailure_pkey` duplicate keys. Confirmed from the timestamps rather than inferred — `wis2watch_ingest` wrote its `ingestion_stalled` row at 18:28:52 into a restore that started at 18:28:32. The dump itself is clean: 105 rows, 105 distinct ids.

It surfaces at the very end, while indexes are built, naming a row written long before. Nobody's first guess.

## The guard

`dbrestore` now refuses unless it has the database to itself, listing what it found:

```
CommandError: 3 other session(s) are connected to this database:

  pid 2302, from 172.23.0.5 (idle)
  pid 3363, from 172.23.0.2 (idle)
  pid 3366, from 172.23.0.8 (idle)

They would keep writing into the restored database while it is being
restored, and the restore would fail on their rows. Stop them first --
including the web container, which is why this is run in a container of
its own:

  docker compose stop wis2watch wis2watch_celery_worker \
                      wis2watch_celery_beat wis2watch_ingest \
                      wis2watch_web_proxy
  docker compose run --rm --no-deps wis2watch manage dbrestore --i-know-this-drops-the-database
  docker compose start
```

It checks connections rather than containers, because a connection is what does the damage and the thing holding one is not always a container. `backend_type = 'client backend'` excludes TimescaleDB's own background workers, which are always connected and which `pre_restore()` stops anyway.

## `make db-restore` had to change

It used `$(MANAGE)` — `compose exec` — which needs the web container running, so it could never have passed the new check. It now stops the stack, restores in a one-off container via the entrypoint's `manage` passthrough, and starts the stack again, including when the restore failed. The confirmation prompt is unchanged.

## No override flag

Deliberate: the way past this is to stop the writers, and every escape hatch here is one somebody reaches for during an incident. Easy to add if it proves obstructive in practice.

## Verified

- Refuses against the live stack, naming all three sessions (output above is real).
- `make db-restore` end to end: exit 0, zero `pg_restore` errors, 774,710 notification messages restored.
- The one-off command the message prints: exit 0, zero errors.
- 18 tests pass, including four new ones covering the refusal, the message, the pass-through when alone, and the background-worker exclusion.