### PR TITLE
feat(#132): a node's own declarations are read and recorded

### DIFF
--- a/wis2watch/src/wis2watch/config/settings/base.py
+++ b/wis2watch/src/wis2watch/config/settings/base.py
@@ -549,6 +549,14 @@ CELERY_BEAT_SCHEDULE = {
         'task': 'wis2watch.core.tasks.run_sync_all_node_stations',
         'schedule': 3600.0,  # Every hour
     },
+    # Hourly, like the station registries and against the same hosts, but at
+    # its own minute: a centre's two endpoints are two fetches, several of the
+    # region's hosts hang until the timeout, and asking both of a centre in the
+    # same minute would put the whole region's slow hosts in one pile.
+    'sync-node-discovery-metadata': {
+        'task': 'wis2watch.core.tasks.run_sync_all_node_datasets',
+        'schedule': crontab(minute=40),
+    },
     # Hourly, and only for the centres whose own broker will not answer -- see
     # wis2watch.ingest.tasks for why an hour is soon enough and why the centres
     # that can be heard live are left alone. Off the hour, so the region's

--- a/wis2watch/src/wis2watch/config/settings/base.py
+++ b/wis2watch/src/wis2watch/config/settings/base.py
@@ -545,9 +545,14 @@ CELERY_BEAT_SCHEDULE = {
         'task': 'wis2watch.core.tasks.run_sync_catalogues',
         'schedule': 21600.0,  # Every 6 hours
     },
+    # On the hour, which the schedules below are offset from. An interval of
+    # 3600 seconds would be hourly too, and every one of those offsets is a
+    # coincidence of when the beat was last restarted: the whole point of
+    # asking a centre's endpoints at different minutes is lost the moment the
+    # minute is whatever the worker happened to start at.
     'sync-node-stations': {
         'task': 'wis2watch.core.tasks.run_sync_all_node_stations',
-        'schedule': 3600.0,  # Every hour
+        'schedule': crontab(minute=0),
     },
     # Hourly, like the station registries and against the same hosts, but at
     # its own minute: a centre's two endpoints are two fetches, several of the

--- a/wis2watch/src/wis2watch/core/catalogue.py
+++ b/wis2watch/src/wis2watch/core/catalogue.py
@@ -40,7 +40,14 @@ from .models import (
     SyncLog,
     WIS2Node,
 )
-from .sync import CREATED, UPDATED, SteppedOver, SyncCounts, fetch_pages
+from .sync import (
+    CREATED,
+    UPDATED,
+    SteppedOver,
+    SyncCounts,
+    declared_dataset_fields,
+    fetch_pages,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -341,13 +348,7 @@ def _apply_dataset(node, discovered, catalogue):
         node=node,
         identifier=discovered.identifier,
         defaults={
-            "title": discovered.title,
-            "wmo_data_policy": discovered.data_policy,
-            "wmo_topic_hierarchy": discovered.topic,
-            "self_link": discovered.canonical_link,
-            "raw_json": discovered.raw,
-            "metadata_created": discovered.metadata_created,
-            "metadata_updated": discovered.metadata_updated,
+            **declared_dataset_fields(discovered),
             "last_synced": dj_timezone.now(),
             # Datasets are the catalogue's to describe: one it still publishes
             # is active, whatever an earlier run concluded about it.

--- a/wis2watch/src/wis2watch/core/models.py
+++ b/wis2watch/src/wis2watch/core/models.py
@@ -253,10 +253,12 @@ class WIS2Node(TimeStampedModel):
     def advertises_discovery_metadata(self):
         """Whether there is anywhere to ask this centre what datasets it declares.
 
-        Read for the same reason the station registry's counterpart is: a
-        centre nobody could ask is not a centre that declares nothing, and the
-        two states have to be told apart wherever what a centre publishes is
-        reported (ADR-0005).
+        Read before the centre is asked, and by nothing else yet -- which is
+        the narrower half of what its station counterpart does. The surfaces
+        reporting on a centre's datasets do not yet tell a centre that
+        answered and declared nothing from one nothing could ask, the
+        distinction ADR-0005 drew for stations; when one of them comes to, this
+        is the fact it reads rather than a second reading of an empty URL.
         """
         return bool(self.discovery_metadata_url)
 

--- a/wis2watch/src/wis2watch/core/models.py
+++ b/wis2watch/src/wis2watch/core/models.py
@@ -101,6 +101,16 @@ class WIS2NodeQuerySet(models.QuerySet):
         """
         return self.filter(stations_url="")
 
+    def advertising_discovery_metadata(self):
+        """The centres there is somewhere to ask what datasets they declare.
+
+        A different endpoint from the station registry and asked apart from
+        it, because the two fail independently: a centre serving its records
+        may serve no station registry at all, and either address may be the
+        one that has gone.
+        """
+        return self.exclude(discovery_metadata_url="")
+
 
 class WIS2Node(TimeStampedModel):
     """
@@ -238,6 +248,17 @@ class WIS2Node(TimeStampedModel):
         centre, when what is true is that nobody asked it.
         """
         return bool(self.stations_url)
+
+    @property
+    def advertises_discovery_metadata(self):
+        """Whether there is anywhere to ask this centre what datasets it declares.
+
+        Read for the same reason the station registry's counterpart is: a
+        centre nobody could ask is not a centre that declares nothing, and the
+        two states have to be told apart wherever what a centre publishes is
+        reported (ADR-0005).
+        """
+        return bool(self.discovery_metadata_url)
 
     @property
     def country_center_point(self):

--- a/wis2watch/src/wis2watch/core/node_datasets.py
+++ b/wis2watch/src/wis2watch/core/node_datasets.py
@@ -1,0 +1,222 @@
+"""Dataset synchronisation from a centre's own discovery metadata.
+
+What a centre says it publishes is one of the pictures this tool compares --
+the others being what a Global Discovery Catalogue registered on its behalf and
+what its traffic is actually carrying. The three routinely disagree, and the
+catalogue is the one that is measurably wrong: it is a copy of what a centre
+once registered, and a centre that has since added, renamed or dropped a
+dataset is described by nobody until it is asked directly.
+
+So every centre is asked for its own records. A wis2box serves them as the
+identical WCMP2 feature a catalogue serves -- same properties, same links --
+which is why nothing here reads a record: :mod:`wis2watch.core.interpretation`
+already does, unchanged.
+
+The rules are :mod:`wis2watch.core.node_stations`', which holds the same shape
+for stations:
+
+- **Declaring is not owning.** The canonical dataset is keyed on the centre and
+  the identifier and shared with the catalogue, so a centre's own record is
+  written down as a declaration beside it rather than as the dataset itself.
+- **Fill, do not overwrite.** A centre fills in what nothing else has recorded
+  and leaves alone what another source already wrote, so an hourly run cannot
+  undo a six-hourly one. What the centre said is kept whole on its declaration,
+  which is what a divergence report reads.
+
+Two things are deliberately not written here. The centre's **own broker and
+address** are advertised on these records as they are on a catalogue's, and are
+the catalogue sync's to apply: which address a centre is asked at has rules of
+its own about whose correction may be taken back (ADR-0007), and a second
+writer for them would be a second opinion on the same field. And **which
+records a centre has stopped serving** is not concluded from a run: a centre
+that answered with less than last time may be mid-rebuild, and five of the
+region's thirty-two nodes were unreachable in one sweep. Silence is a caveat
+to state, never a deletion.
+
+Reading a response is the interpretation seam's job. What is here is the
+writing -- and the page fetch, which is an argument to the sync so that the
+rules above are testable without the network.
+"""
+
+import logging
+
+from django.db import transaction
+
+from .dataset_sources import record_declaration
+from .interpretation import extract_discovery_records
+from .models import Dataset, DatasetSource, SyncLog
+from .sync import CREATED, UPDATED, SteppedOver, SyncCounts, fetch_pages
+
+logger = logging.getLogger(__name__)
+
+#: Records requested per page. A centre serves a handful; the region's largest
+#: publisher serves a few dozen.
+PAGE_SIZE = 500
+
+#: How long a node is given to answer. Shorter than a catalogue's, because
+#: there are as many of these as there are centres and several never answer.
+FETCH_TIMEOUT = 30
+
+
+def fetch_node_discovery_pages(node):
+    """Every page of a centre's own discovery metadata, exactly as returned.
+
+    The response format is whatever the stored endpoint asks for -- the URL a
+    wis2box node advertises names it already -- so a page size is all that is
+    added here.
+
+    Asked once, unlike a catalogue, for the reason the station registry is:
+    this runs hourly against every centre that advertises an address, a large
+    share of them at hosts that never answer or that hang until the timeout.
+    The schedule is already the retry, and asking each of them three times an
+    hour would spend the difference on the centres least likely to be there.
+    """
+    return fetch_pages(
+        node.discovery_metadata_url,
+        params={"limit": PAGE_SIZE},
+        verify=node.verify_ssl,
+        timeout=FETCH_TIMEOUT,
+        read_from=node.centre_id,
+        attempts=1,
+    )
+
+
+def _fill_canonical_record(dataset, declared):
+    """Fill in what nothing else has recorded about the dataset.
+
+    A centre is the better authority on what it publishes, and this still
+    fills rather than overwrites. The two sources are compared by a report
+    that reads both declarations whole, and a canonical record rewritten
+    hourly would leave that report comparing the centre with itself -- the
+    disagreement erased by the very sync that found it.
+    """
+    filled = {
+        field: value
+        for field, value in _declared_fields(declared).items()
+        if value and not getattr(dataset, field)
+    }
+
+    if not filled:
+        return
+
+    for field, value in filled.items():
+        setattr(dataset, field, value)
+
+    dataset.save(update_fields=[*filled, "modified"])
+
+
+def _declared_fields(declared):
+    """What a centre's record says, under the canonical record's own names.
+
+    ``last_synced`` is not among them and is not written at all. It is when
+    the catalogue last confirmed the record -- what a backfilled catalogue
+    declaration is dated from -- and a centre stamping it would have this sync
+    reporting the catalogue as current every hour on records the catalogue may
+    not have carried for months. When the centre itself last said so is on the
+    centre's own declaration, which is where a reader compares the two.
+    """
+    return {
+        "title": declared.title,
+        "wmo_data_policy": declared.data_policy,
+        "wmo_topic_hierarchy": declared.topic,
+        "self_link": declared.canonical_link,
+        "raw_json": declared.raw,
+        "metadata_created": declared.metadata_created,
+        "metadata_updated": declared.metadata_updated,
+    }
+
+
+def apply_declared_dataset(node, declared):
+    """Record that this centre declares a dataset, reporting what happened.
+
+    Each record is applied in its own savepoint, so one the database refuses --
+    an identifier longer than the column, say -- is counted and stepped over
+    rather than losing the rest of the run.
+
+    What is counted is the declaration rather than the dataset: a dataset the
+    catalogue already created is still news about this centre, and it is the
+    centre this run is a report on.
+    """
+    try:
+        with transaction.atomic():
+            dataset, created = Dataset.objects.get_or_create(
+                node=node,
+                identifier=declared.identifier,
+                defaults=_declared_fields(declared),
+            )
+
+            if not created:
+                _fill_canonical_record(dataset, declared)
+
+            _, declaration_created = record_declaration(
+                dataset,
+                DatasetSource.NODE,
+                raw=declared.raw,
+            )
+
+            return CREATED if declaration_created else UPDATED
+    except Exception as exc:
+        logger.warning(
+            "Could not apply dataset %s declared by %s: %s",
+            declared.identifier,
+            node.centre_id,
+            exc,
+        )
+
+        return SteppedOver(item=declared.identifier, reason=str(exc))
+
+
+def sync_node_datasets(node, fetch=None):
+    """Sync one centre's own discovery metadata, returning the run's ``SyncLog``.
+
+    A centre advertising no address returns None and is not logged: no run was
+    attempted, and an hourly failed log for every centre whose base URL nobody
+    has filled in would bury the centres that really did fail.
+
+    A record naming another centre is not this centre's declaration and is
+    passed over uncounted, the way a catalogue's records for centres outside
+    the region are. Datasets are keyed on the centre that publishes them, and
+    filing another centre's record under whichever node happened to serve it
+    would invent a publisher.
+
+    ``fetch`` is how the records are read, defaulting to the network.
+    """
+    if not node.advertises_discovery_metadata:
+        logger.debug("%s advertises no discovery metadata", node.centre_id)
+
+        return None
+
+    fetch = fetch or fetch_node_discovery_pages
+
+    sync_log = SyncLog.objects.create(
+        node=node,
+        sync_type=SyncLog.DISCOVERY_METADATA,
+        status=SyncLog.FAILED,
+    )
+
+    counts = SyncCounts()
+
+    try:
+        for payload in fetch(node):
+            for record in extract_discovery_records(payload):
+                if record.node.centre_id != node.centre_id:
+                    logger.debug(
+                        "%s serves a record belonging to %s",
+                        node.centre_id,
+                        record.node.centre_id,
+                    )
+
+                    continue
+
+                counts.found += 1
+                counts.record(apply_declared_dataset(node, record.dataset))
+    except Exception as exc:
+        logger.error("Discovery metadata sync failed for %s: %s", node.centre_id, exc)
+
+        return counts.close(sync_log, SyncLog.FAILED, str(exc))
+
+    counts.close(sync_log, counts.status)
+
+    logger.info("Discovery metadata sync for %s: %s", node.centre_id, sync_log.summary)
+
+    return sync_log

--- a/wis2watch/src/wis2watch/core/node_datasets.py
+++ b/wis2watch/src/wis2watch/core/node_datasets.py
@@ -45,7 +45,14 @@ from django.db import transaction
 from .dataset_sources import record_declaration
 from .interpretation import extract_discovery_records
 from .models import Dataset, DatasetSource, SyncLog
-from .sync import CREATED, UPDATED, SteppedOver, SyncCounts, fetch_pages
+from .sync import (
+    CREATED,
+    UPDATED,
+    SteppedOver,
+    SyncCounts,
+    declared_dataset_fields,
+    fetch_pages,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -89,10 +96,18 @@ def _fill_canonical_record(dataset, declared):
     that reads both declarations whole, and a canonical record rewritten
     hourly would leave that report comparing the centre with itself -- the
     disagreement erased by the very sync that found it.
+
+    What is filled is what a centre's record says. ``last_synced`` is not
+    among it and is never written here: it is when the *catalogue* last
+    confirmed the record, which is what a backfilled catalogue declaration is
+    dated from, and a centre stamping it would have this sync reporting the
+    catalogue as current every hour on records the catalogue may not have
+    carried for months. When the centre itself last said so is on the centre's
+    own declaration, which is where a reader compares the two.
     """
     filled = {
         field: value
-        for field, value in _declared_fields(declared).items()
+        for field, value in declared_dataset_fields(declared).items()
         if value and not getattr(dataset, field)
     }
 
@@ -103,27 +118,6 @@ def _fill_canonical_record(dataset, declared):
         setattr(dataset, field, value)
 
     dataset.save(update_fields=[*filled, "modified"])
-
-
-def _declared_fields(declared):
-    """What a centre's record says, under the canonical record's own names.
-
-    ``last_synced`` is not among them and is not written at all. It is when
-    the catalogue last confirmed the record -- what a backfilled catalogue
-    declaration is dated from -- and a centre stamping it would have this sync
-    reporting the catalogue as current every hour on records the catalogue may
-    not have carried for months. When the centre itself last said so is on the
-    centre's own declaration, which is where a reader compares the two.
-    """
-    return {
-        "title": declared.title,
-        "wmo_data_policy": declared.data_policy,
-        "wmo_topic_hierarchy": declared.topic,
-        "self_link": declared.canonical_link,
-        "raw_json": declared.raw,
-        "metadata_created": declared.metadata_created,
-        "metadata_updated": declared.metadata_updated,
-    }
 
 
 def apply_declared_dataset(node, declared):
@@ -142,7 +136,7 @@ def apply_declared_dataset(node, declared):
             dataset, created = Dataset.objects.get_or_create(
                 node=node,
                 identifier=declared.identifier,
-                defaults=_declared_fields(declared),
+                defaults=declared_dataset_fields(declared),
             )
 
             if not created:

--- a/wis2watch/src/wis2watch/core/sync.py
+++ b/wis2watch/src/wis2watch/core/sync.py
@@ -1,9 +1,9 @@
 """What every synchronisation run does the same way.
 
 Every sync WIS2Watch runs -- the registry from a Global Discovery Catalogue,
-the stations a node's own registry declares -- reads an OGC API Features
-collection page by page and writes what it can. Two things are therefore said
-once, here, rather than once per sync:
+the datasets and stations a centre's own endpoints declare -- reads an OGC API
+Features collection page by page and writes what it can. Four things are
+therefore said once, here, rather than once per sync:
 
 - **How a collection is read.** Page after page, following the server's own
   ``next`` link while it advances, resuming from an offset of our own where it
@@ -18,6 +18,10 @@ once, here, rather than once per sync:
 - **Where a source places a station.** Every source that declares a station
   gives it a latitude, a longitude and sometimes an elevation, and the canonical
   location is one three-dimensional point whichever source supplied it.
+- **What a source says about a dataset.** A catalogue's record and a centre's
+  own are the same WCMP2 feature, so what either of them contributes to the
+  canonical dataset is one mapping rather than one per sync -- two copies of
+  it would drift, and the drift would read as the two sources disagreeing.
 
 What differs between the syncs -- which URL, which credentials, how long to
 wait -- stays with the sync that knows it.
@@ -323,6 +327,33 @@ def declared_position(declared):
         declared.elevation if declared.elevation is not None else 0,
         srid=4326,
     )
+
+
+def declared_dataset_fields(declared):
+    """What a source says about a dataset, under the canonical record's names.
+
+    Written once because two sources describe a dataset in the identical WCMP2
+    feature -- a catalogue's copy of what a centre registered, and the centre's
+    own records -- so the mapping onto the canonical row is the same mapping.
+    Kept apart from either sync, in the way a station's declared position is,
+    because two copies of it would drift and the drift would show up as the
+    two sources disagreeing about a dataset neither had read differently.
+
+    What each sync does with these is its own: the catalogue writes them over
+    the record it owns, and a centre fills in only what nothing else has. The
+    fields no source supplies -- ``last_synced``, ``status`` -- are named by
+    the sync that has something to say about them, and are deliberately not
+    here.
+    """
+    return {
+        "title": declared.title,
+        "wmo_data_policy": declared.data_policy,
+        "wmo_topic_hierarchy": declared.topic,
+        "self_link": declared.canonical_link,
+        "raw_json": declared.raw,
+        "metadata_created": declared.metadata_created,
+        "metadata_updated": declared.metadata_updated,
+    }
 
 
 @dataclass(frozen=True)

--- a/wis2watch/src/wis2watch/core/tasks.py
+++ b/wis2watch/src/wis2watch/core/tasks.py
@@ -12,6 +12,7 @@ from .cadence import learn_cadence_baselines, learn_station_activity_baselines
 from .catalogue import sync_catalogues
 from .daily_rollups import update_daily_rollups
 from .digest import send_digest
+from .node_datasets import sync_node_datasets
 from .node_stations import sync_node_stations
 from .oscar import sync_oscar_stations
 from .probes import nodes_advertising_links, probe_node_links, probed_hour
@@ -97,6 +98,56 @@ def run_sync_all_node_stations():
 
     for node_id in node_ids:
         run_sync_node_stations.delay(node_id)
+
+    return node_ids
+
+
+@shared_task
+def run_sync_node_datasets(node_id):
+    """Ask one centre what datasets it declares.
+
+    Failures are diagnostic state rather than task failures: a centre that
+    cannot be reached is recorded on its own sync log, and the next scheduled
+    run asks again. Retrying here would only duplicate the schedule.
+    """
+    from .models import WIS2Node
+
+    sync_log = sync_node_datasets(WIS2Node.objects.get(id=node_id))
+
+    if sync_log is None:
+        return None
+
+    logger.info(
+        "[DISCOVERY METADATA SYNC] %s: %s", sync_log.node.centre_id, sync_log.summary
+    )
+
+    return sync_log.id
+
+
+@shared_task
+def run_sync_all_node_datasets():
+    """Ask every centre for its own records, so a new one needs no manual trigger.
+
+    One task per centre rather than one run over all of them, for the reason
+    the station fan-out gives: each is an HTTP fetch against a different
+    centre, several of the region's are slow or unreachable from outside, and
+    fanning out keeps one of those from holding up the rest of the region.
+
+    Queued apart from the station registry even though both read the same
+    host. The two endpoints fail independently -- a centre serving its records
+    may serve no station registry at all -- and each run has to be able to
+    state its own bound.
+    """
+    from .models import WIS2Node
+
+    node_ids = list(
+        WIS2Node.objects.advertising_discovery_metadata().values_list("id", flat=True)
+    )
+
+    logger.info("[DISCOVERY METADATA SYNC] queueing %s nodes", len(node_ids))
+
+    for node_id in node_ids:
+        run_sync_node_datasets.delay(node_id)
 
     return node_ids
 

--- a/wis2watch/src/wis2watch/core/tests/fixtures/README.md
+++ b/wis2watch/src/wis2watch/core/tests/fixtures/README.md
@@ -8,7 +8,8 @@ suggest.
 The first three were captured on **2026-08-11**, the node station registry on
 **2026-08-12**, and the two node message archives on **2026-08-13**.
 
-The CMA paging capture is later, on **2026-08-31**.
+The CMA paging capture and South Africa's own discovery metadata are later,
+both on **2026-08-31**.
 
 ## `global_broker_notifications.jsonl`
 
@@ -104,6 +105,33 @@ A registry longer than the page size links to its next page under `rel: next`,
 the same as a Global Discovery Catalogue does; this capture fits on one page
 and so carries no such link. The default page size of a station endpoint is
 routinely ten, which is why the fetch asks for more.
+
+## `node_discovery_metadata_za_weathersa.json`
+
+South Africa's own discovery metadata
+(`https://wis.weathersa.co.za/oapi/collections/discovery-metadata/items`),
+which is what a wis2box node publishes about the datasets it operates. The
+page is unedited, exactly as the node returned it at `limit=500` — envelope,
+links and all: three records, `numberMatched` and `numberReturned` both 3, and
+no `rel: next` link, because the whole collection fits on one page. A centre
+serving more than a page of records links its next one the same way a
+catalogue does.
+
+**The records are the same WCMP2 features a Global Discovery Catalogue
+serves** — same properties, same links, `wmo:topicHierarchy` and
+`wmo:dataPolicy` and a `canonical` link on the centre's own host — which is
+why the node sync reads them with the catalogue's own extraction and adds no
+parser of its own. The one difference is the notification link: a catalogue
+appends one per Global Broker, and a node advertises only its own
+(`mqtts://…@wis.weathersa.co.za:8883`), so every record here carries an origin
+broker.
+
+Captured for the disagreement it holds. At capture the Canadian GDC carried
+two of these three records; `urn:wmo:md:za-weathersa:xoeh2t` was served by the
+centre and by no catalogue, which is the finding the per-node sync exists to
+make. The three also cover both data policies (`core` and `recommended`), a
+record carrying a `license` link and one carrying no `collection` link, and
+two records that differ only in policy and topic while sharing a title.
 
 ## `node_messages_sc_seychelles_met.json` and `node_messages_gh_gmet.json`
 

--- a/wis2watch/src/wis2watch/core/tests/fixtures/node_discovery_metadata_za_weathersa.json
+++ b/wis2watch/src/wis2watch/core/tests/fixtures/node_discovery_metadata_za_weathersa.json
@@ -1,0 +1,606 @@
+{
+ "type": "FeatureCollection",
+ "features": [
+  {
+   "id": "urn:wmo:md:za-weathersa:xoeh2t",
+   "conformsTo": [
+    "http://wis.wmo.int/spec/wcmp/2/conf/core"
+   ],
+   "type": "Feature",
+   "wis2box": {
+    "topic_hierarchy": "za-weathersa.data.core.weather.surface-based-observations.synop",
+    "centre_id": "za-weathersa",
+    "data_mappings": {
+     "plugins": {
+      "bin": [
+       {
+        "plugin": "wis2box.data.bufr4.ObservationDataBUFR",
+        "notify": true,
+        "buckets": [
+         "wis2box-incoming"
+        ],
+        "file-pattern": "^.*\\.bin$"
+       }
+      ],
+      "txt": [
+       {
+        "plugin": "wis2box.data.synop2bufr.ObservationDataSYNOP2BUFR",
+        "notify": true,
+        "file-pattern": "^.*_(\\d{4})(\\d{2}).*.txt$"
+       }
+      ],
+      "b": [
+       {
+        "plugin": "wis2box.data.bufr4.ObservationDataBUFR",
+        "notify": true,
+        "buckets": [
+         "wis2box-incoming"
+        ],
+        "file-pattern": "^.*\\.b$"
+       }
+      ],
+      "csv": [
+       {
+        "plugin": "wis2box.data.csv2bufr.ObservationDataCSV2BUFR",
+        "template": "aws-template",
+        "notify": true,
+        "buckets": [
+         "wis2box-incoming"
+        ],
+        "file-pattern": "^.*\\.csv$"
+       }
+      ],
+      "bufr4": [
+       {
+        "plugin": "wis2box.data.bufr2geojson.ObservationDataBUFR2GeoJSON",
+        "buckets": [
+         "wis2box-public"
+        ],
+        "file-pattern": "^WIGOS_(\\d-\\d+-\\d+-\\w+)_.*\\.bufr4$"
+       }
+      ]
+     }
+    }
+   },
+   "time": {
+    "interval": [
+     "2025-03-13",
+     ".."
+    ],
+    "resolution": "PT1H"
+   },
+   "geometry": {
+    "type": "Polygon",
+    "coordinates": [
+     [
+      [
+       12.3449768408952,
+       -18.0913127580676
+      ],
+      [
+       35.8301204770289,
+       -18.0913127580676
+      ],
+      [
+       35.8301204770289,
+       -34.8191663551237
+      ],
+      [
+       12.3449768408952,
+       -34.8191663551237
+      ],
+      [
+       12.3449768408952,
+       -18.0913127580676
+      ]
+     ]
+    ]
+   },
+   "properties": {
+    "type": "dataset",
+    "identifier": "urn:wmo:md:za-weathersa:xoeh2t",
+    "title": "Hourly synoptic observations from fixed-land stations (SYNOP) (za-weathersa)",
+    "description": "Hourly synoptic observations",
+    "keywords": [
+     "observations",
+     "temperature",
+     "visibility",
+     "precipitation",
+     "pressure",
+     "clouds",
+     "snow depth",
+     "evaporation",
+     "radiation",
+     "wind",
+     "total sunshine",
+     "humidity"
+    ],
+    "themes": [
+     {
+      "concepts": [
+       {
+        "id": "weather",
+        "title": "Weather"
+       }
+      ],
+      "scheme": "http://codes.wmo.int/wis/topic-hierarchy/earth-system-discipline"
+     }
+    ],
+    "contacts": [
+     {
+      "organization": "South African Weather Service",
+      "emails": [
+       {
+        "value": "rinae.tshibubudze@weathersa.co.za"
+       }
+      ],
+      "addresses": [
+       {
+        "country": "ZAF"
+       }
+      ],
+      "links": [
+       {
+        "rel": "about",
+        "href": "https://www.weathersa.co.za",
+        "type": "text/html"
+       }
+      ],
+      "roles": [
+       "host"
+      ]
+     }
+    ],
+    "created": "2025-03-13T15:59:07Z",
+    "updated": "2025-03-13T15:59:07Z",
+    "wmo:dataPolicy": "core",
+    "wmo:topicHierarchy": "origin/a/wis2/za-weathersa/data/core/weather/surface-based-observations/synop",
+    "id": "urn:wmo:md:za-weathersa:xoeh2t"
+   },
+   "links": [
+    {
+     "href": "https://wis.weathersa.co.za/oapi/collections/urn:wmo:md:za-weathersa:xoeh2t/items?sortby=-reportTime",
+     "type": "application/json",
+     "name": "urn:wmo:md:za-weathersa:xoeh2t",
+     "rel": "collection",
+     "title": "Observations in json format for urn:wmo:md:za-weathersa:xoeh2t"
+    },
+    {
+     "href": "mqtts://everyone:everyone@wis.weathersa.co.za:8883",
+     "type": "application/json",
+     "name": "origin/a/wis2/za-weathersa/data/core/weather/surface-based-observations/synop",
+     "rel": "items",
+     "channel": "origin/a/wis2/za-weathersa/data/core/weather/surface-based-observations/synop",
+     "filters": {
+      "wigos_station_identifier": {
+       "type": "string",
+       "title": "WIGOS Station Identifier",
+       "description": "Filter by WIGOS Station Identifier"
+      }
+     },
+     "title": "Notifications"
+    },
+    {
+     "href": "https://wis.weathersa.co.za/data/metadata/urn:wmo:md:za-weathersa:xoeh2t.json",
+     "type": "application/geo+json",
+     "name": "urn:wmo:md:za-weathersa:xoeh2t",
+     "rel": "canonical",
+     "title": "urn:wmo:md:za-weathersa:xoeh2t"
+    }
+   ]
+  },
+  {
+   "id": "urn:wmo:md:za-weathersa:jwtdpd",
+   "conformsTo": [
+    "http://wis.wmo.int/spec/wcmp/2/conf/core"
+   ],
+   "type": "Feature",
+   "wis2box": {
+    "topic_hierarchy": "za-weathersa.data.core.weather.surface-based-observations.temp",
+    "centre_id": "za-weathersa",
+    "data_mappings": {
+     "plugins": {
+      "b": [
+       {
+        "plugin": "wis2box.data.bufr4.ObservationDataBUFR",
+        "notify": true,
+        "buckets": [
+         "wis2box-incoming"
+        ],
+        "file-pattern": "^.*\\.b$"
+       }
+      ],
+      "bin": [
+       {
+        "plugin": "wis2box.data.bufr4.ObservationDataBUFR",
+        "notify": true,
+        "buckets": [
+         "wis2box-incoming"
+        ],
+        "file-pattern": "^.*\\.bin$"
+       }
+      ],
+      "bufr": [
+       {
+        "plugin": "wis2box.data.bufr4.ObservationDataBUFR",
+        "notify": true,
+        "buckets": [
+         "wis2box-incoming"
+        ],
+        "file-pattern": "^.*\\.bufr$"
+       }
+      ]
+     }
+    }
+   },
+   "time": {
+    "interval": [
+     "2025-03-20",
+     ".."
+    ],
+    "resolution": "PT12H"
+   },
+   "geometry": {
+    "type": "Polygon",
+    "coordinates": [
+     [
+      [
+       -17.6550231591048,
+       -22.091312758067588
+      ],
+      [
+       54.8301204770289,
+       -22.091312758067588
+      ],
+      [
+       54.8301204770289,
+       -44.8191663551237
+      ],
+      [
+       -17.6550231591048,
+       -44.8191663551237
+      ],
+      [
+       -17.6550231591048,
+       -22.091312758067588
+      ]
+     ]
+    ]
+   },
+   "properties": {
+    "type": "dataset",
+    "identifier": "urn:wmo:md:za-weathersa:jwtdpd",
+    "title": "Upper-level temperature/humidity/wind reports from fixed-land stations (TEMP) (za-weathersa)",
+    "description": "Upper-level temperature",
+    "keywords": [
+     "observations",
+     "upper air",
+     "humidity",
+     "wind",
+     "observations",
+     "temperature",
+     "dewpoint",
+     "clouds",
+     "pressure",
+     "atmospheric profile"
+    ],
+    "themes": [
+     {
+      "concepts": [
+       {
+        "id": "weather",
+        "title": "Weather"
+       }
+      ],
+      "scheme": "http://codes.wmo.int/wis/topic-hierarchy/earth-system-discipline"
+     }
+    ],
+    "contacts": [
+     {
+      "organization": "South African Weather Service",
+      "emails": [
+       {
+        "value": "christa.ferreira@weathersa.co.za"
+       }
+      ],
+      "addresses": [
+       {
+        "country": "ZAF"
+       }
+      ],
+      "links": [
+       {
+        "rel": "about",
+        "href": "https://weathersa.co.za",
+        "type": "text/html"
+       }
+      ],
+      "roles": [
+       "host"
+      ]
+     }
+    ],
+    "created": "2025-03-20T12:13:00Z",
+    "updated": "2025-03-20T12:13:00Z",
+    "wmo:dataPolicy": "core",
+    "wmo:topicHierarchy": "origin/a/wis2/za-weathersa/data/core/weather/surface-based-observations/temp",
+    "id": "urn:wmo:md:za-weathersa:jwtdpd"
+   },
+   "links": [
+    {
+     "href": "mqtts://everyone:everyone@wis.weathersa.co.za:8883",
+     "type": "application/json",
+     "name": "origin/a/wis2/za-weathersa/data/core/weather/surface-based-observations/temp",
+     "rel": "items",
+     "channel": "origin/a/wis2/za-weathersa/data/core/weather/surface-based-observations/temp",
+     "filters": {
+      "wigos_station_identifier": {
+       "type": "string",
+       "title": "WIGOS Station Identifier",
+       "description": "Filter by WIGOS Station Identifier"
+      }
+     },
+     "title": "Notifications"
+    },
+    {
+     "href": "https://wis.weathersa.co.za/data/metadata/urn:wmo:md:za-weathersa:jwtdpd.json",
+     "type": "application/geo+json",
+     "name": "urn:wmo:md:za-weathersa:jwtdpd",
+     "rel": "canonical",
+     "title": "urn:wmo:md:za-weathersa:jwtdpd"
+    }
+   ]
+  },
+  {
+   "id": "urn:wmo:md:za-weathersa:76h87o",
+   "conformsTo": [
+    "http://wis.wmo.int/spec/wcmp/2/conf/core"
+   ],
+   "type": "Feature",
+   "wis2box": {
+    "data_mappings": {
+     "plugins": {
+      "bin": [
+       {
+        "plugin": "wis2box.data.bufr4.ObservationDataBUFR",
+        "notify": true,
+        "buckets": [
+         "wis2box-incoming"
+        ],
+        "file-pattern": "^.*\\.bin$"
+       }
+      ],
+      "txt": [
+       {
+        "plugin": "wis2box.data.synop2bufr.ObservationDataSYNOP2BUFR",
+        "notify": true,
+        "buckets": [
+         "wis2box-incoming"
+        ],
+        "file-pattern": "^.*_(\\d{4})(\\d{2}).*.txt$"
+       }
+      ],
+      "b": [
+       {
+        "plugin": "wis2box.data.bufr4.ObservationDataBUFR",
+        "notify": true,
+        "buckets": [
+         "wis2box-incoming"
+        ],
+        "file-pattern": "^.*\\.b$"
+       }
+      ],
+      "csv": [
+       {
+        "plugin": "wis2box.data.csv2bufr.ObservationDataCSV2BUFR",
+        "template": "aws-template",
+        "notify": true,
+        "buckets": [
+         "wis2box-incoming"
+        ],
+        "file-pattern": "^.*\\.csv$"
+       }
+      ],
+      "bufr4": [
+       {
+        "plugin": "wis2box.data.bufr2geojson.ObservationDataBUFR2GeoJSON",
+        "buckets": [
+         "wis2box-public"
+        ],
+        "file-pattern": "^WIGOS_(\\d-\\d+-\\d+-\\w+)_.*\\.bufr4$"
+       }
+      ],
+      "grib2": [
+       {
+        "plugin": "wis2box.data.universal.UniversalData",
+        "template": null,
+        "notify": true,
+        "buckets": [
+         "wis2box-incoming"
+        ],
+        "file-pattern": "^.*?_(\\d{8}).*?\\..*$"
+       }
+      ]
+     }
+    },
+    "centre_id": "za-weathersa",
+    "topic_hierarchy": "za-weathersa.data.recommended.weather.surface-based-observations.synop"
+   },
+   "time": {
+    "interval": [
+     "2026-04-13",
+     ".."
+    ],
+    "resolution": "PT1H"
+   },
+   "geometry": {
+    "type": "Polygon",
+    "coordinates": [
+     [
+      [
+       16.344976840895242,
+       -22.091312758067588
+      ],
+      [
+       32.830120477028885,
+       -22.091312758067588
+      ],
+      [
+       32.830120477028885,
+       -34.81916635512371
+      ],
+      [
+       16.344976840895242,
+       -34.81916635512371
+      ],
+      [
+       16.344976840895242,
+       -22.091312758067588
+      ]
+     ]
+    ]
+   },
+   "properties": {
+    "type": "dataset",
+    "identifier": "urn:wmo:md:za-weathersa:76h87o",
+    "title": "Hourly synoptic observations from fixed-land stations (SYNOP) (za-weathersa)",
+    "description": "Aviation Recommeded Data",
+    "keywords": [
+     "observations",
+     "temperature",
+     "visibility",
+     "precipitation",
+     "pressure",
+     "clouds",
+     "snow depth",
+     "evaporation",
+     "radiation",
+     "wind",
+     "total sunshine",
+     "humidity"
+    ],
+    "themes": [
+     {
+      "concepts": [
+       {
+        "id": "weather",
+        "title": "Weather"
+       },
+       {
+        "id": "atmospheric-composition",
+        "title": "Atmospheric Composition"
+       },
+       {
+        "id": "space-weather",
+        "title": "Space Weather"
+       }
+      ],
+      "scheme": "http://codes.wmo.int/wis/topic-hierarchy/earth-system-discipline"
+     }
+    ],
+    "contacts": [
+     {
+      "organization": "South African Weather Service",
+      "emails": [
+       {
+        "value": "rinae.tshibubudze@weathersa.co.za"
+       }
+      ],
+      "addresses": [
+       {
+        "country": "ZAF"
+       }
+      ],
+      "links": [
+       {
+        "rel": "about",
+        "href": "https://weathersa.co.za",
+        "type": "text/html"
+       }
+      ],
+      "roles": [
+       "host"
+      ]
+     }
+    ],
+    "created": "2026-04-13T18:35:48Z",
+    "updated": "2026-04-13T18:35:48Z",
+    "wmo:dataPolicy": "recommended",
+    "wmo:topicHierarchy": "origin/a/wis2/za-weathersa/data/recommended/weather/surface-based-observations/synop",
+    "id": "urn:wmo:md:za-weathersa:76h87o"
+   },
+   "links": [
+    {
+     "rel": "license",
+     "href": "https://wis.weathersa.co.za/data/license.txt",
+     "title": "License for this dataset",
+     "type": "text/html"
+    },
+    {
+     "href": "https://wis.weathersa.co.za/oapi/collections/urn:wmo:md:za-weathersa:76h87o/items?sortby=-reportTime",
+     "type": "application/json",
+     "name": "urn:wmo:md:za-weathersa:76h87o",
+     "rel": "collection",
+     "title": "Observations in json format for urn:wmo:md:za-weathersa:76h87o"
+    },
+    {
+     "href": "mqtts://everyone:everyone@wis.weathersa.co.za:8883",
+     "type": "application/json",
+     "name": "origin/a/wis2/za-weathersa/data/recommended/weather/surface-based-observations/synop",
+     "rel": "items",
+     "channel": "origin/a/wis2/za-weathersa/data/recommended/weather/surface-based-observations/synop",
+     "filters": {
+      "wigos_station_identifier": {
+       "type": "string",
+       "title": "WIGOS Station Identifier",
+       "description": "Filter by WIGOS Station Identifier"
+      }
+     },
+     "title": "Notifications"
+    },
+    {
+     "href": "https://wis.weathersa.co.za/data/metadata/urn:wmo:md:za-weathersa:76h87o.json",
+     "type": "application/geo+json",
+     "name": "urn:wmo:md:za-weathersa:76h87o",
+     "rel": "canonical",
+     "title": "urn:wmo:md:za-weathersa:76h87o"
+    }
+   ]
+  }
+ ],
+ "numberMatched": 3,
+ "numberReturned": 3,
+ "links": [
+  {
+   "type": "application/geo+json",
+   "rel": "self",
+   "title": "This document as GeoJSON",
+   "href": "https://wis.weathersa.co.za/oapi/collections/discovery-metadata/items?f=json&limit=500"
+  },
+  {
+   "rel": "alternate",
+   "type": "application/ld+json",
+   "title": "This document as RDF (JSON-LD)",
+   "href": "https://wis.weathersa.co.za/oapi/collections/discovery-metadata/items?f=jsonld&limit=500"
+  },
+  {
+   "type": "text/html",
+   "rel": "alternate",
+   "title": "This document as HTML",
+   "href": "https://wis.weathersa.co.za/oapi/collections/discovery-metadata/items?f=html&limit=500"
+  },
+  {
+   "type": "text/csv; charset=utf-8",
+   "rel": "alternate",
+   "title": "This document as CSV",
+   "href": "https://wis.weathersa.co.za/oapi/collections/discovery-metadata/items?f=csv&limit=500"
+  },
+  {
+   "type": "application/json",
+   "title": "Discovery metadata",
+   "rel": "collection",
+   "href": "https://wis.weathersa.co.za/oapi/collections/discovery-metadata"
+  }
+ ],
+ "timeStamp": "2026-08-31T13:46:09.729342Z"
+}

--- a/wis2watch/src/wis2watch/core/tests/test_admin.py
+++ b/wis2watch/src/wis2watch/core/tests/test_admin.py
@@ -1086,6 +1086,7 @@ class NodeDetailViewTests(TestCase):
         return response, patched
 
     def synced(self, sync_type, status=SyncLog.SUCCESS, error=""):
+        """A run of one kind, as the sync that stood in for it would return it."""
         return SyncLog(
             node=self.node, sync_type=sync_type, status=status, error_message=error
         )
@@ -1121,7 +1122,24 @@ class NodeDetailViewTests(TestCase):
         )
 
         self.assertContains(response, "Station synchronization completed")
+        self.assertContains(response, "Error reading the discovery metadata")
         self.assertContains(response, "connection refused")
+
+    def test_a_failure_says_which_endpoint_it_was(self):
+        """Both down is when this is read, and two identical errors help nobody."""
+        response, _patched = self.sync_by_hand(
+            sync_node_stations=self.synced(
+                SyncLog.NODE_STATIONS, status=SyncLog.FAILED, error="registry refused"
+            ),
+            sync_node_datasets=self.synced(
+                SyncLog.DISCOVERY_METADATA,
+                status=SyncLog.FAILED,
+                error="records refused",
+            ),
+        )
+
+        self.assertContains(response, "Error reading the station registry")
+        self.assertContains(response, "Error reading the discovery metadata")
 
     def test_a_node_that_advertises_no_station_registry_says_so(self):
         self.node.stations_url = ""

--- a/wis2watch/src/wis2watch/core/tests/test_admin.py
+++ b/wis2watch/src/wis2watch/core/tests/test_admin.py
@@ -1,4 +1,5 @@
 import re
+from contextlib import ExitStack
 from datetime import timedelta
 from unittest import mock
 
@@ -1061,32 +1062,88 @@ class NodeDetailViewTests(TestCase):
         self.assertIn("Nairobi JKIA", rows[1])
         self.assertIn("63740", rows[1])
 
-    def test_syncing_a_node_by_hand_asks_it_for_its_stations(self):
-        """Datasets come from the catalogue; a node is asked only for stations."""
-        with mock.patch("wis2watch.core.views.sync_node_stations") as sync:
-            sync.return_value = SyncLog(
-                node=self.node,
-                sync_type=SyncLog.NODE_STATIONS,
-                status=SyncLog.SUCCESS,
-            )
+    def sync_by_hand(self, **stood_in_for):
+        """Post the page's sync, with the named endpoints stood in for.
+
+        Only what a test is not about is patched. What is left runs for real,
+        which for a centre advertising no address is the whole of what is being
+        asserted -- and for one that does advertise it is why every test here
+        patches whatever it is not asking about, an unpatched sync being a
+        fetch against the centre's real host.
+        """
+        with ExitStack() as stack:
+            patched = {
+                name: stack.enter_context(
+                    mock.patch(f"wis2watch.core.views.{name}", return_value=sync_log)
+                )
+                for name, sync_log in stood_in_for.items()
+            }
 
             response = self.client.post(
                 reverse("node_details", args=[self.node.id]), {"node_id": self.node.id}
             )
 
+        return response, patched
+
+    def synced(self, sync_type, status=SyncLog.SUCCESS, error=""):
+        return SyncLog(
+            node=self.node, sync_type=sync_type, status=status, error_message=error
+        )
+
+    def test_syncing_a_node_by_hand_asks_it_for_its_stations(self):
+        response, patched = self.sync_by_hand(
+            sync_node_stations=self.synced(SyncLog.NODE_STATIONS),
+            sync_node_datasets=self.synced(SyncLog.DISCOVERY_METADATA),
+        )
+
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(sync.call_args.args[0], self.node)
+        self.assertEqual(patched["sync_node_stations"].call_args.args[0], self.node)
+
+    def test_syncing_a_node_by_hand_asks_it_what_it_publishes(self):
+        """The catalogue is not the only thing that says what a centre has."""
+        response, patched = self.sync_by_hand(
+            sync_node_stations=self.synced(SyncLog.NODE_STATIONS),
+            sync_node_datasets=self.synced(SyncLog.DISCOVERY_METADATA),
+        )
+
+        self.assertEqual(patched["sync_node_datasets"].call_args.args[0], self.node)
+        self.assertContains(response, "Discovery metadata synchronization completed")
+
+    def test_each_endpoint_is_reported_apart_from_the_other(self):
+        """They fail independently, so one message could not cover both."""
+        response, _patched = self.sync_by_hand(
+            sync_node_stations=self.synced(SyncLog.NODE_STATIONS),
+            sync_node_datasets=self.synced(
+                SyncLog.DISCOVERY_METADATA,
+                status=SyncLog.FAILED,
+                error="connection refused",
+            ),
+        )
+
+        self.assertContains(response, "Station synchronization completed")
+        self.assertContains(response, "connection refused")
 
     def test_a_node_that_advertises_no_station_registry_says_so(self):
         self.node.stations_url = ""
         self.node.node_type = "other"
         self.node.save()
 
-        response = self.client.post(
-            reverse("node_details", args=[self.node.id]), {"node_id": self.node.id}
+        response, _patched = self.sync_by_hand(
+            sync_node_datasets=self.synced(SyncLog.DISCOVERY_METADATA)
         )
 
         self.assertContains(response, "advertises no station registry")
+
+    def test_a_node_that_advertises_no_discovery_metadata_says_so(self):
+        self.node.discovery_metadata_url = ""
+        self.node.node_type = "other"
+        self.node.save()
+
+        response, _patched = self.sync_by_hand(
+            sync_node_stations=self.synced(SyncLog.NODE_STATIONS)
+        )
+
+        self.assertContains(response, "advertises no discovery metadata")
 
     def test_a_centre_nobody_asked_is_not_reported_as_declaring_nothing(self):
         """The page's claim about the centre has to be one it can make."""
@@ -1142,7 +1199,9 @@ class NodeDetailViewTests(TestCase):
         Each view is its own URL, so a POST lands back where it was made
         rather than on whichever view a fragment happened to name.
         """
-        with mock.patch("wis2watch.core.views.sync_node_stations"):
+        with mock.patch("wis2watch.core.views.sync_node_stations"), mock.patch(
+            "wis2watch.core.views.sync_node_datasets"
+        ):
             response = self.client.post(
                 reverse("node_details", args=[self.node.id]), {"node_id": self.node.id}
             )

--- a/wis2watch/src/wis2watch/core/tests/test_node_datasets_sync.py
+++ b/wis2watch/src/wis2watch/core/tests/test_node_datasets_sync.py
@@ -1,0 +1,461 @@
+"""Dataset synchronisation from a node's own discovery metadata.
+
+The sync runs against the committed capture of South Africa's own records
+rather than the network: the page fetch is an argument, so these tests exercise
+the writing rules against the features a node really serves.
+
+What is asserted here is the shape of the two-source dataset picture. A centre
+declaring a dataset is provenance, not identity: the canonical record is keyed
+on the centre and the identifier and shared with the catalogue, while what the
+centre itself said is kept whole on its own declaration.
+
+The capture is also the finding this sync exists for. South Africa serves three
+records and the writing catalogue carries two of them, so
+``urn:wmo:md:za-weathersa:xoeh2t`` is a dataset the centre publishes that no
+catalogue holds.
+"""
+
+from unittest import mock
+
+import requests
+from django.test import TestCase
+from django.utils import timezone as dj_timezone
+
+from wis2watch.core.models import (
+    Dataset,
+    DatasetSource,
+    GlobalDiscoveryCatalogue,
+    SyncLog,
+    WIS2Node,
+)
+from wis2watch.core.node_datasets import (
+    fetch_node_discovery_pages,
+    sync_node_datasets,
+)
+from wis2watch.core.sync import (
+    MAX_PAGES,
+    MAX_REASON_CHARS,
+    MAX_STEPPED_OVER_RECORDED,
+    ReadKeptFailing,
+)
+
+from .support import at, failing_fetch, load_json_fixture, pages
+
+RECORDS = "node_discovery_metadata_za_weathersa.json"
+
+#: Every dataset the capture declares.
+DECLARED = {
+    "urn:wmo:md:za-weathersa:xoeh2t",
+    "urn:wmo:md:za-weathersa:jwtdpd",
+    "urn:wmo:md:za-weathersa:76h87o",
+}
+
+#: The one of them no catalogue carries.
+UNCATALOGUED = "urn:wmo:md:za-weathersa:xoeh2t"
+
+SYNOP_TOPIC = (
+    "origin/a/wis2/za-weathersa/data/core/weather/surface-based-observations/synop"
+)
+
+
+def one_record(identifier=UNCATALOGUED, **properties):
+    """A discovery response declaring a single record."""
+    return {
+        "features": [
+            {
+                "properties": {
+                    "identifier": identifier,
+                    "title": "Hourly synoptic observations (za-weathersa)",
+                    "wmo:dataPolicy": "core",
+                    "wmo:topicHierarchy": SYNOP_TOPIC,
+                    **properties,
+                }
+            }
+        ]
+    }
+
+
+class NodeDatasetsTestCase(TestCase):
+    def setUp(self):
+        self.payload = load_json_fixture(RECORDS)
+        self.node = WIS2Node.objects.create(
+            centre_id="za-weathersa",
+            name="South African Weather Service",
+            base_url="https://wis.weathersa.co.za",
+        )
+
+    def sync(self, *payloads, node=None):
+        return sync_node_datasets(
+            node or self.node, fetch=pages(*(payloads or (self.payload,)))
+        )
+
+    def declaration(self, identifier=UNCATALOGUED):
+        return DatasetSource.objects.get(
+            dataset__identifier=identifier,
+            dataset__node=self.node,
+            source_type=DatasetSource.NODE,
+        )
+
+    def catalogued(self, identifier, **fields):
+        """A dataset as the writing catalogue left it, declared by it."""
+        catalogue, _ = GlobalDiscoveryCatalogue.objects.get_or_create(
+            centre_id="ca-eccc-msc-global-discovery",
+            defaults={
+                "name": "Canadian GDC",
+                "base_url": "https://wis2-gdc.weather.gc.ca",
+                "is_writer": True,
+            },
+        )
+
+        dataset = Dataset.objects.create(
+            node=self.node,
+            identifier=identifier,
+            raw_json={"identifier": identifier},
+            **fields,
+        )
+
+        DatasetSource.objects.create(
+            dataset=dataset,
+            source_type=DatasetSource.GDC,
+            catalogue=catalogue,
+            last_seen=at("2026-08-01T00:00:00"),
+        )
+
+        return dataset
+
+
+class DeclaredDatasetTests(NodeDatasetsTestCase):
+    """What a centre's own metadata declares becomes datasets and provenance."""
+
+    def test_every_declared_record_becomes_a_dataset(self):
+        self.sync()
+
+        self.assertEqual(
+            set(Dataset.objects.values_list("identifier", flat=True)), DECLARED
+        )
+
+    def test_each_dataset_records_that_the_centre_itself_declared_it(self):
+        self.sync()
+
+        self.assertEqual(
+            set(
+                DatasetSource.objects.filter(
+                    source_type=DatasetSource.NODE
+                ).values_list("dataset__identifier", flat=True)
+            ),
+            DECLARED,
+        )
+
+    def test_a_declaration_names_no_catalogue(self):
+        """A centre speaks for itself; there is no catalogue in between."""
+        self.sync()
+
+        self.assertIsNone(self.declaration().catalogue)
+
+    def test_the_declared_record_is_kept_whole(self):
+        self.sync()
+
+        raw = self.declaration().raw_json
+
+        self.assertEqual(raw["properties"]["identifier"], UNCATALOGUED)
+        self.assertEqual(raw["properties"]["wmo:topicHierarchy"], SYNOP_TOPIC)
+
+    def test_a_declaration_records_when_the_centre_last_confirmed_it(self):
+        before = dj_timezone.now()
+
+        self.sync()
+
+        self.assertGreaterEqual(self.declaration().last_seen, before)
+
+    def test_a_dataset_no_catalogue_carries_is_created(self):
+        """The finding this sync exists for, against the capture that shows it."""
+        self.catalogued("urn:wmo:md:za-weathersa:jwtdpd")
+        self.catalogued("urn:wmo:md:za-weathersa:76h87o")
+
+        self.sync()
+
+        dataset = Dataset.objects.get(identifier=UNCATALOGUED)
+
+        self.assertEqual(
+            set(dataset.sources.values_list("source_type", flat=True)),
+            {DatasetSource.NODE},
+        )
+
+    def test_a_dataset_created_here_carries_what_the_centre_said_of_it(self):
+        self.sync()
+
+        dataset = Dataset.objects.get(identifier=UNCATALOGUED)
+
+        self.assertEqual(
+            dataset.title,
+            "Hourly synoptic observations from fixed-land stations (SYNOP) "
+            "(za-weathersa)",
+        )
+        self.assertEqual(dataset.wmo_data_policy, Dataset.CORE)
+        self.assertEqual(dataset.wmo_topic_hierarchy, SYNOP_TOPIC)
+        self.assertEqual(dataset.status, Dataset.ACTIVE)
+        self.assertEqual(
+            dataset.self_link,
+            "https://wis.weathersa.co.za/data/metadata/"
+            "urn:wmo:md:za-weathersa:xoeh2t.json",
+        )
+        self.assertEqual(dataset.metadata_created, at("2025-03-13T15:59:07"))
+
+    def test_a_dataset_the_catalogue_already_describes_is_left_to_it(self):
+        """Declaring is not owning: the centre's own words go on its row."""
+        self.catalogued(
+            UNCATALOGUED,
+            title="A title the catalogue holds",
+            wmo_data_policy=Dataset.RECOMMENDED,
+            wmo_topic_hierarchy="origin/a/wis2/za-weathersa/data/core/other",
+        )
+
+        self.sync()
+
+        dataset = Dataset.objects.get(identifier=UNCATALOGUED)
+
+        self.assertEqual(dataset.title, "A title the catalogue holds")
+        self.assertEqual(dataset.wmo_data_policy, Dataset.RECOMMENDED)
+        self.assertEqual(
+            dataset.wmo_topic_hierarchy, "origin/a/wis2/za-weathersa/data/core/other"
+        )
+        self.assertEqual(
+            self.declaration().raw_json["properties"]["wmo:topicHierarchy"],
+            SYNOP_TOPIC,
+        )
+
+    def test_what_no_other_source_recorded_is_filled_in(self):
+        """A dataset the traffic created is named by nothing until now."""
+        Dataset.objects.create(
+            node=self.node, identifier=UNCATALOGUED, raw_json={}
+        )
+
+        self.sync()
+
+        dataset = Dataset.objects.get(identifier=UNCATALOGUED)
+
+        self.assertEqual(dataset.wmo_topic_hierarchy, SYNOP_TOPIC)
+        self.assertEqual(dataset.wmo_data_policy, Dataset.CORE)
+        self.assertTrue(dataset.title)
+        self.assertEqual(dataset.raw_json["properties"]["identifier"], UNCATALOGUED)
+
+    def test_when_a_catalogue_last_confirmed_a_record_is_not_this_syncs_to_stamp(self):
+        """``last_synced`` is the catalogue's; the centre's timing is its own."""
+        synced = at("2026-08-01T00:00:00")
+        self.catalogued(UNCATALOGUED, last_synced=synced)
+
+        self.sync()
+
+        self.assertEqual(Dataset.objects.get(identifier=UNCATALOGUED).last_synced, synced)
+
+    def test_a_record_naming_another_centre_is_not_this_centres_declaration(self):
+        self.sync(one_record(identifier="urn:wmo:md:ke-meteo:synop"))
+
+        self.assertEqual(Dataset.objects.count(), 0)
+        self.assertEqual(DatasetSource.objects.count(), 0)
+
+    def test_another_centres_datasets_are_not_touched(self):
+        kenya = WIS2Node.objects.create(centre_id="ke-meteo", name="Kenya Met")
+        theirs = Dataset.objects.create(
+            node=kenya, identifier=UNCATALOGUED, raw_json={}
+        )
+
+        self.sync()
+
+        theirs.refresh_from_db()
+
+        self.assertEqual(theirs.raw_json, {})
+        self.assertEqual(Dataset.objects.filter(identifier=UNCATALOGUED).count(), 2)
+
+
+class SyncLogTests(NodeDatasetsTestCase):
+    """Every run is recorded against the centre it asked, whatever became of it."""
+
+    def test_a_run_is_logged_against_the_node(self):
+        sync_log = self.sync()
+
+        self.assertEqual(sync_log.node, self.node)
+        self.assertEqual(sync_log.sync_type, SyncLog.DISCOVERY_METADATA)
+        self.assertEqual(sync_log.status, SyncLog.SUCCESS)
+        self.assertIsNotNone(sync_log.completed_at)
+
+    def test_a_first_run_counts_every_record_as_declared_anew(self):
+        sync_log = self.sync()
+
+        self.assertEqual(sync_log.items_found, len(DECLARED))
+        self.assertEqual(sync_log.items_created, len(DECLARED))
+        self.assertEqual(sync_log.items_updated, 0)
+
+    def test_a_second_run_updates_rather_than_duplicates(self):
+        self.sync()
+        sync_log = self.sync()
+
+        self.assertEqual(sync_log.items_created, 0)
+        self.assertEqual(sync_log.items_updated, len(DECLARED))
+        self.assertEqual(Dataset.objects.count(), len(DECLARED))
+        self.assertEqual(DatasetSource.objects.count(), len(DECLARED))
+
+    def test_a_dataset_the_catalogue_created_is_still_a_new_declaration(self):
+        """What is counted is the centre saying so, not the row it lands on."""
+        self.catalogued(UNCATALOGUED)
+
+        sync_log = self.sync(one_record())
+
+        self.assertEqual(sync_log.items_created, 1)
+
+    def test_a_record_naming_no_topic_is_nothing_this_tool_can_monitor(self):
+        payload = {
+            "features": [
+                {"properties": {"identifier": "urn:wmo:md:za-weathersa:no-topic"}},
+                *self.payload["features"],
+            ]
+        }
+
+        sync_log = self.sync(payload)
+
+        self.assertEqual(sync_log.items_found, len(DECLARED))
+        self.assertEqual(sync_log.items_created, len(DECLARED))
+
+    def test_a_node_that_does_not_answer_leaves_what_it_declared_standing(self):
+        self.sync()
+        last_seen = self.declaration().last_seen
+
+        sync_log = sync_node_datasets(
+            self.node, fetch=failing_fetch("connection refused")
+        )
+
+        self.assertEqual(sync_log.status, SyncLog.FAILED)
+        self.assertIn("connection refused", sync_log.error_message)
+        self.assertEqual(Dataset.objects.count(), len(DECLARED))
+        self.assertEqual(self.declaration().last_seen, last_seen)
+
+    def test_a_record_that_cannot_be_stored_does_not_lose_the_run(self):
+        long_id = "urn:wmo:md:za-weathersa:" + "x" * 500
+
+        sync_log = self.sync(
+            {"features": [*one_record(long_id)["features"], *self.payload["features"]]}
+        )
+
+        self.assertEqual(sync_log.status, SyncLog.PARTIAL)
+        self.assertEqual(sync_log.items_errored, 1)
+        self.assertEqual(sync_log.items_created, len(DECLARED))
+        self.assertEqual(Dataset.objects.count(), len(DECLARED))
+
+    def test_a_record_that_cannot_be_stored_says_which_one_and_why(self):
+        long_id = "urn:wmo:md:za-weathersa:" + "x" * 500
+
+        sync_log = self.sync({"features": one_record(long_id)["features"]})
+
+        (stepped_over,) = sync_log.stepped_over
+
+        self.assertEqual(stepped_over["item"], long_id)
+        self.assertTrue(stepped_over["reason"])
+
+    def test_a_run_that_stored_everything_it_read_stepped_over_nothing(self):
+        sync_log = self.sync()
+
+        self.assertEqual(sync_log.stepped_over, [])
+
+    def test_a_run_that_steps_over_more_than_it_will_hold_still_counts_them_all(self):
+        unstorable = [
+            one_record("urn:wmo:md:za-weathersa:" + "x" * 500 + str(n))["features"][0]
+            for n in range(MAX_STEPPED_OVER_RECORDED + 5)
+        ]
+
+        sync_log = self.sync({"features": unstorable})
+
+        self.assertEqual(sync_log.items_errored, MAX_STEPPED_OVER_RECORDED + 5)
+        self.assertEqual(len(sync_log.stepped_over), MAX_STEPPED_OVER_RECORDED)
+        self.assertEqual(sync_log.reasons_withheld, 5)
+
+    def test_a_reason_too_long_to_hold_is_kept_to_a_readable_line(self):
+        with mock.patch(
+            "wis2watch.core.node_datasets.record_declaration",
+            side_effect=RuntimeError("refused " + "x" * 2000),
+        ):
+            sync_log = self.sync(one_record())
+
+        (stepped_over,) = sync_log.stepped_over
+
+        self.assertLessEqual(len(stepped_over["reason"]), MAX_REASON_CHARS)
+        self.assertTrue(stepped_over["reason"].startswith("refused "))
+
+    def test_every_page_of_a_paged_response_is_read(self):
+        first = {"features": self.payload["features"][:1]}
+        second = {"features": self.payload["features"][1:]}
+
+        sync_log = self.sync(first, second)
+
+        self.assertEqual(sync_log.items_found, len(DECLARED))
+        self.assertEqual(Dataset.objects.count(), len(DECLARED))
+
+
+class NoDiscoveryMetadataTests(TestCase):
+    """A centre with nowhere to ask is not a centre that declares nothing."""
+
+    def test_a_node_with_no_discovery_endpoint_is_left_alone(self):
+        node = WIS2Node.objects.create(centre_id="ke-meteo", name="Kenya Met")
+
+        self.assertIsNone(sync_node_datasets(node, fetch=failing_fetch("never called")))
+        self.assertEqual(SyncLog.objects.count(), 0)
+
+
+class FetchTests(NodeDatasetsTestCase):
+    """The fetch reads the centre's own records, and follows its paging."""
+
+    def response(self, payload):
+        return mock.Mock(
+            json=mock.Mock(return_value=payload), raise_for_status=mock.Mock()
+        )
+
+    def test_it_asks_the_node_for_the_records_it_advertises(self):
+        with mock.patch("wis2watch.core.sync.requests.get") as get:
+            get.return_value = self.response({"features": []})
+
+            list(fetch_node_discovery_pages(self.node))
+
+        self.assertEqual(get.call_args.args[0], self.node.discovery_metadata_url)
+        self.assertIs(get.call_args.kwargs["verify"], True)
+
+    def test_a_node_that_will_not_answer_is_asked_once(self):
+        """The hourly schedule is this sync's retry, across thirty-two centres
+        of which several never answer."""
+        with mock.patch("wis2watch.core.sync.requests.get") as get:
+            get.side_effect = requests.exceptions.ConnectionError("refused")
+
+            with self.assertRaises(ReadKeptFailing):
+                list(fetch_node_discovery_pages(self.node))
+
+        self.assertEqual(get.call_count, 1)
+
+    def test_it_follows_the_next_link_until_there_is_none(self):
+        first = {
+            "features": [],
+            "links": [{"rel": "next", "href": "https://wis.weathersa.co.za/page-2"}],
+        }
+        second = {"features": [], "links": [{"rel": "self", "href": "..."}]}
+
+        with mock.patch("wis2watch.core.sync.requests.get") as get:
+            get.side_effect = [self.response(first), self.response(second)]
+
+            payloads = list(fetch_node_discovery_pages(self.node))
+
+        self.assertEqual(payloads, [first, second])
+        self.assertEqual(
+            get.call_args_list[1].args[0], "https://wis.weathersa.co.za/page-2"
+        )
+
+    def test_a_response_that_never_stops_paging_fails_rather_than_half_reads(self):
+        forever = {
+            "features": [],
+            "links": [{"rel": "next", "href": "https://wis.weathersa.co.za/page-on"}],
+        }
+
+        with mock.patch("wis2watch.core.sync.requests.get") as get:
+            get.return_value = self.response(forever)
+
+            sync_log = sync_node_datasets(self.node)
+
+        self.assertEqual(sync_log.status, SyncLog.FAILED)
+        self.assertIn("do not terminate", sync_log.error_message)
+        self.assertEqual(get.call_count, MAX_PAGES)

--- a/wis2watch/src/wis2watch/core/tests/test_node_detail.py
+++ b/wis2watch/src/wis2watch/core/tests/test_node_detail.py
@@ -264,6 +264,18 @@ class DatasetSourceTests(NodeDetailTestCase):
             [DatasetSource.GDC, DatasetSource.OBSERVED],
         )
 
+    def test_the_centres_own_declaration_stands_beside_the_catalogues(self):
+        """The two disagree, and the page is where that is read side by side."""
+        synop = self.dataset("synop")
+        self.declare(synop, DatasetSource.GDC, catalogue=self.catalogue(is_writer=True))
+        self.declare(synop, DatasetSource.NODE, last_seen=NOW)
+
+        by_type = {source.source_type: source for source in self.sources_of()}
+
+        self.assertEqual(sorted(by_type), [DatasetSource.GDC, DatasetSource.NODE])
+        self.assertEqual(by_type[DatasetSource.NODE].last_seen, NOW)
+        self.assertEqual(by_type[DatasetSource.NODE].catalogue_centre_id, "")
+
     def test_a_source_that_names_no_catalogue_says_so(self):
         self.declare(self.dataset("synop"), DatasetSource.OBSERVED, last_seen=NOW)
 

--- a/wis2watch/src/wis2watch/core/tests/test_tasks.py
+++ b/wis2watch/src/wis2watch/core/tests/test_tasks.py
@@ -154,8 +154,20 @@ class NodeDatasetTaskTests(TestCase):
 
     def test_it_is_not_asked_in_the_same_minute_as_the_regions_other_fetches(self):
         """One centre's two endpoints in one minute is the region's slow hosts
-        in a single pile."""
-        others = ("poll-message-archives", "probe-canonical-links")
+        in a single pile.
+
+        The station registry first, since it is the one this reads the same
+        hosts as. An interval schedule would defeat the whole comparison --
+        its minute is whenever the beat was last restarted -- so what is
+        asserted is that both name a minute and that the minutes differ.
+        """
+        others = (
+            "sync-node-stations",
+            "poll-message-archives",
+            "probe-canonical-links",
+        )
+
+        self.assertTrue(self.entry["schedule"].minute)
 
         for name in others:
             with self.subTest(schedule=name):

--- a/wis2watch/src/wis2watch/core/tests/test_tasks.py
+++ b/wis2watch/src/wis2watch/core/tests/test_tasks.py
@@ -34,7 +34,9 @@ from wis2watch.core.tasks import (
     run_probe_canonical_links,
     run_probe_node_links,
     run_send_daily_digest,
+    run_sync_all_node_datasets,
     run_sync_all_node_stations,
+    run_sync_node_datasets,
     run_sync_node_stations,
     run_sync_oscar_stations,
     run_update_daily_rollups,
@@ -99,6 +101,68 @@ class NodeStationTaskTests(TestCase):
 
         self.assertIsNone(run_sync_node_stations(node.id))
         self.assertEqual(SyncLog.objects.count(), 0)
+
+
+class NodeDatasetTaskTests(TestCase):
+    """Which centres are asked what they publish, and on whose beat.
+
+    Asked apart from the station registries though both read the same hosts:
+    the two endpoints fail independently, and each run states its own bound.
+    """
+
+    def setUp(self):
+        self.node = WIS2Node.objects.create(
+            centre_id="za-weathersa",
+            name="South African Weather Service",
+            base_url="https://wis.weathersa.co.za",
+        )
+        self.entry = settings.CELERY_BEAT_SCHEDULE["sync-node-discovery-metadata"]
+
+    def test_every_node_advertising_its_records_is_queued(self):
+        with mock.patch("wis2watch.core.tasks.run_sync_node_datasets.delay"):
+            self.assertEqual(run_sync_all_node_datasets(), [self.node.id])
+
+    def test_a_node_advertising_no_records_is_not_asked_for_them(self):
+        WIS2Node.objects.create(centre_id="ke-meteo", name="Kenya Met")
+
+        with mock.patch("wis2watch.core.tasks.run_sync_node_datasets.delay"):
+            self.assertEqual(run_sync_all_node_datasets(), [self.node.id])
+
+    def test_a_run_reports_the_log_it_wrote(self):
+        with mock.patch("wis2watch.core.tasks.sync_node_datasets") as sync:
+            sync.return_value = SyncLog.objects.create(
+                node=self.node,
+                sync_type=SyncLog.DISCOVERY_METADATA,
+                status=SyncLog.SUCCESS,
+            )
+
+            self.assertEqual(
+                run_sync_node_datasets(self.node.id), sync.return_value.id
+            )
+
+    def test_a_node_that_was_not_asked_reports_nothing(self):
+        node = WIS2Node.objects.create(centre_id="ke-meteo", name="Kenya Met")
+
+        self.assertIsNone(run_sync_node_datasets(node.id))
+        self.assertEqual(SyncLog.objects.count(), 0)
+
+    def test_the_scheduled_task_is_the_one_that_answers_to_that_name(self):
+        self.assertEqual(self.entry["task"], run_sync_all_node_datasets.name)
+
+    def test_it_runs_hourly(self):
+        self.assertEqual(self.entry["schedule"].hour, {*range(24)})
+
+    def test_it_is_not_asked_in_the_same_minute_as_the_regions_other_fetches(self):
+        """One centre's two endpoints in one minute is the region's slow hosts
+        in a single pile."""
+        others = ("poll-message-archives", "probe-canonical-links")
+
+        for name in others:
+            with self.subTest(schedule=name):
+                self.assertNotEqual(
+                    self.entry["schedule"].minute,
+                    settings.CELERY_BEAT_SCHEDULE[name]["schedule"].minute,
+                )
 
 
 class LinkProbeTaskTests(TestCase):

--- a/wis2watch/src/wis2watch/core/views.py
+++ b/wis2watch/src/wis2watch/core/views.py
@@ -20,6 +20,7 @@ from .analysis import (
 )
 from .forms import SyncNodeForm
 from .models import SyncLog, WIS2Node
+from .node_datasets import sync_node_datasets
 from .node_stations import sync_node_stations
 from .stations import node_stations_as_csv
 from .viewsets import WIS2NodeViewSet
@@ -246,6 +247,23 @@ def node_breadcrumbs(node, leaf=None):
     return trail
 
 
+def _report_sync(request, sync_log, *, unadvertised, completed):
+    """Say what one hand-run sync came to, in the terms of the endpoint it read.
+
+    A run that never happened is a warning rather than an error: a centre
+    advertising no address for one of its endpoints has not failed at
+    anything, and nothing went and looked.
+    """
+    if sync_log is None:
+        messages.warning(request, unadvertised)
+    elif sync_log.status == SyncLog.FAILED:
+        messages.error(
+            request, _("Error during synchronization: ") + sync_log.error_message
+        )
+    else:
+        messages.success(request, completed + sync_log.summary)
+
+
 def node_details(request, node_id):
     """Everything known about one centre, on one page.
 
@@ -267,23 +285,25 @@ def node_details(request, node_id):
     if request.method == "POST":
         form = SyncNodeForm(request.POST)
         if form.is_valid():
-            # Datasets come from the catalogue now, so syncing a node by hand
-            # asks it only for its station registry. The node is the page's
-            # own; the form carries its id so a stray post cannot sync another.
-            sync_log = sync_node_stations(node)
-
-            if sync_log is None:
-                messages.warning(request, _("This node advertises no station registry."))
-            elif sync_log.status == SyncLog.FAILED:
-                messages.error(
-                    request,
-                    _("Error during synchronization: ") + sync_log.error_message,
-                )
-            else:
-                messages.success(
-                    request,
-                    _("Station synchronization completed: ") + sync_log.summary,
-                )
+            # Both of the centre's endpoints, and reported apart. They fail
+            # independently -- a centre serving its records may serve no
+            # station registry, and either address may be the one that has
+            # gone -- so one message covering both would leave a reader unable
+            # to tell which half of the page is now current. The node is the
+            # page's own; the form carries its id so a stray post cannot sync
+            # another.
+            _report_sync(
+                request,
+                sync_node_stations(node),
+                unadvertised=_("This node advertises no station registry."),
+                completed=_("Station synchronization completed: "),
+            )
+            _report_sync(
+                request,
+                sync_node_datasets(node),
+                unadvertised=_("This node advertises no discovery metadata."),
+                completed=_("Discovery metadata synchronization completed: "),
+            )
         else:
             messages.error(request, _("Invalid form submission."))
 

--- a/wis2watch/src/wis2watch/core/views.py
+++ b/wis2watch/src/wis2watch/core/views.py
@@ -247,8 +247,14 @@ def node_breadcrumbs(node, leaf=None):
     return trail
 
 
-def _report_sync(request, sync_log, *, unadvertised, completed):
+def _report_sync(request, sync_log, *, unadvertised, failed, completed):
     """Say what one hand-run sync came to, in the terms of the endpoint it read.
+
+    Every branch names the endpoint, the failing one included. A centre with
+    both of its addresses down is exactly when this is read, and two messages
+    reading "Error during synchronization" would leave somebody with two
+    faults and no way to tell which belongs to which -- the same reason the
+    two runs are reported apart at all.
 
     A run that never happened is a warning rather than an error: a centre
     advertising no address for one of its endpoints has not failed at
@@ -257,9 +263,7 @@ def _report_sync(request, sync_log, *, unadvertised, completed):
     if sync_log is None:
         messages.warning(request, unadvertised)
     elif sync_log.status == SyncLog.FAILED:
-        messages.error(
-            request, _("Error during synchronization: ") + sync_log.error_message
-        )
+        messages.error(request, failed + sync_log.error_message)
     else:
         messages.success(request, completed + sync_log.summary)
 
@@ -296,12 +300,14 @@ def node_details(request, node_id):
                 request,
                 sync_node_stations(node),
                 unadvertised=_("This node advertises no station registry."),
+                failed=_("Error reading the station registry: "),
                 completed=_("Station synchronization completed: "),
             )
             _report_sync(
                 request,
                 sync_node_datasets(node),
                 unadvertised=_("This node advertises no discovery metadata."),
+                failed=_("Error reading the discovery metadata: "),
                 completed=_("Discovery metadata synchronization completed: "),
             )
         else:


### PR DESCRIPTION
Closes #132.

Every one of the region's 32 nodes is a wis2box, every one already carried a derived `discovery_metadata_url`, and `SyncLog.DISCOVERY_METADATA` existed with zero rows: the endpoint had never been fetched. So what a centre publishes was known only as a Global Discovery Catalogue once recorded it — a copy of what was registered rather than what is served, and measurably wrong for a third of the region's centres.

## What it does

`core/node_datasets.py` asks each centre for its own records, hourly, on its own beat entry. A node serves the identical WCMP2 feature a catalogue serves, so `interpretation/discovery.py` reads it unchanged and what is added is a fetcher and a writer.

- Fetched and paged through the shared `fetch_pages`, asked once rather than three times — the hourly schedule is the retry, and several of the region's hosts hang until the timeout.
- Each record becomes or refreshes a `DatasetSource.NODE` declaration, `last_seen` advanced, naming no catalogue.
- A dataset the centre declares that no catalogue carries is created.
- A `SyncLog` row per node per run under `DISCOVERY_METADATA`, with found/created/updated/errored and the records it stepped over (ADR-0010).
- A node that does not answer changes nothing: its declarations stand, and the failure is recorded on its own log. Unreachability is a caveat, never a deletion.

The writing rules are the station registry's. **Declaring is not owning** — the canonical dataset stays one row and what the centre said is kept whole on a declaration beside it, which is what makes the disagreement with the catalogue readable. **Fill, do not overwrite** — only empty fields are filled, so an hourly run cannot undo a six-hourly one; `last_synced` stays the catalogue's alone.

Deliberately not written here: the centre's own broker and address (ADR-0007 governs those, and a second writer would be a second opinion on the same field), and any conclusion that a centre has withdrawn a record.

## Schedule

`sync-node-discovery-metadata` runs at `crontab(minute=40)`. `sync-node-stations` was a bare `3600.0` interval — hourly at whatever minute the beat last restarted at — so the offset two schedules already claimed to keep was fiction; it is now pinned to `crontab(minute=0)` and the offset is asserted against it.

## Node detail page

Nothing new was needed: #131's source badges and the per-kind sync-run grouping already surface a centre's declarations beside the catalogue's. Tests pin it.

Syncing a centre by hand now asks both of its endpoints and reports each apart — the page's own comment said datasets came from the catalogue, which stopped being true here, and the two endpoints fail independently.

## Fixture

`node_discovery_metadata_za_weathersa.json`, captured live: South Africa serves three records and the Canadian GDC carries two, so `urn:wmo:md:za-weathersa:xoeh2t` is exactly the finding this sync exists to make. Documented in the fixtures README.

## Testing

Full suite green (1770 tests). New tests cover a node answering, a node not answering, a node declaring what no catalogue carries, paging, records stepped over, and a record naming another centre — all offline, the page fetch being an argument to the sync.

Also smoke-run against the real region: `za-weathersa` 3 created then 3 updated on a second run, `gh-gmet` 1.

https://claude.ai/code/session_01T1ASYrnh4RcHhHjQeWy1xS