### PR TITLE
The admin home says how much is under watch

### DIFF
--- a/wis2watch/src/wis2watch/config/templates/wagtailadmin/home.html
+++ b/wis2watch/src/wis2watch/config/templates/wagtailadmin/home.html
@@ -1,12 +1,53 @@
 {% extends "wagtailadmin/home.html" %}
 {% load i18n wagtailadmin_tags wis2watch_tags %}
 
-{% block branding_welcome %}
-    {% trans "Welcome to" %}
-    {% if 'WAGTAIL_SITE_NAME'|django_settings %}
-        {{ 'WAGTAIL_SITE_NAME'|django_settings }}
-    {% else %}
-        {% trans "WIS2Watch" %}
-    {% endif %}
-{% endblock %}
+{% comment %}
+    The admin home, with the page-explorer search taken out of its header.
 
+    Wagtail puts a search box under the welcome title that searches the page
+    tree. `construct_main_menu` hides the explorer, so on this admin that box
+    is a search of somewhere nobody can go -- and it sat directly beneath the
+    strip of counts, which is the one thing in that header anybody wants.
+
+    Wagtail wraps it in no block of its own, so removing it means restating
+    `content`. **That is a copy of Wagtail's own block**, and copies go stale:
+    an upgrade that changes what the dashboard header holds will not reach us
+    here. `AdminSmokeTests` asserts what this page must and must not carry, so
+    a Wagtail upgrade that matters fails loudly rather than quietly.
+
+    `header_title` is built here rather than left to the view. Wagtail's own
+    `content` defines it as a fragment wrapping `branding_welcome`, so a
+    restated block that omits it renders the base view's generic "Dashboard"
+    and leaves `branding_welcome` defined but unreachable.
+{% endcomment %}
+
+{% block content %}
+    {% fragment as header_title %}
+        {% block branding_welcome %}
+            {% trans "Welcome to" %}
+            {% if 'WAGTAIL_SITE_NAME'|django_settings %}
+                {{ 'WAGTAIL_SITE_NAME'|django_settings }}
+            {% else %}
+                {% trans "WIS2Watch" %}
+            {% endif %}
+        {% endblock %}
+    {% endfragment %}
+
+    {% component upgrade_notification %}
+    <div class="w-dashboard w-px-6 sm:w-px-[3.75rem] w-mt-16 sm:w-mt-10 lg:w-mt-[3.75rem]">
+        <header class="w-flex w-flex-col lg:w-flex-row">
+            <div class="lg:w-pr-20 lg:w-grow w-mb-12">
+                <h1 class="w-h1 w-mt-0">{{ header_title }}</h1>
+                {% component site_summary %}
+            </div>
+            {% include "wagtailadmin/home/account_summary.html" %}
+        </header>
+        {% if panels %}
+            {% for panel in panels %}
+                {% component panel fallback_render_method=True %}
+            {% endfor %}
+        {% else %}
+            <p>{% trans "This is your dashboard on which helpful information about content you've created will be displayed." %}</p>
+        {% endif %}
+    </div>
+{% endblock %}

--- a/wis2watch/src/wis2watch/core/panels.py
+++ b/wis2watch/src/wis2watch/core/panels.py
@@ -1,15 +1,178 @@
 """What the admin home shows on login.
 
-Wagtail's dashboard is a list of panels other people's code contributes to,
-and this is ours. It is a module of its own rather than a class in
-``wagtail_hooks``, which stays what it has always been here: wiring, and
-nothing that has to be read to understand a page.
+Two kinds of thing, and they answer two different questions. The strip of
+counts in the page header says how big the region is; the panel below it says
+how the region is doing. Both live here because both are the same decision --
+what the admin home is for -- and splitting them across two modules would let
+that decision be made twice.
+
+A module of its own rather than classes in ``wagtail_hooks``, which stays what
+it has always been here: wiring, and nothing that has to be read to understand
+a page.
 """
 
-from django.urls import reverse_lazy
+from django.urls import reverse, reverse_lazy
+from django.utils.functional import cached_property
+from django.utils.translation import ngettext_lazy
+from wagtail.admin.site_summary import SummaryItem
 from wagtail.admin.ui.components import Component
 
 from .analysis import GAP_REPORTS
+from .models import Dataset, Station
+from .viewsets import wis2node_viewset
+
+
+class ScopeSummaryItem(SummaryItem):
+    """One tile in the header strip: how much of a thing is under watch.
+
+    The strip answers the question the panel below it assumes and never
+    states. A reader looking at seven silent rows cannot tell from the table
+    alone whether that is seven centres out of nine or seven out of ninety,
+    and the size of the region is not written anywhere else on the page.
+
+    **Scope, not health.** Nothing here is a count of what is wrong. That is
+    the panel's job, and a headline number over its own table would be a
+    second verdict on the same question, free to disagree with it. These count
+    what exists, which the panel never says.
+
+    **A tile counts exactly what its page lists.** Every tile is a route, so
+    its number is its destination's row count by construction: it asks the
+    viewset that renders that listing, for the URL, for the count and for
+    whether this reader may open it. A tile reading 1,204 above a page showing
+    1,190 is the classic failure of a summary strip, and asking one object
+    three questions is what forecloses it. The admin tests assert it against
+    each listing's own paginator, which is what keeps it foreclosed when
+    somebody narrows a listing later.
+
+    Subclasses supply the viewset, an icon and a noun. The markup is written
+    once, below, for the reason ``includes/all_nodes_panel.html`` already
+    gives: two copies of a thing is how one of them drifts.
+    """
+
+    template_name = "wis2watchcore/home/scope_summary_item.html"
+
+    #: The name of the listing route on the viewset. Model viewsets call it
+    #: ``index`` and snippet viewsets call it ``list``, so it is named per tile
+    #: rather than assumed.
+    url_name = "index"
+
+    #: Registered icon name. The tile carries its menu entry's icon, so the
+    #: two read as the same thing rather than as two routes to one page.
+    icon = None
+
+    #: Singular and plural of the noun, picked by ``ngettext_lazy`` against the
+    #: count. The number is rendered separately, by the template, so that it
+    #: can be given its thousands separator -- which costs a translator the
+    #: ability to reorder the two. Accepted: the alternative was a translatable
+    #: string per tile, and a template per tile to hold it.
+    label = None
+
+    @cached_property
+    def viewset(self):
+        """The viewset that renders this tile's destination."""
+        raise NotImplementedError
+
+    def get_context_data(self, parent_context):
+        """The count, the noun for it, and where the tile goes.
+
+        Args:
+            parent_context: the admin home's own context.
+
+        Returns:
+            dict: icon name, pluralised label, total and destination URL.
+        """
+        total = self.viewset.model.objects.count()
+
+        return {
+            "icon": self.icon,
+            "label": self.label % total,
+            "total": total,
+            "link": reverse(self.viewset.get_url_name(self.url_name)),
+        }
+
+    def is_shown(self):
+        """Whether this reader may open the page the tile leads to.
+
+        Wagtail's own ``PagesSummaryItem`` gates itself the same way, and for
+        the same reason: a tile is a link, and a link to a 403 is worse than
+        no link. Asked of the viewset's policy rather than of a permission
+        named here, so a tile cannot come to disagree with its own listing
+        about who is allowed in.
+        """
+        return self.viewset.permission_policy.user_has_any_permission(
+            self.request.user, ["add", "change", "delete", "view"]
+        )
+
+
+class NodesSummaryItem(ScopeSummaryItem):
+    """How many publishing centres are registered.
+
+    First, because it is the denominator for everything below it and for the
+    panel beneath. Called "Nodes" rather than "Centres" -- which is the word
+    most of this codebase's prose uses -- because the menu entry and the page
+    it opens both say Nodes, and a tile that renames its destination makes a
+    reader check whether they landed in the right place.
+
+    Knowably incomplete, and deliberately so: a centre publishing that no
+    catalogue has indexed is not in this number, which is what the unregistered
+    centres gap report exists to say. The strip is not the surface for that
+    caveat -- it counts what is watched, and a centre nobody registered is not
+    being watched.
+    """
+
+    order = 100
+    icon = "circle-nodes"
+    label = ngettext_lazy("Node", "Nodes")
+
+    @cached_property
+    def viewset(self):
+        return wis2node_viewset
+
+
+class DatasetsSummaryItem(ScopeSummaryItem):
+    """How many datasets those centres between them claim to publish.
+
+    The unit the expectations are actually set on: silence is judged per
+    dataset, not per centre, so this is the count of things that can go quiet.
+
+    Carries ``list-ul`` because ``DatasetViewSet`` does, and generic though it
+    is -- the Overview menu item and the catalogues listing wear it too --
+    matching the menu matters more here than being distinctive.
+    """
+
+    order = 200
+    icon = "list-ul"
+    label = ngettext_lazy("Dataset", "Datasets")
+    url_name = "list"
+
+    @cached_property
+    def viewset(self):
+        return Dataset.snippet_viewset
+
+
+class StationsSummaryItem(ScopeSummaryItem):
+    """How many stations the region declares or has been heard from.
+
+    Earns its place twice. It is the scope of the finest-grained thing this
+    tool watches, and it is the only route to the station listing at all: the
+    station is a snippet, and ``construct_main_menu`` hides the snippets menu,
+    so without this tile the page is reachable only by typing its URL. It is
+    the same trap ``DatasetViewSet`` was given a menu entry to escape.
+
+    One number over three kinds of declaration -- OSCAR's, a node's own
+    registry's, and traffic observed with nobody having declared it -- because
+    the station record is one record however many sources named it. Which
+    sources named which station is the drilldown's question, not the strip's.
+    """
+
+    order = 300
+    icon = "map-pin"
+    label = ngettext_lazy("Station", "Stations")
+    url_name = "list"
+
+    @cached_property
+    def viewset(self):
+        return Station.snippet_viewset
 
 
 class TransmissionStatusPanel(Component):

--- a/wis2watch/src/wis2watch/core/templates/wis2watchcore/home/scope_summary_item.html
+++ b/wis2watch/src/wis2watch/core/templates/wis2watchcore/home/scope_summary_item.html
@@ -1,0 +1,25 @@
+{% load i18n humanize wagtailadmin_tags %}
+
+{% comment %}
+    One tile in the admin home's header strip, whichever tile it is.
+
+    Written once rather than once per tile, for the reason
+    `includes/all_nodes_panel.html` already gives: two copies of a thing is how
+    one of them keeps a screen-reader suffix and the other loses it.
+
+    Takes `icon`, `label`, `total` and `link` from `ScopeSummaryItem`, which
+    has already picked singular or plural for the noun. The number is rendered
+    here rather than folded into the label so that `intcomma` can reach it --
+    eight thousand stations without a separator is a number nobody reads.
+
+    Markup follows Wagtail's own `site_summary_pages.html`, so the tile sits in
+    `w-summary__list` looking like one of them.
+{% endcomment %}
+
+<li>
+    {% icon name=icon %}
+    <a href="{{ link }}">
+        {{ total|intcomma }} {{ label }}
+        <span class="w-sr-only">{% trans "under watch" %}</span>
+    </a>
+</li>

--- a/wis2watch/src/wis2watch/core/tests/test_admin.py
+++ b/wis2watch/src/wis2watch/core/tests/test_admin.py
@@ -2,6 +2,7 @@ from datetime import timedelta
 from unittest import mock
 
 from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Permission
 from django.test import TestCase, override_settings
 from django.urls import reverse
 from django.utils import timezone as dj_timezone
@@ -21,10 +22,16 @@ from wis2watch.core.models import (
     UnregisteredCentre,
     WIS2Node,
 )
+from wis2watch.core.panels import (
+    DatasetsSummaryItem,
+    NodesSummaryItem,
+    StationsSummaryItem,
+)
 from wis2watch.core.viewsets import (
     GlobalDiscoveryCatalogueViewSet,
     MessageSourceViewSet,
     WIS2NodeViewSet,
+    wis2node_viewset,
 )
 
 from .support import at
@@ -106,6 +113,102 @@ class AdminSmokeTests(TestCase):
             "Awaiting your review",
         ):
             self.assertNotIn(heading, html)
+
+    def test_the_admin_home_says_how_big_the_region_is(self):
+        """The strip states the scope the panel below it only assumes.
+
+        Seven silent rows mean one thing out of nine centres and another out
+        of ninety, and the health table never says which. Each tile is also a
+        route, so the destination is asserted beside the number -- the stations
+        one especially, since the hidden snippets menu leaves this as the only
+        way to reach that listing at all.
+        """
+        WIS2Node.objects.create(centre_id="ke-kmd", name="Kenya")
+        WIS2Node.objects.create(centre_id="tz-tma", name="Tanzania")
+        Station.objects.create(wigos_id="0-20000-0-63741", name="Nairobi")
+
+        html = self.client.get(reverse("wagtailadmin_home")).content.decode()
+
+        self.assertIn(
+            f'<a href="{reverse(wis2node_viewset.get_url_name("index"))}">', html
+        )
+        self.assertIn("2 Nodes", html)
+        self.assertIn(
+            f'<a href="{reverse(Station.snippet_viewset.get_url_name("list"))}">', html
+        )
+        self.assertIn("1 Station", html)
+
+    def test_a_tile_counts_exactly_what_its_page_lists(self):
+        """The invariant the whole strip rests on.
+
+        A tile reading 1,204 above a page showing 1,190 is the classic failure
+        of a summary strip, and it arrives silently -- somebody narrows a
+        listing, and the header goes on quoting the unnarrowed count. Asserted
+        against each listing's own paginator rather than against a second call
+        to ``.count()``, so that narrowing either side fails here.
+        """
+        node = WIS2Node.objects.create(centre_id="ke-kmd", name="Kenya")
+        WIS2Node.objects.create(centre_id="tz-tma", name="Tanzania")
+        Dataset.objects.create(
+            node=node,
+            identifier="urn:wmo:md:ke-kmd:surface",
+            title="Surface weather",
+            wmo_data_policy=Dataset.CORE,
+            wmo_topic_hierarchy="origin/a/wis2/ke-kmd/surface-based-obs",
+            raw_json={},
+        )
+        Station.objects.create(wigos_id="0-20000-0-63741", name="Nairobi")
+
+        for item_class in (NodesSummaryItem, DatasetsSummaryItem, StationsSummaryItem):
+            with self.subTest(tile=item_class.__name__):
+                item = item_class(self.client.request().wsgi_request)
+                total = item.get_context_data({})["total"]
+
+                listing = self.client.get(
+                    reverse(item.viewset.get_url_name(item.url_name))
+                )
+
+                self.assertEqual(listing.status_code, 200)
+                self.assertEqual(
+                    total, listing.context["page_obj"].paginator.count
+                )
+
+    def test_a_single_node_is_not_described_as_nodes(self):
+        """One tile, one noun, and the noun agrees with the number.
+
+        The strip's labels are picked in Python because the markup is written
+        once for all three tiles, which rules out a per-tile ``blocktrans``.
+        This is what says the substitute works.
+        """
+        WIS2Node.objects.create(centre_id="ke-kmd", name="Kenya")
+
+        html = self.client.get(reverse("wagtailadmin_home")).content.decode()
+
+        self.assertIn("1 Node\n", html)
+        self.assertNotIn("1 Nodes", html)
+
+    def test_a_tile_is_hidden_from_whoever_cannot_open_its_page(self):
+        """A link to a 403 is worse than no link.
+
+        Wagtail gates its own pages tile the same way. Asserted with a user who
+        may reach the admin at all and nothing beyond it, which is the shape
+        any restricted group here would take.
+        """
+        onlooker = get_user_model().objects.create_user(
+            "onlooker", password="s3cret", is_staff=True
+        )
+        onlooker.user_permissions.add(
+            Permission.objects.get(
+                content_type__app_label="wagtailadmin", codename="access_admin"
+            )
+        )
+        self.client.force_login(onlooker)
+
+        html = self.client.get(reverse("wagtailadmin_home")).content.decode()
+
+        self.assertNotIn("Nodes\n", html)
+        self.assertNotIn("Datasets\n", html)
+        self.assertNotIn("Stations\n", html)
 
     def test_the_monitoring_map_loads(self):
         response = self.client.get(reverse("ingest_map"))

--- a/wis2watch/src/wis2watch/core/tests/test_admin.py
+++ b/wis2watch/src/wis2watch/core/tests/test_admin.py
@@ -1,3 +1,4 @@
+import re
 from datetime import timedelta
 from unittest import mock
 
@@ -113,6 +114,41 @@ class AdminSmokeTests(TestCase):
             "Awaiting your review",
         ):
             self.assertNotIn(heading, html)
+
+    def test_the_admin_home_does_not_offer_to_search_a_page_tree(self):
+        """The header's search box searched somewhere nobody can go.
+
+        `construct_main_menu` hides the explorer, so a search of the page tree
+        was a search of an unreachable place -- sitting directly under the
+        strip of counts, which is the one thing in that header anybody wants.
+
+        Removing it meant restating Wagtail's `content` block, and a restated
+        block goes stale silently. This is the assertion that notices.
+        """
+        html = self.client.get(reverse("wagtailadmin_home")).content.decode()
+
+        # The form's action specifically, not the explorer's URL anywhere on
+        # the page: the sidebar's own JSON config names it too, and always did.
+        self.assertNotIn(
+            f'action="{reverse("wagtailadmin_explore_root")}"', html
+        )
+
+    def test_the_admin_home_still_welcomes_the_reader(self):
+        """The title survives the block that was restated around it.
+
+        Wagtail builds `header_title` inside the very block this admin
+        replaces, so omitting that fragment renders the base view's generic
+        "Dashboard" and leaves `branding_welcome` defined but unreachable --
+        a regression with nothing to fail. This is that something.
+        """
+        html = self.client.get(reverse("wagtailadmin_home")).content.decode()
+
+        heading = " ".join(
+            re.search(r"<h1[^>]*>(.*?)</h1>", html, re.S).group(1).split()
+        )
+
+        self.assertIn("Welcome to", heading)
+        self.assertNotEqual("Dashboard", heading)
 
     def test_the_admin_home_says_how_big_the_region_is(self):
         """The strip states the scope the panel below it only assumes.

--- a/wis2watch/src/wis2watch/core/viewsets.py
+++ b/wis2watch/src/wis2watch/core/viewsets.py
@@ -252,8 +252,13 @@ class HardFailureViewSet(ModelViewSet):
         return ReadOnlyPermissionPolicy(self.model)
 
 
+#: The registered instance, named so that anything wanting to speak about the
+#: nodes listing -- its URL, or who may open it -- asks the object that renders
+#: it rather than a second one built to look the same.
+wis2node_viewset = WIS2NodeViewSet()
+
 admin_viewsets = [
-    WIS2NodeViewSet(),
+    wis2node_viewset,
     MessageSourceViewSet(),
     GlobalDiscoveryCatalogueViewSet(),
     OutgoingEmailViewSet(),

--- a/wis2watch/src/wis2watch/core/wagtail_hooks.py
+++ b/wis2watch/src/wis2watch/core/wagtail_hooks.py
@@ -4,7 +4,12 @@ from wagtail.admin.menu import MenuItem
 from wagtail.snippets.models import register_snippet
 
 from wis2watch.core.viewsets import DatasetViewSet, admin_viewsets
-from .panels import TransmissionStatusPanel
+from .panels import (
+    DatasetsSummaryItem,
+    NodesSummaryItem,
+    StationsSummaryItem,
+    TransmissionStatusPanel,
+)
 from .views import (
     gap_report_index,
     gap_report_table,
@@ -68,11 +73,35 @@ def construct_homepage_panels(request, panels):
     panels.append(TransmissionStatusPanel())
 
 
+#: Wagtail's own header tiles, all three counting a CMS this tool's operators
+#: have no menu entry for. Stripped for the same reason the dashboard panels
+#: below them are.
+WAGTAIL_SUMMARY_ITEMS = (
+    "PagesSummaryItem",
+    "DocumentsSummaryItem",
+    "ImagesSummaryItem",
+)
+
+
 @hooks.register('construct_homepage_summary_items')
 def construct_homepage_summary_items(request, summary_items):
-    hidden_summary_items = ["PagesSummaryItem", "DocumentsSummaryItem", "ImagesSummaryItem"]
-    
-    summary_items[:] = [item for item in summary_items if item.__class__.__name__ not in hidden_summary_items]
+    """How big the region is, above the table that says how it is doing.
+
+    Strip and then append, rather than assigning the three outright: a tile
+    contributed by another app is not this hook's to discard silently, and the
+    panels hook above already works this way.
+    """
+    summary_items[:] = [
+        item
+        for item in summary_items
+        if item.__class__.__name__ not in WAGTAIL_SUMMARY_ITEMS
+    ]
+
+    summary_items.extend([
+        NodesSummaryItem(request),
+        DatasetsSummaryItem(request),
+        StationsSummaryItem(request),
+    ])
 
 
 @hooks.register('register_admin_menu_item')
@@ -108,6 +137,9 @@ register_snippet(DatasetViewSet)
 def register_icons(icons):
     return icons + [
         'wagtailfontawesomesvg/solid/circle-nodes.svg',
+        # The stations tile's. Wagtail's own set has no pin -- `thumbtack` is
+        # the nearest and reads as a note rather than a place.
+        'wagtailfontawesomesvg/solid/map-pin.svg',
     ]
 
 


### PR DESCRIPTION
Closes #124.

The dashboard leads with the transmission status panel: whether each centre's data is flowing. What it never says is how big the region is. The summary strip in the header was empty -- the hook stripped Wagtail's three CMS tiles and put nothing back -- so that is where this goes.

```
Welcome to WIS2WATCH
⬡ 32 Nodes    ≡ 54 Datasets    ⚲ 8,227 Stations
────────────────────────────────────────────────
Transmission status              [reports ▾]
  ke-kmd   ● silent 14h   ...
```

## The tiles

- `ScopeSummaryItem` in `core/panels.py`, with three subclasses. Under `panels.py` rather than a module of its own because the strip and the panel are the same decision -- what the admin home is for -- and its docstring already claimed that scope.
- One template for all three tiles, for the reason `includes/all_nodes_panel.html` already gives.
- `map-pin` added to `register_icons`; the other two tiles wear their menu entry's icon.
- The hook strips and then **appends**, matching `construct_homepage_panels` directly above, so a tile contributed by another app is not discarded silently.

**A tile's number is its destination's row count.** Each tile asks the viewset that renders its listing for the URL, for the count and for whether this reader may open it -- one object, three questions. A tile reading 1,204 above a page showing 1,190 is how a summary strip goes wrong, and it goes wrong silently, so it is asserted against each listing's own paginator rather than left in a comment.

`is_shown()` gates each tile on its viewset's permission policy, as Wagtail's own `PagesSummaryItem` does.

## The header, while we were in it

The page-explorer search box under the welcome title searched a page tree `construct_main_menu` hides -- and sat directly beneath the new strip. Removing it means restating Wagtail's `content` block, since it is wrapped in no block of its own, and two things come with that:

- `header_title` is built *inside* the block being restated, as a fragment wrapping `branding_welcome`. A copy that omits it renders the base view's generic "Dashboard" and leaves `branding_welcome` defined but unreachable. Restated with it.
- The `w-mb-12` separating header from first panel was on the removed form. Moved onto the header's own div, so the panel sits where it always has rather than riding up against the counts.

A restated block goes stale silently, so two assertions say what the page must and must not carry -- the upgrade that matters fails loudly instead.

## Not here

- **Node vs centre.** The tiles say "Nodes" because the menu and the page both do. Settling the split wants its own issue and probably an ADR.
- **`base_url_path` is dead on all five `ModelViewSet`s** -- `reverse()` gives `/wis2node/`, not `/nodes/`; only `SnippetViewSet` honours it. Noticed while wiring the links up. Separate issue.

## Testing

Six new tests in `AdminSmokeTests`. Each was checked to fail under a deliberate mutation -- counts bumped, plural forced, permission gate stubbed to `True`, the fragment dropped and the search form put back -- and in each case exactly the intended tests failed.

Full suite on a freshly built test database: **1,547 tests, OK**.

https://claude.ai/code/session_01MKMYduSHzKRXFiMU4JDTzi