### PR TITLE
A centre announcing its record is not one publishing data

### DIFF
--- a/wis2watch/src/wis2watch/core/announcements.py
+++ b/wis2watch/src/wis2watch/core/announcements.py
@@ -30,18 +30,26 @@ expired, their counts are baked into rollups that no message remains to
 recompute, and no arithmetic here could tell them apart from the unattributed
 data they sit beside.
 
-Written to be run again. Finding nothing is the ordinary outcome, and a run
-that stopped half way has left behind a database this arrives at the same
-answer from.
+The removal and the rebuild are one transaction, which is the only way this
+can be safe to run again. Every step of it destroys the evidence for the step
+before -- once the announcements are deleted, a re-run finds nothing to do and
+would leave a bucket that was dropped but never recomputed missing for good,
+since nothing else ever revisits an hour that old. Held together, an
+interrupted run leaves the database exactly as it found it and running again
+starts from the beginning.
+
+Finding nothing is the ordinary outcome, and is what every run after the first
+comes to.
 """
 
 import logging
 from dataclasses import dataclass
 from datetime import timedelta
 
+from django.db import transaction
 from django.db.models import Max, Q
 
-from .daily_rollups import floor_to_day, rollup_days
+from .daily_rollups import DAILY_GROUP_BY, floor_to_day, rollup_days
 from .interpretation import announces_catalogue_record
 from .models import (
     DailyStationRollup,
@@ -49,14 +57,15 @@ from .models import (
     NodeLastSeen,
     NotificationMessage,
 )
-from .rollups import floor_to_hour, rollup_hours
+from .rollups import GROUP_BY, floor_to_hour, rollup_hours
 
 logger = logging.getLogger(__name__)
 
-#: How many rollup buckets are named in one delete. The keys are named one by
-#: one -- a bucket is five columns, two of which are routinely null -- and a
-#: region's fortnight of announcements is a few hundred of them, so they are
-#: sent in batches rather than as one statement the length of the finding.
+#: How many rollup buckets are named in one delete. A bucket is named a column
+#: at a time, since several of those columns are routinely null and null is not
+#: something an ``IN`` matches, and a region's fortnight of announcements comes
+#: to a few hundred of them -- so they go in batches rather than as one
+#: statement the length of the finding.
 KEY_BATCH = 200
 
 #: What a stored row has to carry before it is worth interpreting. The topic
@@ -64,7 +73,16 @@ KEY_BATCH = 200
 #: this narrows a fortnight of the region's traffic to the handful of rows that
 #: could be one. It decides nothing: what a row is is decided by the same rule
 #: the ingest decides it by.
-CANDIDATES = Q(topic__contains="/metadata") | Q(data_id__contains="/metadata/")
+POSSIBLE_ANNOUNCEMENTS = Q(topic__contains="/metadata") | Q(
+    data_id__contains="/metadata/"
+)
+
+#: The hourly grain, as a message carries it: the bucket columns with the
+#: message's own publication time standing in for the bucket it falls in.
+#: Taken from the grain rather than restated here, for the reason
+#: ``grain_columns`` is -- the key a bucket is deleted by and the key it was
+#: written under have to be one key, or this deletes buckets nothing counted.
+MESSAGE_COLUMNS = ("time",) + GROUP_BY[1:]
 
 
 @dataclass
@@ -92,9 +110,8 @@ def stored_announcements():
     refuses one by. A row is a catalogue record because of where it was
     published, and there is one statement of what that means.
     """
-    candidates = NotificationMessage.objects.filter(CANDIDATES).values(
-        "id", "time", "source_id", "node_id", "dataset_id", "station_id",
-        "topic", "data_id",
+    candidates = NotificationMessage.objects.filter(POSSIBLE_ANNOUNCEMENTS).values(
+        "id", "topic", "data_id", *MESSAGE_COLUMNS
     )
 
     return [
@@ -107,60 +124,44 @@ def stored_announcements():
 def _bucket_keys(announcements):
     """The hourly buckets the announcements were counted into."""
     return {
-        (
-            floor_to_hour(row["time"]),
-            row["source_id"],
-            row["node_id"],
-            row["dataset_id"],
-            row["station_id"],
-        )
+        (floor_to_hour(row["time"]),)
+        + tuple(row[column] for column in MESSAGE_COLUMNS[1:])
         for row in announcements
     }
 
 
-def _drop_hourly_buckets(keys):
-    """Remove the hourly buckets, so an emptied one does not survive."""
+def _daily_keys(keys):
+    """The station-days summarised from those hourly buckets.
+
+    The daily grain drops the dataset and collapses the hour, so several of the
+    buckets fall into one day -- which is why a day is dropped whole rather than
+    at the grain its hours were found at. Read across the two grains by name so
+    that a column moving in either is a column that moves here.
+    """
+    return {
+        tuple(
+            floor_to_day(bucket["hour"]) if column == "day" else bucket[column]
+            for column in DAILY_GROUP_BY
+        )
+        for bucket in (dict(zip(GROUP_BY, key)) for key in keys)
+    }
+
+
+def _drop_buckets(model, columns, keys):
+    """Remove named rollup buckets, so an emptied one does not survive.
+
+    Ordered before batching only so that a run sends the same statements twice
+    running, which is what makes a failure reproducible. The sort is by the
+    written-out key because a bucket names a nullable dataset and a nullable
+    station, and None does not compare with a primary key.
+    """
     for batch in _batched(sorted(keys, key=str), KEY_BATCH):
         matches = Q()
 
-        for hour, source_id, node_id, dataset_id, station_id in batch:
-            matches |= Q(
-                hour=hour,
-                source_id=source_id,
-                node_id=node_id,
-                dataset_id=dataset_id,
-                station_id=station_id,
-            )
+        for key in batch:
+            matches |= Q(**dict(zip(columns, key)))
 
-        HourlyRollup.objects.filter(matches).delete()
-
-
-def _drop_daily_buckets(keys):
-    """Remove the station-days summarised from those buckets.
-
-    The daily summary drops the dataset, so one day of one station is rewritten
-    from every hourly bucket under it -- which is why the day is dropped whole
-    rather than by the grain the hours were found at.
-    """
-    days = {
-        (floor_to_day(hour), source_id, node_id, station_id)
-        for hour, source_id, node_id, _dataset_id, station_id in keys
-    }
-
-    for batch in _batched(sorted(days, key=str), KEY_BATCH):
-        matches = Q()
-
-        for day, source_id, node_id, station_id in batch:
-            matches |= Q(
-                day=day,
-                source_id=source_id,
-                node_id=node_id,
-                station_id=station_id,
-            )
-
-        DailyStationRollup.objects.filter(matches).delete()
-
-    return days
+        model.objects.filter(matches).delete()
 
 
 def _restate_last_seen(node_ids):
@@ -175,6 +176,12 @@ def _restate_last_seen(node_ids):
     hour rather than an instant, and understates by up to an hour a question
     asked in days. A centre with neither is one nothing has ever heard publish
     data, and its row is removed rather than left saying otherwise.
+
+    The fallback carries the same limit the rollups do: an hour older than the
+    raw retention window has no messages left to be recomputed from, so a
+    centre whose last rollup was an hour of nothing but announcements lands on
+    that hour. It is still the latest thing the region has evidence of, and it
+    is weeks earlier than the announcement that would otherwise have stood.
 
     Time only moves backwards here. This corrects an overstatement, and a run
     finding a centre that has published since cannot be the thing that decides
@@ -212,6 +219,10 @@ def _batched(items, size):
 def discard_stored_announcements():
     """Drop the announcements already stored, and rebuild what counted them.
 
+    One transaction, for the reason this module opens with: each step removes
+    the evidence the next one would be found by, so a run that stopped between
+    two of them would leave a rebuild nothing was ever going to come back for.
+
     Returns:
         DiscardCounts: what was removed and what was rebuilt.
     """
@@ -222,27 +233,29 @@ def discard_stored_announcements():
 
     keys = _bucket_keys(announcements)
     hours = sorted({key[0] for key in keys})
+    days = _daily_keys(keys)
     node_ids = {row["node_id"] for row in announcements} - {None}
 
-    NotificationMessage.objects.filter(
-        id__in=[row["id"] for row in announcements]
-    ).delete()
+    with transaction.atomic():
+        NotificationMessage.objects.filter(
+            id__in=[row["id"] for row in announcements]
+        ).delete()
 
-    _drop_hourly_buckets(keys)
-    rollup_hours(since=hours[0], until=hours[-1] + timedelta(hours=1))
+        _drop_buckets(HourlyRollup, GROUP_BY, keys)
+        rollup_hours(since=hours[0], until=hours[-1] + timedelta(hours=1))
 
-    days = _drop_daily_buckets(keys)
-    rollup_days(
-        since=floor_to_day(hours[0]),
-        until=floor_to_day(hours[-1]) + timedelta(days=1),
-    )
+        _drop_buckets(DailyStationRollup, DAILY_GROUP_BY, days)
+        rollup_days(
+            since=floor_to_day(hours[0]),
+            until=floor_to_day(hours[-1]) + timedelta(days=1),
+        )
 
-    counts = DiscardCounts(
-        messages=len(announcements),
-        hours=len(keys),
-        days=len(days),
-        nodes=_restate_last_seen(node_ids),
-    )
+        counts = DiscardCounts(
+            messages=len(announcements),
+            hours=len(keys),
+            days=len(days),
+            nodes=_restate_last_seen(node_ids),
+        )
 
     logger.info("Discarded catalogue-record announcements: %s", counts.summary)
 

--- a/wis2watch/src/wis2watch/core/announcements.py
+++ b/wis2watch/src/wis2watch/core/announcements.py
@@ -1,0 +1,249 @@
+"""Removing the catalogue-record announcements that were stored as data.
+
+A centre announces its own WCMP2 discovery metadata record on the ``metadata``
+topic below itself, and re-announces it periodically. Those notifications are
+recognised at ingest now and never reach storage -- but everything a region
+heard before that is still held, still counted in the rollups derived from it,
+and still standing behind the last-seen time of every centre that announced
+one. A centre that published no data at all for a week reads as having
+published a handful of messages, which is the finding this tool exists to make
+being covered up by its own storage.
+
+So the rows are found and dropped, and everything derived from them is
+rebuilt. Rebuilt rather than adjusted: a rollup is a pure function of the
+messages under it, so recomputing the hours the announcements fell in arrives
+at the numbers those hours would have had if the announcements had never been
+stored -- where subtracting a count would be a second derivation of the same
+figure, and would be wrong the moment either drifted.
+
+The one thing recomputing cannot do on its own is remove a bucket. An hourly
+rollup is only ever written from messages that exist, so an hour whose whole
+traffic was one announcement leaves a row that the recompute never visits and
+never corrects. Those buckets are therefore deleted before the recompute runs,
+and the recompute writes back the ones that still have messages behind them.
+
+Only hours an announcement was found in are touched, which is also the only
+range where this can be right: raw messages are kept for a fortnight, so an
+hour with an announcement still in it necessarily still holds the rest of its
+traffic too. Nothing older is reachable -- those announcements are long
+expired, their counts are baked into rollups that no message remains to
+recompute, and no arithmetic here could tell them apart from the unattributed
+data they sit beside.
+
+Written to be run again. Finding nothing is the ordinary outcome, and a run
+that stopped half way has left behind a database this arrives at the same
+answer from.
+"""
+
+import logging
+from dataclasses import dataclass
+from datetime import timedelta
+
+from django.db.models import Max, Q
+
+from .daily_rollups import floor_to_day, rollup_days
+from .interpretation import announces_catalogue_record
+from .models import (
+    DailyStationRollup,
+    HourlyRollup,
+    NodeLastSeen,
+    NotificationMessage,
+)
+from .rollups import floor_to_hour, rollup_hours
+
+logger = logging.getLogger(__name__)
+
+#: How many rollup buckets are named in one delete. The keys are named one by
+#: one -- a bucket is five columns, two of which are routinely null -- and a
+#: region's fortnight of announcements is a few hundred of them, so they are
+#: sent in batches rather than as one statement the length of the finding.
+KEY_BATCH = 200
+
+#: What a stored row has to carry before it is worth interpreting. The topic
+#: and the data identifier are the two places a catalogue record is named, and
+#: this narrows a fortnight of the region's traffic to the handful of rows that
+#: could be one. It decides nothing: what a row is is decided by the same rule
+#: the ingest decides it by.
+CANDIDATES = Q(topic__contains="/metadata") | Q(data_id__contains="/metadata/")
+
+
+@dataclass
+class DiscardCounts:
+    """What a run came to."""
+
+    messages: int = 0
+    hours: int = 0
+    days: int = 0
+    nodes: int = 0
+
+    @property
+    def summary(self):
+        """What the run came to, in one line, for a log."""
+        return (
+            f"messages={self.messages} hours={self.hours} "
+            f"days={self.days} nodes={self.nodes}"
+        )
+
+
+def stored_announcements():
+    """Every stored row that announces a catalogue record rather than data.
+
+    Narrowed in the database and decided in Python, by the same rule the ingest
+    refuses one by. A row is a catalogue record because of where it was
+    published, and there is one statement of what that means.
+    """
+    candidates = NotificationMessage.objects.filter(CANDIDATES).values(
+        "id", "time", "source_id", "node_id", "dataset_id", "station_id",
+        "topic", "data_id",
+    )
+
+    return [
+        row
+        for row in candidates
+        if announces_catalogue_record(row["topic"], row["data_id"])
+    ]
+
+
+def _bucket_keys(announcements):
+    """The hourly buckets the announcements were counted into."""
+    return {
+        (
+            floor_to_hour(row["time"]),
+            row["source_id"],
+            row["node_id"],
+            row["dataset_id"],
+            row["station_id"],
+        )
+        for row in announcements
+    }
+
+
+def _drop_hourly_buckets(keys):
+    """Remove the hourly buckets, so an emptied one does not survive."""
+    for batch in _batched(sorted(keys, key=str), KEY_BATCH):
+        matches = Q()
+
+        for hour, source_id, node_id, dataset_id, station_id in batch:
+            matches |= Q(
+                hour=hour,
+                source_id=source_id,
+                node_id=node_id,
+                dataset_id=dataset_id,
+                station_id=station_id,
+            )
+
+        HourlyRollup.objects.filter(matches).delete()
+
+
+def _drop_daily_buckets(keys):
+    """Remove the station-days summarised from those buckets.
+
+    The daily summary drops the dataset, so one day of one station is rewritten
+    from every hourly bucket under it -- which is why the day is dropped whole
+    rather than by the grain the hours were found at.
+    """
+    days = {
+        (floor_to_day(hour), source_id, node_id, station_id)
+        for hour, source_id, node_id, _dataset_id, station_id in keys
+    }
+
+    for batch in _batched(sorted(days, key=str), KEY_BATCH):
+        matches = Q()
+
+        for day, source_id, node_id, station_id in batch:
+            matches |= Q(
+                day=day,
+                source_id=source_id,
+                node_id=node_id,
+                station_id=station_id,
+            )
+
+        DailyStationRollup.objects.filter(matches).delete()
+
+    return days
+
+
+def _restate_last_seen(node_ids):
+    """Take each centre's last-seen back to its latest surviving evidence.
+
+    An announcement kept a centre's last-seen warm, which is the whole of the
+    complaint: a centre that has published nothing since is read as one that
+    published minutes ago, and no silence is ever raised for it.
+
+    The latest message still held is what answers it, and where a centre has
+    none left, the latest hour its rollups were ever written for -- which is an
+    hour rather than an instant, and understates by up to an hour a question
+    asked in days. A centre with neither is one nothing has ever heard publish
+    data, and its row is removed rather than left saying otherwise.
+
+    Time only moves backwards here. This corrects an overstatement, and a run
+    finding a centre that has published since cannot be the thing that decides
+    when it last did.
+    """
+    restated = 0
+
+    for node_id in node_ids:
+        latest = NotificationMessage.objects.filter(node_id=node_id).aggregate(
+            latest=Max("time")
+        )["latest"]
+
+        if latest is None:
+            latest = HourlyRollup.objects.filter(node_id=node_id).aggregate(
+                latest=Max("hour")
+            )["latest"]
+
+        if latest is None:
+            restated += NodeLastSeen.objects.filter(node_id=node_id).delete()[0]
+            continue
+
+        restated += NodeLastSeen.objects.filter(
+            node_id=node_id, last_message_at__gt=latest
+        ).update(last_message_at=latest)
+
+    return restated
+
+
+def _batched(items, size):
+    """``items`` in runs of at most ``size``."""
+    for start in range(0, len(items), size):
+        yield items[start : start + size]
+
+
+def discard_stored_announcements():
+    """Drop the announcements already stored, and rebuild what counted them.
+
+    Returns:
+        DiscardCounts: what was removed and what was rebuilt.
+    """
+    announcements = stored_announcements()
+
+    if not announcements:
+        return DiscardCounts()
+
+    keys = _bucket_keys(announcements)
+    hours = sorted({key[0] for key in keys})
+    node_ids = {row["node_id"] for row in announcements} - {None}
+
+    NotificationMessage.objects.filter(
+        id__in=[row["id"] for row in announcements]
+    ).delete()
+
+    _drop_hourly_buckets(keys)
+    rollup_hours(since=hours[0], until=hours[-1] + timedelta(hours=1))
+
+    days = _drop_daily_buckets(keys)
+    rollup_days(
+        since=floor_to_day(hours[0]),
+        until=floor_to_day(hours[-1]) + timedelta(days=1),
+    )
+
+    counts = DiscardCounts(
+        messages=len(announcements),
+        hours=len(keys),
+        days=len(days),
+        nodes=_restate_last_seen(node_ids),
+    )
+
+    logger.info("Discarded catalogue-record announcements: %s", counts.summary)
+
+    return counts

--- a/wis2watch/src/wis2watch/core/interpretation/__init__.py
+++ b/wis2watch/src/wis2watch/core/interpretation/__init__.py
@@ -45,8 +45,10 @@ from .oscar import (
 from .timestamps import parse_timestamp
 from .topics import (
     CACHE,
+    METADATA,
     ORIGIN,
     ParsedTopic,
+    announces_catalogue_record,
     parse_topic,
     subscription_topic,
     sweep_topic,
@@ -56,6 +58,7 @@ __all__ = [
     "BrokerConnection",
     "CACHE",
     "DEFAULT_PORTS",
+    "METADATA",
     "OPERATIONAL",
     "DiscoveredDataset",
     "DiscoveredNode",
@@ -65,6 +68,7 @@ __all__ = [
     "OscarStation",
     "ParsedNotification",
     "ParsedTopic",
+    "announces_catalogue_record",
     "archived_notifications",
     "canonical_link",
     "centre_id_from_identifier",

--- a/wis2watch/src/wis2watch/core/interpretation/topics.py
+++ b/wis2watch/src/wis2watch/core/interpretation/topics.py
@@ -6,6 +6,12 @@ centre and the data's place in the topic hierarchy::
     origin/a/wis2/ke-meteo/data/core/weather/surface-based-observations/synop
     cache/a/wis2/ke-meteo/data/core/weather/surface-based-observations/synop
 
+The level directly below the centre says what kind of thing is being announced.
+``data`` is a publication; ``metadata`` is the centre announcing its own
+catalogue record, which is not one::
+
+    origin/a/wis2/ke-meteo/metadata
+
 Everything downstream -- which centre a message belongs to, whether a Global
 Cache picked it up, whether the centre is one we monitor -- is read off that
 structure, so it is parsed once, here.
@@ -18,6 +24,10 @@ STANDARD_SEGMENT = ("a", "wis2")
 
 ORIGIN = "origin"
 CACHE = "cache"
+
+#: The level below the centre on which it announces its WCMP2 discovery
+#: metadata record. Every other level below a centre carries data.
+METADATA = "metadata"
 
 #: The MQTT wildcard matching a centre's whole hierarchy, however deep.
 MULTI_LEVEL_WILDCARD = "#"
@@ -44,6 +54,11 @@ class ParsedTopic:
     def is_cache(self):
         """Whether this is traffic republished by a Global Cache."""
         return self.prefix == CACHE
+
+    @property
+    def announces_catalogue_record(self):
+        """Whether this topic carries a catalogue record rather than data."""
+        return self.hierarchy[:1] == (METADATA,)
 
     def as_origin(self):
         """The same topic as published at origin.
@@ -128,3 +143,29 @@ def parse_topic(topic):
         centre_id=centre_id.lower(),
         hierarchy=tuple(tokens[4:]),
     )
+
+
+def announces_catalogue_record(topic, data_id=""):
+    """Whether a notification announces a discovery metadata record.
+
+    A centre announces its own WCMP2 record on ``.../{centre}/metadata``, and
+    every Global Cache republishes that announcement under its own prefix. It
+    is a notification like any other and nothing about its payload says it is
+    not a publication -- what says so is where it was published.
+
+    The topic answers it wherever one was observed, and answers it alone: a
+    message that went out on a data topic is a data publication whatever else
+    it says about itself.
+
+    A centre's own message archive returns notifications with no topic at all,
+    and there the data identifier is read instead. It spells the same path the
+    topic would have -- ``{centre}/metadata/{record}`` -- which is what lets the
+    one announcement be recognised from either vantage point rather than only
+    from the broker.
+    """
+    if topic and topic.strip():
+        parsed = parse_topic(topic)
+
+        return parsed is not None and parsed.announces_catalogue_record
+
+    return (data_id or "").split("/")[1:2] == [METADATA]

--- a/wis2watch/src/wis2watch/core/migrations/0025_a_centre_announcing_its_record_is_not_publishing.py
+++ b/wis2watch/src/wis2watch/core/migrations/0025_a_centre_announcing_its_record_is_not_publishing.py
@@ -1,0 +1,45 @@
+"""Drop the catalogue-record announcements this region already stored as data.
+
+Until now a centre's announcement of its own WCMP2 record was stored, counted
+and rolled up exactly like a publication, so every volume figure carries a
+trickle of them and every centre that announced one has a last-seen kept warm
+by it. The ingest recognises them now; what it cannot do is unsay what was
+stored before it did.
+
+Calls the removal directly rather than reimplementing it against the historical
+models, which is the usual caution here and would be the wrong trade in this
+case: what has to be dropped is decided by the same rule the ingest refuses one
+by, and a second spelling of that rule is exactly how the stored history and
+the incoming traffic come to disagree about what an announcement is. The rows
+this touches are a fortnight old at most -- older ones expired long ago -- so
+this is small wherever it runs.
+
+There is no reverse. What it removes is not a schema change and was never data
+about the region: it was a centre saying where its catalogue record lives.
+Re-running it is safe and finding nothing is the ordinary outcome, so an
+interrupted run is put right by running it again --
+``discard_stored_announcements()`` in a shell, which is what this calls.
+
+Not atomic, so the delete and the rebuild commit as they go rather than being
+held open against a database that is also serving ingestion.
+"""
+
+from django.db import migrations
+
+
+def discard_announcements(apps, schema_editor):
+    from wis2watch.core.announcements import discard_stored_announcements
+
+    discard_stored_announcements()
+
+
+class Migration(migrations.Migration):
+    atomic = False
+
+    dependencies = [
+        ("wis2watchcore", "0024_a_station_judged_against_itself"),
+    ]
+
+    operations = [
+        migrations.RunPython(discard_announcements, migrations.RunPython.noop),
+    ]

--- a/wis2watch/src/wis2watch/core/migrations/0025_a_centre_announcing_its_record_is_not_publishing.py
+++ b/wis2watch/src/wis2watch/core/migrations/0025_a_centre_announcing_its_record_is_not_publishing.py
@@ -20,8 +20,11 @@ Re-running it is safe and finding nothing is the ordinary outcome, so an
 interrupted run is put right by running it again --
 ``discard_stored_announcements()`` in a shell, which is what this calls.
 
-Not atomic, so the delete and the rebuild commit as they go rather than being
-held open against a database that is also serving ingestion.
+Declared not atomic because the atomicity that matters here is the removal's
+own, and it holds it itself: the delete and the rebuild it makes necessary are
+one transaction inside ``discard_stored_announcements``, which is what makes
+running it again safe. Leaving the migration to wrap it as well would say the
+guarantee came from being a migration, which it does not.
 """
 
 from django.db import migrations

--- a/wis2watch/src/wis2watch/core/tests/fixtures/README.md
+++ b/wis2watch/src/wis2watch/core/tests/fixtures/README.md
@@ -125,8 +125,11 @@ what a centre publishing its own discovery metadata looks like from the
 archive. It carries the WCMP2 record inline as base64, names **no**
 `metadata_id` (the record it announces is the one that would be named), carries
 no `wigos_station_identifier`, and advertises only a `rel: update` link — no
-canonical link at all. So it resolves to no dataset and no station, and is
-stored for all that, as the MQTT path stores one.
+canonical link at all. Nothing in the payload says it is not a publication;
+what says so is its `data_id`, which spells the topic it went out on —
+`{centre}/metadata/{record}`. That is what the ingest recognises it by here,
+there being no topic, and it is set aside rather than stored, as the MQTT path
+sets aside one on `origin/a/wis2/{centre}/metadata`.
 
 | Capture | Retention at capture | The window asked for | Match count |
 | --- | --- | --- | --- |

--- a/wis2watch/src/wis2watch/core/tests/test_announcements.py
+++ b/wis2watch/src/wis2watch/core/tests/test_announcements.py
@@ -8,6 +8,7 @@ announcement has to stop reading as one heard from minutes ago.
 """
 
 from datetime import timedelta
+from unittest import mock
 
 from django.test import TestCase
 
@@ -289,6 +290,29 @@ class RepeatedRunTests(DiscardTestCase):
         counts = discard_stored_announcements()
 
         self.assertEqual(counts.messages, 0)
+        self.assertEqual(self.hours(), before)
+
+    def test_a_run_that_fails_part_way_leaves_the_database_as_it_found_it(self):
+        """Each step destroys the evidence for the last, so it is one or none.
+
+        A rebuild left undone would never be come back for: the next run finds
+        no announcements, and nothing else revisits an hour that old.
+        """
+        self.store("2026-08-12T10:05:00")
+        self.announce("2026-08-12T10:00:00")
+        self.derive()
+
+        before = self.hours()
+
+        with mock.patch(
+            "wis2watch.core.announcements.rollup_hours",
+            side_effect=OSError("the connection dropped"),
+        ):
+            with self.assertRaises(OSError):
+                discard_stored_announcements()
+
+        self.assertEqual(len(stored_announcements()), 1)
+        self.assertEqual(NotificationMessage.objects.count(), 2)
         self.assertEqual(self.hours(), before)
 
     def test_many_announcements_across_many_hours_are_all_removed(self):

--- a/wis2watch/src/wis2watch/core/tests/test_announcements.py
+++ b/wis2watch/src/wis2watch/core/tests/test_announcements.py
@@ -1,0 +1,311 @@
+"""Dropping the catalogue-record announcements a region stored as data.
+
+These run against a seeded database because what has to be true afterwards is
+about derived rows, not about a return value: an hour that was nothing but an
+announcement has to stop existing as a bucket, an hour that was mostly data has
+to come back counting the data, and a centre whose only recent traffic was an
+announcement has to stop reading as one heard from minutes ago.
+"""
+
+from datetime import timedelta
+
+from django.test import TestCase
+
+from wis2watch.core.announcements import (
+    discard_stored_announcements,
+    stored_announcements,
+)
+from wis2watch.core.daily_rollups import rollup_days
+from wis2watch.core.models import (
+    DailyStationRollup,
+    HourlyRollup,
+    MessageSource,
+    NodeLastSeen,
+    NotificationMessage,
+    WIS2Node,
+)
+from wis2watch.core.rollups import rollup_hours
+from wis2watch.core.tests.support import at
+
+DATA_TOPIC = "origin/a/wis2/ke-meteo/data/core/weather/surface-based-observations/synop"
+METADATA_TOPIC = "origin/a/wis2/ke-meteo/metadata"
+
+WINDOW = {"since": at("2026-08-10T00:00:00"), "until": at("2026-08-14T00:00:00")}
+
+
+class DiscardTestCase(TestCase):
+    def setUp(self):
+        self.source = MessageSource.objects.create(
+            name="Global Broker",
+            source_type=MessageSource.GLOBAL_BROKER,
+            host="globalbroker.example.int",
+        )
+        self.node = WIS2Node.objects.create(centre_id="ke-meteo", name="Kenya Met")
+
+    def store(self, when, *, topic=DATA_TOPIC, data_id="", node=None):
+        """One notification, stored as the ingest used to store it."""
+        node = node or self.node
+        moment = at(when)
+
+        return NotificationMessage.objects.create(
+            source=self.source,
+            node=node,
+            notification_id=f"{node.centre_id}-{topic}-{when}",
+            topic=topic,
+            data_id=data_id,
+            time=moment,
+            raw_json={},
+        )
+
+    def announce(self, when, **kwargs):
+        """One announcement of the centre's own catalogue record."""
+        return self.store(when, topic=METADATA_TOPIC, **kwargs)
+
+    def derive(self):
+        """The rollups as the scheduled runs would have left them."""
+        rollup_hours(**WINDOW)
+        rollup_days(**WINDOW)
+
+    def see(self, when, node=None):
+        NodeLastSeen.objects.create(
+            node=node or self.node, last_message_at=at(when)
+        )
+
+    def hours(self):
+        return [
+            (row.hour.isoformat(), row.message_count)
+            for row in HourlyRollup.objects.order_by("hour")
+        ]
+
+
+class FindingThemTests(DiscardTestCase):
+    """Which stored rows are announcements at all."""
+
+    def test_a_row_on_the_metadata_topic_is_one(self):
+        self.announce("2026-08-12T10:00:00")
+
+        self.assertEqual(len(stored_announcements()), 1)
+
+    def test_a_row_from_a_centre_s_own_archive_is_one(self):
+        """The archive stores no topic, so the data identifier names it."""
+        self.store(
+            "2026-08-12T10:00:00",
+            topic="",
+            data_id="ke-meteo/metadata/urn:wmo:md:ke-meteo:synop",
+        )
+
+        self.assertEqual(len(stored_announcements()), 1)
+
+    def test_a_data_row_is_not_one(self):
+        self.store("2026-08-12T10:00:00")
+
+        self.assertEqual(stored_announcements(), [])
+
+    def test_a_data_row_whose_identifier_merely_says_metadata_is_not_one(self):
+        """The topic was observed, and observation settles it."""
+        self.store(
+            "2026-08-12T10:00:00",
+            data_id="ke-meteo/metadata/urn:wmo:md:ke-meteo:synop",
+        )
+
+        self.assertEqual(stored_announcements(), [])
+
+
+class RemovalTests(DiscardTestCase):
+    """What is dropped, and what is left alone."""
+
+    def test_an_announcement_is_removed(self):
+        self.announce("2026-08-12T10:00:00")
+
+        counts = discard_stored_announcements()
+
+        self.assertEqual(counts.messages, 1)
+        self.assertEqual(NotificationMessage.objects.count(), 0)
+
+    def test_the_same_centre_s_data_is_left_where_it_is(self):
+        published = self.store("2026-08-12T10:30:00")
+        self.announce("2026-08-12T10:00:00")
+
+        discard_stored_announcements()
+
+        self.assertEqual(
+            list(NotificationMessage.objects.values_list("id", flat=True)),
+            [published.id],
+        )
+
+    def test_a_run_finding_nothing_changes_nothing(self):
+        self.store("2026-08-12T10:00:00")
+        self.derive()
+
+        counts = discard_stored_announcements()
+
+        self.assertEqual(counts.summary, "messages=0 hours=0 days=0 nodes=0")
+        self.assertEqual(self.hours(), [("2026-08-12T10:00:00+00:00", 1)])
+
+
+class RollupTests(DiscardTestCase):
+    """What the announcements were counted into is rebuilt without them."""
+
+    def test_an_hour_that_was_only_an_announcement_stops_being_a_bucket(self):
+        self.announce("2026-08-12T10:00:00")
+        self.derive()
+
+        self.assertEqual(self.hours(), [("2026-08-12T10:00:00+00:00", 1)])
+
+        discard_stored_announcements()
+
+        self.assertEqual(self.hours(), [])
+
+    def test_an_hour_that_carried_both_is_counted_back_down(self):
+        self.store("2026-08-12T10:05:00")
+        self.store("2026-08-12T10:15:00")
+        self.announce("2026-08-12T10:00:00")
+        self.derive()
+
+        self.assertEqual(self.hours(), [("2026-08-12T10:00:00+00:00", 3)])
+
+        discard_stored_announcements()
+
+        self.assertEqual(self.hours(), [("2026-08-12T10:00:00+00:00", 2)])
+
+    def test_an_hour_the_announcements_never_touched_is_left_alone(self):
+        self.store("2026-08-11T09:00:00")
+        self.announce("2026-08-12T10:00:00")
+        self.derive()
+
+        discard_stored_announcements()
+
+        self.assertEqual(self.hours(), [("2026-08-11T09:00:00+00:00", 1)])
+
+    def test_the_day_summarised_from_them_is_rebuilt_too(self):
+        self.store("2026-08-12T09:00:00")
+        self.announce("2026-08-12T10:00:00")
+        self.announce("2026-08-12T11:00:00")
+        self.derive()
+
+        summary = DailyStationRollup.objects.get()
+
+        self.assertEqual(summary.message_count, 3)
+        self.assertEqual(summary.active_hours, 3)
+
+        discard_stored_announcements()
+
+        summary = DailyStationRollup.objects.get()
+
+        self.assertEqual(summary.message_count, 1)
+        self.assertEqual(summary.active_hours, 1)
+
+    def test_a_day_that_was_only_announcements_stops_being_a_row(self):
+        self.announce("2026-08-12T10:00:00")
+        self.derive()
+
+        self.assertEqual(DailyStationRollup.objects.count(), 1)
+
+        discard_stored_announcements()
+
+        self.assertEqual(DailyStationRollup.objects.count(), 0)
+
+
+class LastSeenTests(DiscardTestCase):
+    """A centre kept warm by an announcement is a centre that looks alive."""
+
+    def test_last_seen_goes_back_to_the_latest_message_still_held(self):
+        self.store("2026-08-12T09:00:00")
+        self.announce("2026-08-12T10:00:00")
+        self.see("2026-08-12T10:00:00")
+
+        counts = discard_stored_announcements()
+
+        self.assertEqual(counts.nodes, 1)
+        self.assertEqual(
+            NodeLastSeen.objects.get(node=self.node).last_message_at,
+            at("2026-08-12T09:00:00"),
+        )
+
+    def test_a_centre_with_no_messages_left_falls_back_to_its_own_history(self):
+        """The rollups outlive the messages, and are the only thing that knows."""
+        HourlyRollup.objects.create(
+            hour=at("2026-07-01T08:00:00"),
+            source=self.source,
+            node=self.node,
+            message_count=4,
+        )
+        self.announce("2026-08-12T10:00:00")
+        self.see("2026-08-12T10:00:00")
+
+        discard_stored_announcements()
+
+        self.assertEqual(
+            NodeLastSeen.objects.get(node=self.node).last_message_at,
+            at("2026-07-01T08:00:00"),
+        )
+
+    def test_a_centre_never_heard_publishing_data_stops_claiming_to_have_been(self):
+        self.announce("2026-08-12T10:00:00")
+        self.see("2026-08-12T10:00:00")
+
+        discard_stored_announcements()
+
+        self.assertEqual(NodeLastSeen.objects.count(), 0)
+
+    def test_a_centre_that_has_published_since_keeps_its_own_time(self):
+        """Time only moves backwards here; it corrects an overstatement."""
+        self.store("2026-08-13T06:00:00")
+        self.announce("2026-08-12T10:00:00")
+        self.see("2026-08-13T06:00:00")
+
+        counts = discard_stored_announcements()
+
+        self.assertEqual(counts.nodes, 0)
+        self.assertEqual(
+            NodeLastSeen.objects.get(node=self.node).last_message_at,
+            at("2026-08-13T06:00:00"),
+        )
+
+    def test_another_centre_s_last_seen_is_not_touched(self):
+        other = WIS2Node.objects.create(centre_id="ng-nimet", name="Nigeria Met")
+        self.see("2026-08-12T10:00:00", node=other)
+        self.announce("2026-08-12T10:00:00")
+
+        discard_stored_announcements()
+
+        self.assertEqual(
+            NodeLastSeen.objects.get(node=other).last_message_at,
+            at("2026-08-12T10:00:00"),
+        )
+
+
+class RepeatedRunTests(DiscardTestCase):
+    """It is written to be run again, because a run can stop half way."""
+
+    def test_a_second_run_finds_nothing_and_leaves_the_numbers_alone(self):
+        self.store("2026-08-12T10:05:00")
+        self.announce("2026-08-12T10:00:00")
+        self.derive()
+
+        discard_stored_announcements()
+        before = self.hours()
+
+        counts = discard_stored_announcements()
+
+        self.assertEqual(counts.messages, 0)
+        self.assertEqual(self.hours(), before)
+
+    def test_many_announcements_across_many_hours_are_all_removed(self):
+        """More buckets than one delete names at a time."""
+        start = at("2026-08-11T00:00:00")
+
+        for offset in range(60):
+            when = (start + timedelta(hours=offset)).isoformat()
+
+            self.announce(when.removesuffix("+00:00"))
+
+        self.derive()
+
+        self.assertEqual(HourlyRollup.objects.count(), 60)
+
+        counts = discard_stored_announcements()
+
+        self.assertEqual(counts.messages, 60)
+        self.assertEqual(HourlyRollup.objects.count(), 0)
+        self.assertEqual(DailyStationRollup.objects.count(), 0)

--- a/wis2watch/src/wis2watch/core/tests/test_interpretation_topics.py
+++ b/wis2watch/src/wis2watch/core/tests/test_interpretation_topics.py
@@ -4,6 +4,7 @@ from django.test import override_settings
 
 from wis2watch.core.interpretation import (
     CACHE,
+    announces_catalogue_record,
     centre_id_prefix,
     is_monitored_centre_id,
     monitored_country_code_for_centre_id,
@@ -107,6 +108,107 @@ class SubscriptionTopicTests(NoNetworkTestCase):
         self.assertIsNone(subscription_topic(""))
         self.assertIsNone(subscription_topic(None))
         self.assertIsNone(subscription_topic("   "))
+
+
+class CatalogueRecordAnnouncementTests(NoNetworkTestCase):
+    """Telling a centre announcing its record from a centre publishing data."""
+
+    def test_the_metadata_topic_carries_a_catalogue_record(self):
+        self.assertTrue(
+            announces_catalogue_record("origin/a/wis2/ke-meteo/metadata")
+        )
+
+    def test_a_cache_republishing_one_is_the_same_announcement(self):
+        self.assertTrue(
+            announces_catalogue_record("cache/a/wis2/ke-meteo/metadata")
+        )
+
+    def test_a_record_named_below_the_metadata_level_is_still_one(self):
+        self.assertTrue(
+            announces_catalogue_record(
+                "origin/a/wis2/gh-gmet/metadata/core.surface-based-observations.synop"
+            )
+        )
+
+    def test_a_data_topic_is_not_one(self):
+        self.assertFalse(
+            announces_catalogue_record(
+                "origin/a/wis2/ke-meteo/data/core/weather/"
+                "surface-based-observations/synop"
+            )
+        )
+
+    def test_a_centre_publishing_data_about_metadata_is_not_one(self):
+        """Only the level directly below the centre decides it."""
+        self.assertFalse(
+            announces_catalogue_record("origin/a/wis2/ke-meteo/data/core/metadata")
+        )
+
+    def test_a_topic_that_is_not_a_wis2_topic_is_not_one(self):
+        self.assertFalse(announces_catalogue_record("some/other/metadata"))
+
+    def test_with_no_topic_the_data_identifier_answers_it(self):
+        """A centre's own archive returns the notification without a topic."""
+        self.assertTrue(
+            announces_catalogue_record(
+                "",
+                data_id=(
+                    "gh-gmet/metadata/"
+                    "urn:wmo:md:gh-gmet:core.surface-based-observations.synop"
+                ),
+            )
+        )
+
+    def test_with_no_topic_a_data_identifier_naming_data_is_not_one(self):
+        self.assertFalse(
+            announces_catalogue_record(
+                "",
+                data_id=(
+                    "gh-gmet:core.surface-based-observations.synop/"
+                    "WIGOS_0-288-0-65492_20260809T160000"
+                ),
+            )
+        )
+
+    def test_a_topic_that_was_observed_settles_it_alone(self):
+        """What a message went out on outranks what it says about itself."""
+        self.assertFalse(
+            announces_catalogue_record(
+                "origin/a/wis2/gh-gmet/data/core/weather/"
+                "surface-based-observations/synop",
+                data_id="gh-gmet/metadata/urn:wmo:md:gh-gmet:whatever",
+            )
+        )
+
+    def test_nothing_named_at_all_is_not_one(self):
+        self.assertFalse(announces_catalogue_record("", data_id=""))
+        self.assertFalse(announces_catalogue_record(None, data_id=None))
+
+
+class ArchivedCatalogueRecordTests(NoNetworkTestCase):
+    """The captured archives carry one announcement each, and it is found."""
+
+    def announcements_in(self, capture):
+        return [
+            feature
+            for feature in load_json_fixture(capture)["features"]
+            if announces_catalogue_record(
+                "", data_id=feature["properties"].get("data_id", "")
+            )
+        ]
+
+    def test_each_captured_archive_page_carries_exactly_one(self):
+        for capture in (
+            "node_messages_sc_seychelles_met.json",
+            "node_messages_gh_gmet.json",
+        ):
+            with self.subTest(capture=capture):
+                found = self.announcements_in(capture)
+
+                self.assertEqual(len(found), 1)
+                self.assertEqual(
+                    [link["rel"] for link in found[0]["links"]], ["update"]
+                )
 
 
 class SweepTopicTests(NoNetworkTestCase):

--- a/wis2watch/src/wis2watch/ingest/archive.py
+++ b/wis2watch/src/wis2watch/ingest/archive.py
@@ -24,8 +24,10 @@ surveyed it costs the same -- each declares a single dataset -- and a message
 whose metadata identifier names no registered dataset is the strongest evidence
 this tool can get that a centre is transmitting undeclared data, since it comes
 from the centre's own archive. Asking per dataset could only ever return the
-datasets already known. Metadata notifications come back mixed in with data
-ones and are stored, as the broker path stores them.
+datasets already known. The centre's announcement of its own catalogue record
+comes back mixed in with the data notifications and is set aside, as the broker
+path sets one aside -- with no topic to recognise it by, the data identifier
+spells the same path the topic would have.
 
 **The window is a fixed trailing one, asked for again each time.** Publication
 time is the publisher's own claim, so a message stamped behind a watermark
@@ -152,7 +154,7 @@ def _record_answer(source, error=""):
 
 
 def _store_page(source, payload):
-    """Store one page of notifications, reporting what became of them.
+    """Store one page of notifications, reporting how many it published.
 
     The node is handed to the store rather than left to be read off a topic:
     the poll knows whose archive it asked for, and the messages carry nothing
@@ -160,11 +162,16 @@ def _store_page(source, payload):
     what to do with one that cannot be identified in time -- is the store's,
     which is the point of writing through it.
 
-    Two of the store's outcomes are the only ones a poll can come back with:
-    accepted, and unstorable. Nothing here can be refused for belonging to
-    another region, since that is decided from the centre a message's topic
-    names and these name none -- which is why what the run reports adds up
-    without counting it.
+    What is returned is what the page offered that the poll had any business
+    with, which is what a sync log means by "found". A centre's announcement of
+    its own catalogue record is not a publication and is left out of it, so
+    that a run's found, created and errored go on adding up rather than the
+    announcement reading as a notification that went missing.
+
+    Two of the store's outcomes are the only ones a poll can come back with
+    besides that: accepted, and unstorable. Nothing here can be refused for
+    belonging to another region, since that is decided from the centre a
+    message's topic names and these name none.
     """
     notifications = archived_notifications(payload)
 
@@ -174,7 +181,7 @@ def _store_page(source, payload):
         node=source.node,
     )
 
-    return len(notifications), counts
+    return len(notifications) - counts.catalogue_records, counts
 
 
 def poll_message_archive(
@@ -210,9 +217,9 @@ def poll_message_archive(
 
     try:
         for payload in fetch(source, since=since, until=until, max_pages=max_pages):
-            offered, stored = _store_page(source, payload)
+            published, stored = _store_page(source, payload)
 
-            counts.found += offered
+            counts.found += published
             counts.created += stored.accepted
             counts.errored += stored.discarded
     except PagingDidNotTerminate as exc:

--- a/wis2watch/src/wis2watch/ingest/store.py
+++ b/wis2watch/src/wis2watch/ingest/store.py
@@ -24,10 +24,19 @@ to be watching it. So ``cache/`` traffic is stored against a vantage point of
 its own: it is countable there, and every count of what a centre published
 stays about the centre.
 
-One thing is refused: traffic from a centre that is neither in the registry nor
-in the monitored region. This tool watches a region, and the wildcard sweep is
-briefly offered the whole world's; keeping what the sweep turns up outside the
-region would trade unbounded storage for messages nobody will ever ask about.
+One thing is set aside rather than stored: a centre announcing its own WCMP2
+discovery metadata record, which every centre does periodically on the
+``metadata`` topic below its own. Nothing in such a notification says it is not
+a publication -- what says so is where it was published -- and stored, it would
+count as traffic on every volume surface and keep a centre that has published
+no data at all reading as though it had. The centre it names is still reported
+as one the region carries, because that much is true whatever it announced.
+
+One thing is refused outright: traffic from a centre that is neither in the
+registry nor in the monitored region. This tool watches a region, and the
+wildcard sweep is briefly offered the whole world's; keeping what the sweep
+turns up outside the region would trade unbounded storage for messages nobody
+will ever ask about.
 The region is decided from the centre ID prefix alone, since a centre nothing
 knows about has nothing else to decide it by, and the centres in the region
 that the registry has no record of are reported back as the finding they are.
@@ -43,6 +52,7 @@ from dataclasses import dataclass, field
 from django.db.models import Q
 
 from ..core.interpretation import (
+    announces_catalogue_record,
     is_monitored_centre_id,
     parse_notification,
     parse_topic,
@@ -75,6 +85,12 @@ class StoreCounts:
     what could not be stored at all, and ``out_of_region`` what was refused for
     belonging to another part of the world.
 
+    ``catalogue_records`` counts the centres' announcements of their own
+    discovery metadata records, which are set aside rather than stored. Named
+    in the log because they are a fixed cost of listening to a region -- a
+    steady trickle, one per centre per re-announcement -- and because a flush
+    that is nothing else is a flush in which no centre published anything.
+
     ``cached`` is how much of a flush was a Global Cache's republication rather
     than a centre's own publication -- typically more than the rest of it,
     since every cache carrying a centre's data republishes it. Named in the log
@@ -100,6 +116,7 @@ class StoreCounts:
     unattributed: int = 0
     unknown_dataset: int = 0
     cached: int = 0
+    catalogue_records: int = 0
     out_of_region: int = 0
     discarded: int = 0
     unregistered_centres: dict[str, str] = field(default_factory=dict)
@@ -110,6 +127,7 @@ class StoreCounts:
         return (
             f"accepted={self.accepted} unattributed={self.unattributed} "
             f"unknown_dataset={self.unknown_dataset} cached={self.cached} "
+            f"catalogue_records={self.catalogue_records} "
             f"out_of_region={self.out_of_region} discarded={self.discarded}"
         )
 
@@ -392,6 +410,13 @@ def store_notifications(source, received, node=None):
     A message the flush cannot prepare is counted and stepped over: one
     malformed notification must not cost the flush it arrived in.
 
+    A centre announcing its own discovery metadata record is counted and set
+    aside before anything is written, so that it reaches neither the rollups
+    nor the centre's last-seen. It is set aside after the region has been
+    judged and after the centre has been noted, though: an unregistered centre
+    announcing its record is still a centre of the region that this tool has no
+    record of, which is the finding a sweep exists to make.
+
     A message from a centre that is neither registered nor in the monitored
     region is refused for the same reason nothing subscribes to the world: it
     is another region's traffic, and this tool answers questions about one.
@@ -436,6 +461,10 @@ def store_notifications(source, received, node=None):
                 continue
 
             counts.unregistered_centres[centre_id] = record.topic
+
+        if announces_catalogue_record(record.topic, record.data_id):
+            counts.catalogue_records += 1
+            continue
 
         records.append(record)
         counts.accepted += 1

--- a/wis2watch/src/wis2watch/ingest/tests/test_archive.py
+++ b/wis2watch/src/wis2watch/ingest/tests/test_archive.py
@@ -90,9 +90,9 @@ class AttributionTests(ArchiveTestCase):
     def test_every_notification_is_stored_against_the_centre_that_was_asked(self):
         self.poll_capture()
 
-        self.assertEqual(NotificationMessage.objects.count(), 14)
+        self.assertEqual(NotificationMessage.objects.count(), 13)
         self.assertEqual(
-            NotificationMessage.objects.filter(node=self.node).count(), 14
+            NotificationMessage.objects.filter(node=self.node).count(), 13
         )
 
     def test_no_stored_row_claims_a_topic(self):
@@ -138,23 +138,25 @@ class AttributionTests(ArchiveTestCase):
 
         undeclared = NotificationMessage.objects.filter(dataset__isnull=True)
 
-        self.assertEqual(undeclared.count(), 14)
+        self.assertEqual(undeclared.count(), 13)
         self.assertEqual(undeclared.exclude(node=self.node).count(), 0)
 
-    def test_a_metadata_notification_is_stored_as_the_broker_path_stores_one(self):
-        """It names no dataset and no station, and is kept for all that."""
+    def test_the_centre_s_announcement_of_its_own_record_is_set_aside(self):
+        """The archive names no topic, so the data identifier answers it.
+
+        It is not a publication, and stored it would count as one everywhere a
+        centre's volume is read -- including for a centre whose archive holds
+        nothing else.
+        """
         self.dataset()
 
         self.poll_capture()
 
-        announcement = NotificationMessage.objects.get(
-            data_id=SC_METADATA_NOTIFICATION
+        self.assertFalse(
+            NotificationMessage.objects.filter(
+                data_id=SC_METADATA_NOTIFICATION
+            ).exists()
         )
-
-        self.assertEqual(announcement.node, self.node)
-        self.assertIsNone(announcement.dataset)
-        self.assertIsNone(announcement.station)
-        self.assertEqual(announcement.metadata_id, "")
 
     def test_a_station_seen_transmitting_is_written_down(self):
         self.poll_capture()
@@ -189,7 +191,7 @@ class RepeatedPollTests(ArchiveTestCase):
         self.poll_capture()
         self.poll_capture()
 
-        self.assertEqual(NotificationMessage.objects.count(), 14)
+        self.assertEqual(NotificationMessage.objects.count(), 13)
 
     def test_two_centres_archives_do_not_collide(self):
         other = WIS2Node.objects.create(centre_id="gh-gmet", name="Ghana Met")
@@ -203,8 +205,8 @@ class RepeatedPollTests(ArchiveTestCase):
             fetch=pages(load_json_fixture(DEEP)),
         )
 
-        self.assertEqual(NotificationMessage.objects.filter(node=self.node).count(), 14)
-        self.assertEqual(NotificationMessage.objects.filter(node=other).count(), 10)
+        self.assertEqual(NotificationMessage.objects.filter(node=self.node).count(), 13)
+        self.assertEqual(NotificationMessage.objects.filter(node=other).count(), 9)
 
 
 class SyncLogTests(ArchiveTestCase):
@@ -219,17 +221,18 @@ class SyncLogTests(ArchiveTestCase):
         self.assertIsNotNone(sync_log.completed_at)
 
     def test_it_reports_what_the_archive_offered_and_what_was_stored(self):
+        """The page carries fourteen; one of them announces a record."""
         sync_log = self.poll_capture()
 
-        self.assertEqual(sync_log.items_found, 14)
-        self.assertEqual(sync_log.items_created, 14)
+        self.assertEqual(sync_log.items_found, 13)
+        self.assertEqual(sync_log.items_created, 13)
         self.assertEqual(sync_log.items_errored, 0)
 
     def test_it_counts_every_page_it_read(self):
         sync_log = self.poll(load_json_fixture(SHALLOW), load_json_fixture(DEEP))
 
-        self.assertEqual(sync_log.items_found, 24)
-        self.assertEqual(sync_log.items_created, 24)
+        self.assertEqual(sync_log.items_found, 22)
+        self.assertEqual(sync_log.items_created, 22)
 
     def test_one_unusable_notification_does_not_cost_the_page_it_came_on(self):
         payload = load_json_fixture(SHALLOW)
@@ -238,10 +241,10 @@ class SyncLogTests(ArchiveTestCase):
         sync_log = self.poll(payload)
 
         self.assertEqual(sync_log.status, SyncLog.PARTIAL)
-        self.assertEqual(sync_log.items_found, 15)
-        self.assertEqual(sync_log.items_created, 14)
+        self.assertEqual(sync_log.items_found, 14)
+        self.assertEqual(sync_log.items_created, 13)
         self.assertEqual(sync_log.items_errored, 1)
-        self.assertEqual(NotificationMessage.objects.count(), 14)
+        self.assertEqual(NotificationMessage.objects.count(), 13)
 
 
 class ReachabilityTests(ArchiveTestCase):
@@ -297,8 +300,8 @@ class ReachabilityTests(ArchiveTestCase):
         )
 
         self.assertEqual(sync_log.status, SyncLog.FAILED)
-        self.assertEqual(sync_log.items_found, 14)
-        self.assertEqual(NotificationMessage.objects.count(), 14)
+        self.assertEqual(sync_log.items_found, 13)
+        self.assertEqual(NotificationMessage.objects.count(), 13)
 
 
 class FetchTests(ArchiveTestCase):

--- a/wis2watch/src/wis2watch/ingest/tests/test_pull_message_archive.py
+++ b/wis2watch/src/wis2watch/ingest/tests/test_pull_message_archive.py
@@ -68,9 +68,21 @@ class PullTests(PullMessageArchiveTestCase):
 
         stored = NotificationMessage.objects.filter(node=self.node)
 
-        self.assertEqual(stored.count(), 14)
+        # Thirteen of the fourteen the page carries: the fourteenth announces
+        # the centre's own catalogue record, which is not a publication.
+        self.assertEqual(stored.count(), 13)
         self.assertEqual(stored.exclude(source=self.source).count(), 0)
         self.assertEqual(set(stored.values_list("topic", flat=True)), {""})
+
+    def test_the_centre_s_announcement_of_its_own_record_is_not_stored(self):
+        self.run_command("sc-seychelles-met", hours=2)
+
+        self.assertEqual(
+            NotificationMessage.objects.filter(
+                data_id__startswith="sc-seychelles-met/metadata/"
+            ).count(),
+            0,
+        )
 
     def test_it_asks_the_archive_for_the_depth_it_was_given(self):
         with mock.patch("wis2watch.ingest.archive.fetch_archive_pages") as fetch:
@@ -106,9 +118,9 @@ class PullTests(PullMessageArchiveTestCase):
 
         self.assertEqual(sync_log.node, self.node)
         self.assertEqual(sync_log.status, SyncLog.SUCCESS)
-        self.assertEqual(sync_log.items_found, 14)
+        self.assertEqual(sync_log.items_found, 13)
         self.assertIn("sc-seychelles-met", output)
-        self.assertIn("found=14", output)
+        self.assertIn("found=13", output)
 
 
 class RollupTests(PullMessageArchiveTestCase):
@@ -124,20 +136,20 @@ class RollupTests(PullMessageArchiveTestCase):
 
         rollups = HourlyRollup.objects.filter(node=self.node)
 
-        # One row per station the hour carried, and one for the metadata
-        # notification, which names none.
-        self.assertEqual(rollups.count(), 14)
+        # One row per station the hour carried. The catalogue-record
+        # announcement the page also carries reaches none of this.
+        self.assertEqual(rollups.count(), 13)
         self.assertEqual(
             set(rollups.values_list("hour", flat=True)),
             {NOW.replace(hour=15, minute=0)},
         )
-        self.assertEqual(sum(rollups.values_list("message_count", flat=True)), 14)
+        self.assertEqual(sum(rollups.values_list("message_count", flat=True)), 13)
 
     def test_a_pull_reaching_back_past_the_scheduled_window_is_counted_too(self):
         """The whole depth asked for, not the trailing two days of it."""
         self.run_command("sc-seychelles-met", hours=24 * 60)
 
-        self.assertEqual(HourlyRollup.objects.filter(node=self.node).count(), 14)
+        self.assertEqual(HourlyRollup.objects.filter(node=self.node).count(), 13)
 
     def test_a_second_pull_of_the_same_window_does_not_double_the_counts(self):
         self.run_command("sc-seychelles-met", hours=2)
@@ -149,7 +161,7 @@ class RollupTests(PullMessageArchiveTestCase):
                     "message_count", flat=True
                 )
             ),
-            14,
+            13,
         )
 
 

--- a/wis2watch/src/wis2watch/ingest/tests/test_store.py
+++ b/wis2watch/src/wis2watch/ingest/tests/test_store.py
@@ -23,7 +23,11 @@ from wis2watch.core.models import (
     StationSource,
     WIS2Node,
 )
-from wis2watch.core.tests.support import in_region, load_jsonl_fixture
+from wis2watch.core.tests.support import (
+    in_region,
+    load_json_fixture,
+    load_jsonl_fixture,
+)
 from wis2watch.ingest.store import store_notifications
 
 CAPTURE = "global_broker_notifications.jsonl"
@@ -35,6 +39,35 @@ KE_STATION = "0-20000-0-63708"
 
 DJ_TOPIC = "origin/a/wis2/dj-anm/data/recommended/weather/aviation/taf"
 BR_TOPIC = "origin/a/wis2/br-inmet/data/core/weather/surface-based-observations/synop"
+
+#: A centre's own archive, which is where a real catalogue-record announcement
+#: was captured: the broker capture happens to carry none, and this is the same
+#: notification as it goes out -- the archive returns the message itself.
+ARCHIVE_CAPTURE = "node_messages_sc_seychelles_met.json"
+
+SC_METADATA_TOPIC = "origin/a/wis2/sc-seychelles-met/metadata"
+SC_TOPIC = (
+    "origin/a/wis2/sc-seychelles-met/data/core/weather/"
+    "surface-based-observations/synop"
+)
+
+
+def catalogue_record_announcement():
+    """The captured announcement of a centre's own WCMP2 record."""
+    for feature in load_json_fixture(ARCHIVE_CAPTURE)["features"]:
+        if feature["properties"]["data_id"].split("/")[1:2] == ["metadata"]:
+            return feature
+
+    raise AssertionError(f"no catalogue-record announcement in {ARCHIVE_CAPTURE}")
+
+
+def archived_data_notification():
+    """A captured data notification from the same centre's archive."""
+    for feature in load_json_fixture(ARCHIVE_CAPTURE)["features"]:
+        if feature["properties"]["data_id"].split("/")[1:2] != ["metadata"]:
+            return feature
+
+    raise AssertionError(f"no data notification in {ARCHIVE_CAPTURE}")
 
 
 def captured():
@@ -358,6 +391,115 @@ class RegionTests(StoreTestCase):
 
         self.assertIsNotNone(record)
         self.assertEqual(record.topic, "some/other/thing")
+
+
+class CatalogueRecordTests(StoreTestCase):
+    """A centre announcing its own record is not a centre publishing data.
+
+    Every centre re-announces its WCMP2 record periodically, and nothing in the
+    payload distinguishes that from a publication -- so stored, it would count
+    as traffic on every volume surface and keep a centre that has published
+    nothing looking as though it had.
+    """
+
+    def setUp(self):
+        super().setUp()
+
+        self.centre = WIS2Node.objects.create(
+            centre_id="sc-seychelles-met", name="Seychelles Met"
+        )
+
+    def announcement_on(self, topic):
+        return (topic, catalogue_record_announcement())
+
+    def test_an_announcement_on_the_metadata_topic_is_not_stored(self):
+        record = store_one(self.source, *self.announcement_on(SC_METADATA_TOPIC))
+
+        self.assertIsNone(record)
+        self.assertEqual(NotificationMessage.objects.count(), 0)
+
+    def test_a_cache_republishing_one_is_not_stored_either(self):
+        record = store_one(
+            self.source,
+            *self.announcement_on(
+                SC_METADATA_TOPIC.replace("origin/", "cache/")
+            ),
+        )
+
+        self.assertIsNone(record)
+        self.assertEqual(NotificationMessage.objects.count(), 0)
+
+    def test_the_same_centre_s_data_is_still_stored(self):
+        counts = store_notifications(
+            self.source,
+            [
+                self.announcement_on(SC_METADATA_TOPIC),
+                (SC_TOPIC, archived_data_notification()),
+            ],
+        )
+
+        record = NotificationMessage.objects.get()
+
+        self.assertEqual(counts.accepted, 1)
+        self.assertEqual(record.node, self.centre)
+        self.assertEqual(record.topic, SC_TOPIC)
+
+    def test_an_announcement_is_counted_as_the_thing_it_is(self):
+        counts = store_notifications(
+            self.source, [self.announcement_on(SC_METADATA_TOPIC)]
+        )
+
+        self.assertEqual(counts.catalogue_records, 1)
+        self.assertEqual(counts.accepted, 0)
+        self.assertEqual(counts.discarded, 0)
+        self.assertIn("catalogue_records=1", counts.summary)
+
+    def test_an_announcement_does_not_move_the_centre_s_last_seen(self):
+        store_notifications(self.source, [self.announcement_on(SC_METADATA_TOPIC)])
+
+        self.assertEqual(NodeLastSeen.objects.count(), 0)
+
+    def test_an_announcement_from_a_centre_s_own_archive_is_not_stored_either(self):
+        """The archive returns no topic, so the data identifier answers it."""
+        counts = store_notifications(
+            self.source,
+            [("", catalogue_record_announcement())],
+            node=self.centre,
+        )
+
+        self.assertEqual(counts.catalogue_records, 1)
+        self.assertEqual(NotificationMessage.objects.count(), 0)
+
+    def test_the_archive_s_data_notifications_are_still_stored(self):
+        counts = store_notifications(
+            self.source,
+            [("", archived_data_notification())],
+            node=self.centre,
+        )
+
+        self.assertEqual(counts.accepted, 1)
+        self.assertEqual(NotificationMessage.objects.get().node, self.centre)
+
+    def test_an_unregistered_centre_announcing_its_record_is_still_reported(self):
+        """It is a centre of the region that the registry has no record of."""
+        WIS2Node.objects.filter(pk=self.centre.pk).delete()
+
+        counts = store_notifications(
+            self.source, [self.announcement_on(SC_METADATA_TOPIC)]
+        )
+
+        self.assertEqual(
+            counts.unregistered_centres, {"sc-seychelles-met": SC_METADATA_TOPIC}
+        )
+
+    def test_another_region_s_announcement_is_refused_as_out_of_region(self):
+        counts = store_notifications(
+            self.source,
+            [self.announcement_on("origin/a/wis2/br-inmet/metadata")],
+        )
+
+        self.assertEqual(counts.out_of_region, 1)
+        self.assertEqual(counts.catalogue_records, 0)
 
 
 class DatasetAttributionTests(StoreTestCase):

--- a/wis2watch/src/wis2watch/ingest/tests/test_store.py
+++ b/wis2watch/src/wis2watch/ingest/tests/test_store.py
@@ -14,6 +14,7 @@ error.
 from django.test import TestCase
 from django.utils import timezone as dj_timezone
 
+from wis2watch.core.interpretation import announces_catalogue_record
 from wis2watch.core.models import (
     Dataset,
     MessageSource,
@@ -52,22 +53,32 @@ SC_TOPIC = (
 )
 
 
-def catalogue_record_announcement():
-    """The captured announcement of a centre's own WCMP2 record."""
+def archived(*, announcing):
+    """The first captured archive message that is, or is not, an announcement.
+
+    Picked by the rule the ingest picks by rather than by one written again
+    here: a test that spelled out what a catalogue record looks like would go
+    on passing after the two spellings had drifted apart.
+    """
     for feature in load_json_fixture(ARCHIVE_CAPTURE)["features"]:
-        if feature["properties"]["data_id"].split("/")[1:2] == ["metadata"]:
+        found = announces_catalogue_record(
+            "", data_id=feature["properties"].get("data_id", "")
+        )
+
+        if found == announcing:
             return feature
 
-    raise AssertionError(f"no catalogue-record announcement in {ARCHIVE_CAPTURE}")
+    raise AssertionError(f"nothing matching in {ARCHIVE_CAPTURE}")
+
+
+def catalogue_record_announcement():
+    """The captured announcement of a centre's own WCMP2 record."""
+    return archived(announcing=True)
 
 
 def archived_data_notification():
     """A captured data notification from the same centre's archive."""
-    for feature in load_json_fixture(ARCHIVE_CAPTURE)["features"]:
-        if feature["properties"]["data_id"].split("/")[1:2] != ["metadata"]:
-            return feature
-
-    raise AssertionError(f"no data notification in {ARCHIVE_CAPTURE}")
+    return archived(announcing=False)
 
 
 def captured():


### PR DESCRIPTION
Closes #127.

Centres announce their WCMP2 discovery metadata record on the `metadata` topic below their own, and re-announce it periodically. Nothing in such a notification says it is not a publication — what says so is where it was published — so every one of them was stored, rolled up and counted as traffic. That inflated every volume figure and kept the last-seen time of a centre that had published nothing at all warm. Measured on the region: 230 of them in 7 days, across 20 of 32 centres.

## What changed

**One rule, in one place.** `announces_catalogue_record(topic, data_id)` in `core/interpretation/topics.py`. The topic decides it wherever one was observed — `.../{centre}/metadata`, either prefix, since a Global Cache republishes the announcement too — and answers it alone: a message that went out on a data topic is a data publication whatever else it says about itself.

Where there is no topic, the data identifier is read instead. A centre's own message archive returns notifications with no topic at all, and the `data_id` spells the same path the topic would have: `{centre}/metadata/{record}`. So the one announcement is recognised from either vantage point rather than only from the broker.

**Set aside at ingest, before storage.** `ingest/store.py` counts them into a new `catalogue_records` and steps over them, so they reach neither `_insert`, nor `_record_last_seen`, nor the rollups derived from stored rows.

They are set aside *after* the region has been judged and after the centre has been noted: an unregistered centre announcing its record is still a centre of the region this tool has no record of, which is the finding the sweep exists to make.

**The region's existing rows are repaired.** `core/announcements.py`, called by migration `0025`:

- the stored rows are found by the same rule the ingest refuses one by, and deleted;
- the hourly buckets they were counted into are **dropped and then recomputed** — dropping first is what an emptied bucket needs, because a recompute is only ever written from messages that exist and would never visit an hour whose whole traffic was an announcement;
- the station-days summarised from those buckets follow;
- each affected centre's last-seen is taken back to its latest surviving evidence.

It is one transaction. Each step destroys the evidence for the one before it, so a run that stopped between dropping a bucket and recomputing it would leave that bucket missing for good — the re-run finds no announcements and returns. Held together, an interrupted run leaves the database as it found it. There is a test for that.

Only hours an announcement was found in are touched, which is also the only range where this can be right: raw messages are kept for a fortnight, so an hour with an announcement still in it necessarily still holds the rest of its traffic. Nothing older is reachable.

## Two deliberate steps past the literal acceptance criteria

- **The archive poll's `found` now excludes announcements** (14 → 13 on the captured page). `SyncCounts` defines `found` as "what the source offered that the run had any business with", and leaving it would make a run's found, created and errored stop adding up — the announcement would read as a notification that went missing.
- **Last-seen is restated retroactively**, and the row is *deleted* for a centre with no evidence it ever published data, which renders as never-heard. The criterion is framed about ingest; a last-seen written by a now-deleted row is stored data derived from it, and leaving it warm would leave the reported bug standing for every centre already affected.

Happy to take the second one back out if it reads as too much.

## One limitation, stated rather than hidden

For a centre with no surviving messages, last-seen falls back to its latest hourly rollup. Rollups older than the raw retention window cannot be recomputed, so a centre whose last rollup was an announcement-only hour lands on that hour. It is still the latest thing the region has evidence of, and weeks earlier than the announcement that would otherwise have stood. The docstring says so.

## Checked and left alone

`PropagationGap` rows carry a topic and hold no FK to the messages, so gaps recorded *from* announcements would survive the delete. Against the live database: 56,805 gaps, none of them from an announcement — a metadata notification propagates like anything else and rarely becomes one — and no new ones can be created now. Not worth code that would never fire.

## Testing

Full suite green, 1588 tests. New coverage: the interpretation rule against both captured node archives; a metadata-topic notification skipped while a data notification on the same centre is still stored, from the broker path and the archive path; the rollup and last-seen repair, including an emptied bucket, a mixed hour counted back down, an untouched hour, re-running, more buckets than one delete names at a time, and the part-way failure.

https://claude.ai/code/session_01BTF4cgqL9zfAZCz3cEaSTw