### PR TITLE
Give the panel header a ground of its own

### DIFF
--- a/wis2watch/src/wis2watch/core/templates/wis2watchcore/panels/all_nodes.html
+++ b/wis2watch/src/wis2watch/core/templates/wis2watchcore/panels/all_nodes.html
@@ -68,6 +68,28 @@
         border-start-end-radius: 5px;
     }
 
+    /* Wagtail hangs a dashboard panel's header 1.25rem past the panel's own
+       left edge -- `margin-inline-start: -1.25rem`, above 50em only -- and
+       then pays it back with 1.25rem of padding, so the first child lands
+       exactly on the panel's content edge and the overhang is invisible.
+
+       It stops being invisible the moment the header has a ground: the
+       background paints the whole border box, overhang included, and a grey
+       tongue sticks out past the panel's rounded corner.
+
+       Both halves are cancelled rather than just the margin, so nothing moves.
+       The margin was buying room for `.w-panel__anchor--prefix`, which is
+       `opacity: 0` until the header is hovered and which sat on the content
+       edge anyway; the first *visible* element, the toggle, is 25px inside the
+       panel either way. Scoped to the same query Wagtail scopes the margin to,
+       because below it there is no overhang to correct. */
+    @media screen and (min-width: 50em) {
+        #node-overview-section > .w-panel__header {
+            margin-inline-start: 0;
+            padding-inline-start: 0;
+        }
+    }
+
     .w-theme-dark #node-overview-section > .w-panel__header {
         background: var(--w-color-surface-header);
     }

--- a/wis2watch/src/wis2watch/core/templates/wis2watchcore/panels/all_nodes.html
+++ b/wis2watch/src/wis2watch/core/templates/wis2watchcore/panels/all_nodes.html
@@ -39,6 +39,46 @@
     has somewhere to land.
 {% endcomment %}
 
+<style>
+    /* The panel's header, given a ground of its own so it reads as a header
+       rather than as the first thing in the content. `--w-color-grey-50` is
+       the convention's subtle-background token; see
+       `.claude/docs/template_conventions.md`.
+
+       **It is not theme-aware.** Wagtail defines the raw grey scale once --
+       grey-50 is 96.9% lightness in every theme -- and `.w-theme-dark`
+       remaps only the *semantic* tokens onto other greys. Used bare, this
+       would lay a near-white bar across a dark panel. So the dark ground is
+       named too, and it is `--w-color-surface-header`, which is Wagtail's own
+       answer for a header surface and lands one step lighter than the
+       dashboard panel's own grey-800 ground.
+
+       Two selectors for the dark case, which is the scar `charts/roles.css`
+       and `core.js` both carry: Wagtail's default is `w-theme-system`, where
+       the OS decides and the class never changes at all, so naming only
+       `.w-theme-dark` leaves the header light for everybody who never opened
+       the setting -- which is most people.
+
+       The top corners are rounded to the panel's own 5px, or the ground
+       squares off a corner the border is still drawing round. */
+    #node-overview-section > .w-panel__header {
+        background: var(--w-color-grey-50);
+        border-bottom: 1px solid var(--w-color-border-furniture);
+        border-start-start-radius: 5px;
+        border-start-end-radius: 5px;
+    }
+
+    .w-theme-dark #node-overview-section > .w-panel__header {
+        background: var(--w-color-surface-header);
+    }
+
+    @media (prefers-color-scheme: dark) {
+        .w-theme-system #node-overview-section > .w-panel__header {
+            background: var(--w-color-surface-header);
+        }
+    }
+</style>
+
 {% fragment as header_controls %}
     {% dropdown toggle_icon="arrow-down" toggle_label=_("Gap reports") classname="w-inline-block" %}
         {% for report in gap_reports %}


### PR DESCRIPTION
Follow-up to #118. Template-only; no bundle change.

The homepage panel's header read as the first thing in the content rather than
as a header. It now uses `--w-color-grey-50`, the subtle-background token
`.claude/docs/template_conventions.md` names for panel headers, with a bottom
rule and the top corners taken to the panel's own 5px.

## Why this is more than one line

**`--w-color-grey-50` is not theme-aware.** Wagtail defines the raw grey scale
once — grey-50 is 96.9% lightness in every theme — and `.w-theme-dark` remaps
only the *semantic* tokens onto other greys (`--w-color-surface-dashboard-panel`
→ `grey-800`, `--w-color-surface-header` → `grey-700`).

Measured in the browser under `.w-theme-dark`, `--w-color-grey-50` still
resolves to `hsl(… calc(11.4% + 85.5%))`. Applied bare, this would have laid a
near-white bar across a dark panel.

So the dark ground is named too, as `--w-color-surface-header` — Wagtail's own
answer for a header surface, landing one step lighter than the panel's own
ground. Measured: `rgb(34,34,34)` on `rgb(29,29,29)`.

Two selectors for the dark case, matching the scar `charts/roles.css` and
`core.js` both already carry: Wagtail's default is `w-theme-system`, where the
OS decides and the class never changes, so naming only `.w-theme-dark` leaves
the header light for everybody who never opened the setting — which is most
people.

## Verification

- 71 admin tests pass.
- Checked in a browser in both themes, and the dark value measured rather than
  eyeballed.

https://claude.ai/code/session_01MKMYduSHzKRXFiMU4JDTzi
